### PR TITLE
Add ogre2 AxisVisual and ArrowVisual

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 ### Ignition Rendering 4.0.0
 
 1. Add ogre2 AxisVisual and ArrowVisual
-    * [Pull request ](https://github.com/ignitionrobotics/ign-rendering/pull/87)
+    * [Pull request 87](https://github.com/ignitionrobotics/ign-rendering/pull/87)
 
 1. Support setting skeleton node weights
     * [BitBucket pull request 256](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-rendering/pull-requests/256)

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,8 @@
 
 ### Ignition Rendering 4.0.0
 
-1. Add ogre2 implementation of AxisVisual and ArrowVisual
-    * [Pull request ]()
+1. Add ogre2 AxisVisual and ArrowVisual
+    * [Pull request ](https://github.com/ignitionrobotics/ign-rendering/pull/87)
 
 1. Support setting skeleton node weights
     * [BitBucket pull request 256](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-rendering/pull-requests/256)

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@
 
 ### Ignition Rendering 4.0.0
 
+1. Add ogre2 implementation of AxisVisual and ArrowVisual
+    * [Pull request ]()
+
 1. Support setting skeleton node weights
     * [BitBucket pull request 256](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-rendering/pull-requests/256)
 

--- a/examples/simple_demo/GlutWindow.cc
+++ b/examples/simple_demo/GlutWindow.cc
@@ -71,13 +71,17 @@ double g_offset = 0.0;
 //////////////////////////////////////////////////
 //! [update camera]
 void updateCameras()
+
 {
+  double angle = g_offset / 2 * M_PI;
+  double x = sin(angle) * 3.0 + 3.0;
+  double y = cos(angle) * 3.0;
   for (ir::CameraPtr camera : g_cameras)
   {
-    camera->SetLocalPosition(g_offset, g_offset, g_offset);
+    camera->SetLocalPosition(x, y, 0.0);
   }
 
-  g_offset+= 0.001;
+  g_offset += 0.0005;
 }
 //! [update camera]
 

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -136,14 +136,6 @@ void buildScene(ScenePtr _scene)
   axis->SetLocalPosition(4.0, 0.5, -0.4);
   root->AddChild(axis);
 
-  // create arrow visual
-  // VisualPtr arrow = _scene->CreateArrowVisual();
-  // arrow->SetLocalPosition(2, -1, -0.3);
-  // arrow->SetLocalScale(2, -1, 2);
-  // arrow->SetLocalRotation(-IGN_PI / 3, -IGN_PI / 3, 0);
-  // arrow->SetMaterial(green);
-  // root->AddChild(arrow);
-
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");
   camera->SetLocalPosition(0.0, 0.0, 0.0);
@@ -155,6 +147,7 @@ void buildScene(ScenePtr _scene)
   camera->SetHFOV(IGN_PI / 2);
   root->AddChild(camera);
 
+  // track target
   camera->SetTrackTarget(box);
 }
 

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -131,6 +131,19 @@ void buildScene(ScenePtr _scene)
   plane->SetMaterial(white);
   root->AddChild(plane);
 
+  // create axis visual
+  VisualPtr axis = _scene->CreateAxisVisual();
+  axis->SetLocalPosition(4.0, 0.5, -0.4);
+  root->AddChild(axis);
+
+  // create arrow visual
+  // VisualPtr arrow = _scene->CreateArrowVisual();
+  // arrow->SetLocalPosition(2, -1, -0.3);
+  // arrow->SetLocalScale(2, -1, 2);
+  // arrow->SetLocalRotation(-IGN_PI / 3, -IGN_PI / 3, 0);
+  // arrow->SetMaterial(green);
+  // root->AddChild(arrow);
+
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");
   camera->SetLocalPosition(0.0, 0.0, 0.0);
@@ -141,6 +154,8 @@ void buildScene(ScenePtr _scene)
   camera->SetAspectRatio(1.333);
   camera->SetHFOV(IGN_PI / 2);
   root->AddChild(camera);
+
+  camera->SetTrackTarget(box);
 }
 
 //////////////////////////////////////////////////
@@ -167,12 +182,21 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string engine("ogre");
+  if (_argc > 1)
+  {
+    engine = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(engine);
   engineNames.push_back("optix");
+
   for (auto engineName : engineNames)
   {
     try

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ArrowVisual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ArrowVisual.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE2_OGRE2ARROWVISUAL_HH_
+#define IGNITION_RENDERING_OGRE2_OGRE2ARROWVISUAL_HH_
+
+#include "ignition/rendering/base/BaseArrowVisual.hh"
+#include "ignition/rendering/ogre2/Ogre2Visual.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief Ogre2.x implementation of the arrow visual class
+    class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2ArrowVisual :
+      public BaseArrowVisual<Ogre2Visual>
+    {
+      /// \brief Constructor
+      protected: Ogre2ArrowVisual();
+
+      /// \brief Destructor
+      public: virtual ~Ogre2ArrowVisual();
+
+      /// \brief Only scene can instantiate an arrow visual
+      private: friend class Ogre2Scene;
+    };
+    }
+  }
+}
+#endif

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2AxisVisual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2AxisVisual.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE2_OGRE2AXISVISUAL_HH_
+#define IGNITION_RENDERING_OGRE2_OGRE2AXISVISUAL_HH_
+
+#include "ignition/rendering/base/BaseAxisVisual.hh"
+#include "ignition/rendering/ogre2/Ogre2Visual.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief Ogre2.x implementation of the axis visual class
+    class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2AxisVisual :
+      public BaseAxisVisual<Ogre2Visual>
+    {
+      /// \brief Constructor
+      protected: Ogre2AxisVisual();
+
+      /// \brief Destructor
+      public: virtual ~Ogre2AxisVisual();
+
+      /// \brief Only scene can instantiate an axis visual
+      private: friend class Ogre2Scene;
+    };
+    }
+  }
+}
+#endif

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
@@ -28,6 +28,8 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
+    class Ogre2ArrowVisual;
+    class Ogre2AxisVisual;
     class Ogre2Camera;
     class Ogre2DepthCamera;
     class Ogre2DirectionalLight;
