### PR TITLE
Run ogre2 tests on windows

### DIFF
--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -22,7 +22,14 @@ target_link_libraries(${ogre2_target}
     ${OPENGL_LIBRARIES}
     IgnOGRE2::IgnOGRE2)
 
+install(DIRECTORY "media"  DESTINATION ${IGN_RENDERING_RESOURCE_PATH}/ogre2)
+
 # Build the unit tests
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources} LIB_DEPS ${ogre2_target})
 
-install(DIRECTORY "media"  DESTINATION ${IGN_RENDERING_RESOURCE_PATH}/ogre2)
+if(WIN32)
+  # tests needs .dll in the same directory
+  add_custom_command(TARGET ${ogre2_target} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    $<TARGET_FILE:${ogre2_target}> ${CMAKE_CURRENT_BINARY_DIR})
+endif()

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -380,6 +380,8 @@ bool RenderEngineManagerPrivate::LoadEnginePlugin(
   systemPaths.AddPluginPaths(_path);
 
   auto pathToLib = systemPaths.FindSharedLibrary(_filename);
+  std::cerr << "LoadEnginePlugin: " << pathToLib << std::endl;
+
   if (pathToLib.empty())
   {
     ignerr << "Failed to load plugin [" << _filename <<

--- a/src/RenderEngine_TEST.cc
+++ b/src/RenderEngine_TEST.cc
@@ -46,6 +46,24 @@ void RenderEngineTest::RenderEngine(const std::string &_renderEngine)
     return;
   }
 
+  std::string homePath;
+  ignition::common::env(IGN_HOMEDIR, homePath);
+  std::string p = homePath + "/.ignition/rendering/ogre2.log";
+  std::ifstream fs(p);
+  std::string str((std::istreambuf_iterator<char>(fs)),
+                   std::istreambuf_iterator<char>());
+  std::cerr << "================== " << std::endl;
+  std::cerr << str << std::endl;
+  std::cerr << "================== " << std::endl;
+//  std::cerr << "========ogre plugin dir iter " << std::endl;
+//  for (ignition::common::DirIter file("/usr/local/opt/ogre2.1/lib/OGRE-2.1/");
+//       file != ignition::common::DirIter(); ++file)
+//  {
+//    std::string current(*file);
+//    std::cerr << current  << std::endl;
+//  }
+
+
   // Check there are no scenes
   EXPECT_EQ(0u, engine->SceneCount());
   EXPECT_FALSE(engine->HasSceneName("scene1"));


### PR DESCRIPTION
The changes make sure that ign-rendering-ogre2.dll is loaded when running tests.

Testing windows CI