### PR TITLE
Add odd grid offset and fix vertical bars

### DIFF
--- a/ogre2/src/Ogre2Grid.cc
+++ b/ogre2/src/Ogre2Grid.cc
@@ -85,7 +85,7 @@ void Ogre2Grid::Create()
   for (unsigned int h = 0; h <= this->verticalCellCount; ++h)
   {
     double hReal = this->heightOffset +
-        (this->verticalCellCount / 2.0f - static_cast<double>(h))
+        (this->verticalCellCount / 2 - static_cast<double>(h))
         * this->cellLength;
 
     // If there are odd vertical cells, shift cell planes up


### PR DESCRIPTION
This PR introduces a better and more intuitive approach to odd horizontal and vertical cell count.  Previously, odd vertical cell count would change the grid to be about the origin, and odd horizontal cell count would readjust the grid as well.  This PR will simply append a row and column to the grid in cases of odd horizontal cell count instead of moving the grid over.  Similarly, an odd vertical cell count will add a grid layer above the current grid rather than moving the grid to center itself around the origin.  I also found a bug in the vertical bar generation of the 3D grids and fixed it in this PR.

Before:
![Screenshot from 2020-04-23 11-05-22](https://user-images.githubusercontent.com/8881852/80146212-5ce6a800-8566-11ea-9483-71d66d5253fd.png)

After
![Screenshot from 2020-04-23 13-32-38](https://user-images.githubusercontent.com/8881852/80146633-fdd56300-8566-11ea-87fb-bf5f819acc1f.png)

Before:
![Screenshot from 2020-04-23 13-35-58](https://user-images.githubusercontent.com/8881852/80146941-881dc700-8567-11ea-8520-48c0b7902232.png)

After:
![Screenshot from 2020-04-23 13-39-42](https://user-images.githubusercontent.com/8881852/80147185-f6628980-8567-11ea-9bfe-8d26d73588b1.png)


Fixes [ign-rendering#70](https://github.com/ignitionrobotics/ign-rendering/issues/70)

Signed-off-by: John Shepherd <john@openrobotics.org>