@@ -67,6 +69,8 @@ namespace ignition
 
     typedef BaseMaterialMap<Ogre2Material>        Ogre2MaterialMap;
 
+    typedef shared_ptr<Ogre2ArrowVisual>          Ogre2ArrowVisualPtr;
+    typedef shared_ptr<Ogre2AxisVisual>           Ogre2AxisVisualPtr;
     typedef shared_ptr<Ogre2Camera>               Ogre2CameraPtr;
     typedef shared_ptr<Ogre2DepthCamera>          Ogre2DepthCameraPtr;
     typedef shared_ptr<Ogre2DirectionalLight>     Ogre2DirectionalLightPtr;

--- a/ogre2/src/Ogre2ArrowVisual.cc
+++ b/ogre2/src/Ogre2ArrowVisual.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ignition/rendering/ogre2/Ogre2ArrowVisual.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+Ogre2ArrowVisual::Ogre2ArrowVisual()
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2ArrowVisual::~Ogre2ArrowVisual()
+{
+}

--- a/ogre2/src/Ogre2AxisVisual.cc
+++ b/ogre2/src/Ogre2AxisVisual.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ignition/rendering/ogre2/Ogre2AxisVisual.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+Ogre2AxisVisual::Ogre2AxisVisual()
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2AxisVisual::~Ogre2AxisVisual()
+{
+}

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -18,6 +18,8 @@
 #include <ignition/common/Console.hh>
 
 #include "ignition/rendering/RenderTypes.hh"
+#include "ignition/rendering/ogre2/Ogre2ArrowVisual.hh"
+#include "ignition/rendering/ogre2/Ogre2AxisVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2Camera.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2DepthCamera.hh"
@@ -279,19 +281,21 @@ VisualPtr Ogre2Scene::CreateVisualImpl(unsigned int _id,
 }
 
 //////////////////////////////////////////////////
