### PR TITLE
Restructure rendering build to account for gui interactions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -249,7 +249,7 @@ cc_binary(
     ],
     deps = [
         ":ign_rendering",
-        "//ign_rendering/ogre2",
+        "//ign_rendering/ogre2:libignition-rendering4-ogre2.so"
     ],
     linkopts = ["-lGL", "-lGLU", "-lglut"],
 )
@@ -263,7 +263,7 @@ cc_binary(
     ],
     deps = [
         ":ign_rendering",
-        "//ign_rendering/ogre2",
+        "//ign_rendering/ogre2:libignition-rendering4-ogre2.so"
     ],
     data = ["examples/ogre2_demo/media"],
     linkopts = ["-lGL", "-lGLU", "-lglut"],

--- a/ogre2/BUILD.bazel
+++ b/ogre2/BUILD.bazel
@@ -83,13 +83,12 @@ public_headers = public_headers_no_gen + [
     "include/ignition/rendering/ogre2/Export.hh",
 ]
 
-cc_binary(
-    name = "libignition-rendering4-ogre2.so",
-    srcs = sources + public_headers,
+cc_library(
+    name = "ogre2",
+    srcs = sources,
+    hdrs = public_headers,
     includes = ["include"],
-    linkopts = ["-Wl,-soname,libignition-rendering4-ogre2.so"],
-    linkshared =  True,
-    visibility = [],
+    visibility = ["//visibility:public"],
     deps = [
         "//ign_math",
         "//ign_common",
@@ -102,7 +101,8 @@ cc_binary(
         "//ogre2/Components:hlms_pbs",
         "//ogre2/Components:hlms_unlit",
         "//ogre2/Components:overlay",
-        "//ogre2:RenderSystem_GL3Plus.so",
+        "//ogre2:ogre_main",
+        "//ogre2:rendersystem_gl3plus",
     ],
     data = ["src/media"],
     local_defines = [
@@ -111,17 +111,30 @@ cc_binary(
     ],
 )
 
-cc_library(
-    name = "ogre2",
-    srcs = ["libignition-rendering4-ogre2.so"],
-    hdrs = public_headers,
+cc_binary(
+    name = "libignition-rendering4-ogre2.so",
+    linkshared = True,
+    srcs = sources + public_headers,
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
-        "//ogre2:libOgreMain.so",
+        "//ign_math",
+        "//ign_common",
+        "//ign_bazel:utilities",
+        "//ign_plugin/core:ign_plugin",
+        "//ign_plugin/register:register",
+        "//ign_common/graphics:graphics",
+        "//ign_common/events:events",
+        "//ign_rendering",
         "//ogre2/Components:hlms_pbs",
         "//ogre2/Components:hlms_unlit",
         "//ogre2/Components:overlay",
-        "//ogre2:RenderSystem_GL3Plus.so",
-    ]
+        "//ogre2:libOgreMain.so",
+        "//ogre2:libRenderSystem_GL3Plus.so",
+    ],
+    data = ["src/media"],
+    local_defines = [
+        "OGRE2_RESOURCE_PATH='\"./ogre2\"'",
+        "OGRE2_VERSION='\"TODO: replace with correct string\"'",
+    ],
 )

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -415,7 +415,11 @@ void Ogre2RenderEngine::LoadPlugins()
 #endif
     std::string p = common::joinPaths(path, "RenderSystem_GL3Plus");
     plugins.push_back(p);
+    p = common::joinPaths(path, "libRenderSystem_GL3Plus");
+    plugins.push_back(p);
     p = common::joinPaths(path, "Plugin_ParticleFX");
+    plugins.push_back(p);
+    p = common::joinPaths(path, "libPlugin_ParticleFX");
     plugins.push_back(p);
 
     for (piter = plugins.begin(); piter != plugins.end(); ++piter)


### PR DESCRIPTION
We need to produce shared libraries in Bazel in order for plugins to be properly loaded in the later portion of the dependency chain.

Signed-off-by: Michael Carroll <michael@openrobotics.org>