-ArrowVisualPtr Ogre2Scene::CreateArrowVisualImpl(unsigned int /*_id*/,
-    const std::string &/*_name*/)
+ArrowVisualPtr Ogre2Scene::CreateArrowVisualImpl(unsigned int _id,
+    const std::string &_name)
 {
-  // TODO(anyone)
-  return ArrowVisualPtr();
+  Ogre2ArrowVisualPtr visual(new Ogre2ArrowVisual);
+  bool result = this->InitObject(visual, _id, _name);
+  return (result) ? visual : nullptr;
 }
 
 //////////////////////////////////////////////////
-AxisVisualPtr Ogre2Scene::CreateAxisVisualImpl(unsigned int /*_id*/,
-    const std::string &/*_name*/)
+AxisVisualPtr Ogre2Scene::CreateAxisVisualImpl(unsigned int _id,
+    const std::string &_name)
 {
-  // TODO(anyone)
-  return AxisVisualPtr();
+  Ogre2AxisVisualPtr visual(new Ogre2AxisVisual);
+  bool result = this->InitObject(visual, _id, _name);
+  return (result) ? visual : nullptr;
 }
 
 //////////////////////////////////////////////////

--- a/src/ArrowVisual_TEST.cc
+++ b/src/ArrowVisual_TEST.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include <ignition/common/Console.hh>
+
+#include "test_config.h"  // NOLINT(build/include)
+
+#include "ignition/rendering/ArrowVisual.hh"
+#include "ignition/rendering/RenderEngine.hh"
+#include "ignition/rendering/RenderingIface.hh"
+#include "ignition/rendering/Scene.hh"
+#include "ignition/rendering/Visual.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+class ArrowVisualTest : public testing::Test,
+                        public testing::WithParamInterface<const char *>
+{
+  /// \brief Test adding removing children
+  public: void ArrowVisual(const std::string &_renderEngine);
+};
+
+/////////////////////////////////////////////////
+void ArrowVisualTest::ArrowVisual(const std::string &_renderEngine)
+{
+  RenderEngine *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ScenePtr scene = engine->CreateScene("scene");
+
+  // create arrow visual
+  ArrowVisualPtr visual = scene->CreateArrowVisual();
+  ASSERT_NE(nullptr, visual);
+
+  // check scale
+  EXPECT_TRUE(visual->InheritScale());
+  EXPECT_EQ(math::Vector3d::One, visual->LocalScale());
+  EXPECT_EQ(math::Vector3d::One, visual->WorldScale());
+
+  visual->SetLocalScale(0.2, 0.3, 0.4);
+  EXPECT_EQ(math::Vector3d(0.2, 0.3, 0.4), visual->LocalScale());
+
+  // check children and geometry
+  EXPECT_EQ(2u, visual->ChildCount());
+
+  NodePtr node = visual->ChildByIndex(0u);
+  VisualPtr child = std::dynamic_pointer_cast<Visual>(node);
+  ASSERT_NE(nullptr, child);
+  EXPECT_EQ(1u, child->GeometryCount());
+
+  node = visual->ChildByIndex(1u);
+  child = std::dynamic_pointer_cast<Visual>(node);
+  ASSERT_NE(nullptr, child);
+  EXPECT_EQ(1u, child->GeometryCount());
+
+  // Clean up
+  engine->DestroyScene(scene);
+  rendering::unloadEngine(engine->Name());
+}
+
+/////////////////////////////////////////////////
+TEST_P(ArrowVisualTest, ArrowVisual)
+{
+  ArrowVisual(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(ArrowVisual, ArrowVisualTest,
+    RENDER_ENGINE_VALUES,
+    ignition::rendering::PrintToStringParam());
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/AxisVisual_TEST.cc
+++ b/src/AxisVisual_TEST.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include <ignition/common/Console.hh>
+
+#include "test_config.h"  // NOLINT(build/include)
+
+#include "ignition/rendering/ArrowVisual.hh"
+#include "ignition/rendering/AxisVisual.hh"
+#include "ignition/rendering/RenderEngine.hh"
+#include "ignition/rendering/RenderingIface.hh"
+#include "ignition/rendering/Scene.hh"
+#include "ignition/rendering/Visual.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+class AxisVisualTest : public testing::Test,
+                       public testing::WithParamInterface<const char *>
+{
+  /// \brief Test adding removing children
+  public: void AxisVisual(const std::string &_renderEngine);
+};
+
+/////////////////////////////////////////////////
+void AxisVisualTest::AxisVisual(const std::string &_renderEngine)
+{
+  RenderEngine *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ScenePtr scene = engine->CreateScene("scene");
+
+  // create axis visual
+  AxisVisualPtr visual = scene->CreateAxisVisual();
+  ASSERT_NE(nullptr, visual);
+
+  // check scale
+  EXPECT_TRUE(visual->InheritScale());
+  EXPECT_EQ(math::Vector3d::One, visual->LocalScale());
+  EXPECT_EQ(math::Vector3d::One, visual->WorldScale());
+
+  visual->SetLocalScale(0.2, 0.3, 0.4);
+  EXPECT_EQ(math::Vector3d(0.2, 0.3, 0.4), visual->LocalScale());
+
+  // check children and geometry
+  EXPECT_EQ(3u, visual->ChildCount());
+
+  for (unsigned int i = 0; i < 3u; ++i)
+  {
+    NodePtr node = visual->ChildByIndex(i);
+    ArrowVisualPtr arrow = std::dynamic_pointer_cast<ArrowVisual>(node);
+    ASSERT_NE(nullptr, arrow);
+
+    EXPECT_EQ(2u, arrow->ChildCount());
+    NodePtr childNode = arrow->ChildByIndex(0u);
+    VisualPtr child = std::dynamic_pointer_cast<Visual>(childNode);
+    EXPECT_EQ(1u, child->GeometryCount());
+
+    childNode = arrow->ChildByIndex(1u);
+    child = std::dynamic_pointer_cast<Visual>(childNode);
+    EXPECT_EQ(1u, child->GeometryCount());
+  }
+
+  // Clean up
+  engine->DestroyScene(scene);
+  rendering::unloadEngine(engine->Name());
+}
+
+/////////////////////////////////////////////////
+TEST_P(AxisVisualTest, AxisVisual)
+{
+  AxisVisual(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(AxisVisual, AxisVisualTest,
+    RENDER_ENGINE_VALUES,
+    ignition::rendering::PrintToStringParam());
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tutorials/18_simple_demo_tutorial.md
+++ b/tutorials/18_simple_demo_tutorial.md
@@ -29,6 +29,6 @@ Engine 'optix' is not supported
 
 ## Code
 
-The function `updateCameras()` is called each time the `DisplayCB` function runs. Using the method `SetLocalPosition` from the `Camera` class we can locate the camera in the world:
+The function `updateCameras()` is called each time the `DisplayCB` function runs. Using the method `SetLocalPosition` from the `Camera` class we can move the camera in the world:
 
 \snippet examples/simple_demo/GlutWindow.cc update camera


### PR DESCRIPTION
Implementation was already done in the base classes ([BaseAxisVisual](https://github.com/ignitionrobotics/ign-rendering/blob/master/include/ignition/rendering/base/BaseAxisVisual.hh) and [BaseArrowVisual](https://github.com/ignitionrobotics/ign-rendering/blob/master/include/ignition/rendering/base/BaseArrowVisual.hh)). This PR closes the loop by filling in the `Create*Visual` functions in `Ogre2Scene` class.

Added tests and updated `simple_demo` to include an axis visual

Signed-off-by: Ian Chen <ichen@osrfoundation.org>