### PR TITLE
Add support for Gaussian noise render pass in Ogre2DepthCamera 

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
@@ -119,6 +119,9 @@ namespace ignition
       /// ogre camera has not been created.
       public: double FarClipPlane() const override;
 
+      // Documentation inherited.
+      public: void AddRenderPass(const RenderPassPtr &_pass) override;
+
       /// \brief Get a pointer to the render target.
       /// \return Pointer to the render target
       protected: virtual RenderTargetPtr RenderTarget() const override;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
@@ -18,6 +18,7 @@
 #define IGNITION_RENDERING_OGRE2_OGRE2RENDERTARGET_HH_
 
 #include <string>
+#include <vector>
 #include <ignition/math/Color.hh>
 
 #include "ignition/rendering/base/BaseRenderTypes.hh"
@@ -94,6 +95,13 @@ namespace ignition
 
       /// \brief Get a pointer to the ogre render target
       public: virtual Ogre::RenderTarget *RenderTarget() const = 0;
+
+      /// \brief Update the render pass chain
+      public: static void UpdateRenderPassChain(
+          Ogre::CompositorWorkspace *_workspace,
+          const std::string &_workspaceDefName,
+          const std::string &_baseNode, const std::string &_finalNode,
+          const std::vector<RenderPassPtr> &_renderPasses, bool _recreateNodes);
 
       /// \brief Update the background color
       protected: virtual void UpdateBackgroundColor();

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -27,12 +27,44 @@
 #include "ignition/rendering/RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2DepthCamera.hh"
+#include "ignition/rendering/ogre2/Ogre2GaussianNoisePass.hh"
 #include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTarget.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
+
+
+namespace ignition
+{
+namespace rendering
+{
+inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+//
+/// \brief Gaussian noise render pass for depth cameras
+/// The class implementation is very similar to Ogre2GaussianNoisePass but
+/// uses a different shader material for apply noise to depth cameras
+class Ogre2DepthGaussianNoisePass : public Ogre2GaussianNoisePass
+{
+  /// \brief Constructor
+  public: Ogre2DepthGaussianNoisePass() {}
+
+  /// \brief Destructor
+  public: virtual ~Ogre2DepthGaussianNoisePass() {}
+
+  // Documentation inherited.
+  public: void PreRender() override;
+
+  // Documentation inherited.
+  public: void CreateRenderPass() override;
+
+  /// brief Pointer to the Gaussian noise ogre material
+  private: Ogre::Material *gaussianNoiseMat = nullptr;
+};
+}
+}
+}
 
 /// \internal
 /// \brief Private data for the Ogre2DepthCamera class
@@ -57,12 +89,15 @@ class ignition::rendering::Ogre2DepthCameraPrivate
   public: std::string ogreCompositorWorkspaceDef;
 
   /// \brief 1st pass compositor node definition
-  public: std::string ogreCompositorNodeDef;
+  public: std::string ogreCompositorBaseNodeDef;
 
-  /// \brief 1st pass compositor workspace. One for each cubemap camera
-  public: Ogre::CompositorWorkspace *ogreCompositorWorkspace;
+  /// \brief Final pass compositor node definition
+  public: std::string ogreCompositorFinalNodeDef;
 
-  /// \brief An array of first pass textures. One for each cubemap camera.
+  /// \brief Compositor workspace.
+  public: Ogre::CompositorWorkspace *ogreCompositorWorkspace = nullptr;
+
+  /// \brief Output texture with depth and color data
   public: Ogre::TexturePtr ogreDepthTexture;
 
   /// \brief Dummy render texture for the depth data
@@ -70,6 +105,15 @@ class ignition::rendering::Ogre2DepthCameraPrivate
 
   /// \brief The depth material
   public: Ogre::MaterialPtr depthMaterial;
+
+  /// \brief The depth material in final pass
+  public: Ogre::MaterialPtr depthFinalMaterial;
+
+  /// \brief A chain of render passes applied to the render target
+  public: std::vector<RenderPassPtr> renderPasses;
+
+  /// \brief Flag to indicate if render pass need to be rebuilt
+  public: bool renderPassDirty = false;
 
   /// \brief Event used to signal rgb point cloud data
   public: ignition::common::EventT<void(const float *,
@@ -84,6 +128,98 @@ class ignition::rendering::Ogre2DepthCameraPrivate
 
 using namespace ignition;
 using namespace rendering;
+
+//////////////////////////////////////////////////
+void Ogre2DepthGaussianNoisePass::PreRender()
+{
+  if (!this->gaussianNoiseMat)
+    return;
+
+  if (!this->enabled)
+    return;
+
+  // modify material here (wont alter the base material!), called for
+  // every drawn geometry instance (i.e. compositor render_quad)
+
+  // Sample three values within the range [0,1.0] and set them for use in
+  // the fragment shader, which will interpret them as offsets from (0,0)
+  // to use when computing pseudo-random values.
+  Ogre::Vector3 offsets(ignition::math::Rand::DblUniform(0.0, 1.0),
+                        ignition::math::Rand::DblUniform(0.0, 1.0),
+                        ignition::math::Rand::DblUniform(0.0, 1.0));
+  // These calls are setting parameters that are declared in two places:
+  // 1. media/materials/scripts/gaussian_noise.material, in
+  //    fragment_program GaussianNoiseFS
+  // 2. media/materials/scripts/gaussian_noise_fs.glsl
+  Ogre::Pass *pass = this->gaussianNoiseMat->getTechnique(0)->getPass(0);
+  Ogre::GpuProgramParametersSharedPtr psParams =
+      pass->getFragmentProgramParameters();
+  psParams->setNamedConstant("offsets", offsets);
+  psParams->setNamedConstant("mean", static_cast<Ogre::Real>(this->mean));
+  psParams->setNamedConstant("stddev",
+      static_cast<Ogre::Real>(this->stdDev));
+}
+
+//////////////////////////////////////////////////
+void Ogre2DepthGaussianNoisePass::CreateRenderPass()
+{
+  static int gaussianDepthNodeCounter = 0;
+
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+
+  std::string nodeDefName = "GaussianDepthNoiseNode_"
+      + std::to_string(gaussianDepthNodeCounter);
+
+  if (ogreCompMgr->hasNodeDefinition(nodeDefName))
+    return;
+
+  // The GaussianNoise material is defined in script (gaussian_noise.material).
+  // clone the material
+  std::string matName = "GaussianNoiseDepth";
+  Ogre::MaterialPtr ogreMat =
+      Ogre::MaterialManager::getSingleton().getByName(matName);
+  if (!ogreMat)
+  {
+    ignerr << "Gaussian noise material not found: '" << matName << "'"
+           << std::endl;
+    return;
+  }
+  if (!ogreMat->isLoaded())
+    ogreMat->load();
+  std::string materialName = matName + "_" +
+      std::to_string(gaussianDepthNodeCounter);
+  this->gaussianNoiseMat = ogreMat->clone(materialName).get();
+
+  this->ogreCompositorNodeDefName = nodeDefName;
+  gaussianDepthNodeCounter++;
+
+  Ogre::CompositorNodeDef *nodeDef =
+      ogreCompMgr->addNodeDefinition(nodeDefName);
+
+  // Input texture
+  nodeDef->addTextureSourceName("rt_input", 0,
+      Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+  nodeDef->addTextureSourceName("rt_output", 1,
+      Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+
+  // rt_input target
+  nodeDef->setNumTargetPass(1);
+  Ogre::CompositorTargetDef *inputTargetDef =
+      nodeDef->addTargetPass("rt_output");
+  inputTargetDef->setNumPasses(1);
+  {
+    // quad pass
+    Ogre::CompositorPassQuadDef *passQuad =
+        static_cast<Ogre::CompositorPassQuadDef *>(
+        inputTargetDef->addPass(Ogre::PASS_QUAD));
+    passQuad->mMaterialName = materialName;
+    passQuad->addQuadTextureSource(0, "rt_input", 0);
+  }
+  nodeDef->mapOutputChannel(0, "rt_output");
+  nodeDef->mapOutputChannel(1, "rt_input");
+}
 
 //////////////////////////////////////////////////
 Ogre2DepthCamera::Ogre2DepthCamera()
@@ -160,7 +296,9 @@ void Ogre2DepthCamera::Destroy()
     ogreCompMgr->removeWorkspaceDefinition(
         this->dataPtr->ogreCompositorWorkspaceDef);
     ogreCompMgr->removeNodeDefinition(
-        this->dataPtr->ogreCompositorNodeDef);
+        this->dataPtr->ogreCompositorBaseNodeDef);
+    ogreCompMgr->removeNodeDefinition(
+        this->dataPtr->ogreCompositorFinalNodeDef);
   }
 
   Ogre::SceneManager *ogreSceneManager;
@@ -278,64 +416,112 @@ void Ogre2DepthCamera::CreateDepthTexture()
     this->Scene()->BackgroundColor().G(),
     this->Scene()->BackgroundColor().B());
   psParams->setNamedConstant("backgroundColor", bg);
-  // We need to include a tolerance for Clipping
-  psParams->setNamedConstant("tolerance",
-      static_cast<float>(1e-6));
 
+  std::string matDepthFinalName = "DepthCameraFinal";
+  Ogre::MaterialPtr matDepthFinal =
+      Ogre::MaterialManager::getSingleton().getByName(matDepthFinalName);
+  this->dataPtr->depthFinalMaterial = matDepthFinal->clone(
+      this->Name() + "_" + matDepthFinalName);
+  this->dataPtr->depthFinalMaterial->load();
+  Ogre::Pass *passFinal =
+      this->dataPtr->depthFinalMaterial->getTechnique(0)->getPass(0);
+  Ogre::GpuProgramParametersSharedPtr psParamsFinal =
+      passFinal->getFragmentProgramParameters();
+  psParamsFinal->setNamedConstant("near",
+      static_cast<float>(this->NearClipPlane()));
+  psParamsFinal->setNamedConstant("far",
+      static_cast<float>(this->FarClipPlane()));
+  psParamsFinal->setNamedConstant("max",
+      static_cast<float>(this->dataPtr->dataMaxVal));
+  psParamsFinal->setNamedConstant("min",
+      static_cast<float>(this->dataPtr->dataMinVal));
   // Create depth camera compositor
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
   Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
 
-  // We need to programmatically create the compositor because we need to
-  // configure it to use the cloned depth material created earlier.
-  // The compositor workspace definition is equivalent to the following
-  // ogre compositor script:
-  // compositor_node DepthCamera
-  // {
-  //   in 0 rt_input
-  //   // colorTexture shares same depth buffer as depthTexture
-  //   texture colorTexture target_width target_height PF_R8G8B8
-  //       depth_texture depth_format PF_D32_FLOAT
-  //   texture depthTexture target_width target_height PF_D32_FLOAT
-  //   target depthTexture
-  //   {
-  //     pass clear
-  //     {
-  //       colour_value 0.0 0.0 0.0 1.0
-  //     }
-  //     pass render_scene
-  //     {
-  //     }
-  //   }
-  //   target rt_input
-  //   {
-  //     pass clear
-  //     {
-  //       colour_value 0.0 0.0 0.0 1.0
-  //     }
-  //     pass render_quad
-  //     {
-  //       material DepthCamera // Use copy instead of original
-  //       input 0 depthTexture
-  //       quad_normals camera_far_corners_view_space
-  //     }
-  //   }
-  //   out 0 rt_input
-  // }
   std::string wsDefName = "DepthCameraWorkspace_" + this->Name();
   this->dataPtr->ogreCompositorWorkspaceDef = wsDefName;
   if (!ogreCompMgr->hasWorkspaceDefinition(wsDefName))
   {
-    std::string nodeDefName = wsDefName + "/Node";
-    this->dataPtr->ogreCompositorNodeDef = nodeDefName;
-    Ogre::CompositorNodeDef *nodeDef =
-        ogreCompMgr->addNodeDefinition(nodeDefName);
-    // Input texture
-    nodeDef->addTextureSourceName("rt_input", 0,
-        Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+    // We need to programmatically create the compositor because we need to
+    // configure it to use the cloned depth material created earlier.
+    // The compositor node definition is equivalent to the following:
+    //
+    // compositor_node DepthCamera
+    // {
+    //   texture rt0 target_width target_height PF_FLOAT32_RGBA
+    //   texture rt1 target_width target_height PF_FLOAT32_RGBA
+    //   // colorTexture shares same depth buffer as depthTexture
+    //   texture colorTexture target_width target_height PF_R8G8B8
+    //       depth_texture depth_format PF_D32_FLOAT
+    //   texture depthTexture target_width target_height PF_D32_FLOAT
+    //   target colorTexture
+    //   {
+    //     pass clear
+    //     {
+    //       colour_value 0.0 0.0 0.0 1.0
+    //     }
+    //     pass render_scene
+    //     {
+    //     }
+    //   }
+    //   target rt0
+    //   {
+    //     pass render_quad
+    //     {
+    //       material DepthCamera // Use copy instead of original
+    //       input 0 depthTexture0
+    //       input 1 colorTexture0
+    //       quad_normals camera_far_corners_view_space
+    //     }
+    //   }
+    //   out 0 rt0
+    //   out 1 rt1
+    // }
+
+    std::string baseNodeDefName = wsDefName + "/BaseNode";
+    this->dataPtr->ogreCompositorBaseNodeDef = baseNodeDefName;
+    Ogre::CompositorNodeDef *baseNodeDef =
+        ogreCompMgr->addNodeDefinition(baseNodeDefName);
+    Ogre::TextureDefinitionBase::TextureDefinition *rt0TexDef =
+        baseNodeDef->addTextureDefinition("rt0");
+    rt0TexDef->textureType = Ogre::TEX_TYPE_2D;
+    rt0TexDef->width = 0;
+    rt0TexDef->height = 0;
+    rt0TexDef->depth = 1;
+    rt0TexDef->numMipmaps = 0;
+    rt0TexDef->widthFactor = 1;
+    rt0TexDef->heightFactor = 1;
+    rt0TexDef->formatList = {Ogre::PF_FLOAT32_RGBA};
+    rt0TexDef->fsaa = 0;
+    rt0TexDef->uav = false;
+    rt0TexDef->automipmaps = false;
+    rt0TexDef->hwGammaWrite = Ogre::TextureDefinitionBase::BoolFalse;
+    rt0TexDef->depthBufferId = Ogre::DepthBuffer::POOL_DEFAULT;
+    rt0TexDef->depthBufferFormat = Ogre::PF_UNKNOWN;
+    rt0TexDef->fsaaExplicitResolve = false;
+
+    Ogre::TextureDefinitionBase::TextureDefinition *rt1TexDef =
+        baseNodeDef->addTextureDefinition("rt1");
+    rt1TexDef->textureType = Ogre::TEX_TYPE_2D;
+    rt1TexDef->width = 0;
+    rt1TexDef->height = 0;
+    rt1TexDef->depth = 1;
+    rt1TexDef->numMipmaps = 0;
+    rt1TexDef->widthFactor = 1;
+    rt1TexDef->heightFactor = 1;
+    rt1TexDef->formatList = {Ogre::PF_FLOAT32_RGBA};
+    rt1TexDef->fsaa = 0;
+    rt1TexDef->uav = false;
+    rt1TexDef->automipmaps = false;
+    rt1TexDef->hwGammaWrite = Ogre::TextureDefinitionBase::BoolFalse;
+    rt1TexDef->depthBufferId = Ogre::DepthBuffer::POOL_DEFAULT;
+    rt1TexDef->depthBufferFormat = Ogre::PF_UNKNOWN;
+    rt1TexDef->fsaaExplicitResolve = false;
+
     Ogre::TextureDefinitionBase::TextureDefinition *depthTexDef =
-        nodeDef->addTextureDefinition("depthTexture");
+        baseNodeDef->addTextureDefinition("depthTexture");
     depthTexDef->textureType = Ogre::TEX_TYPE_2D;
     depthTexDef->width = 0;
     depthTexDef->height = 0;
@@ -353,7 +539,7 @@ void Ogre2DepthCamera::CreateDepthTexture()
     depthTexDef->fsaaExplicitResolve = false;
 
     Ogre::TextureDefinitionBase::TextureDefinition *colorTexDef =
-        nodeDef->addTextureDefinition("colorTexture");
+        baseNodeDef->addTextureDefinition("colorTexture");
     colorTexDef->textureType = Ogre::TEX_TYPE_2D;
     colorTexDef->width = 0;
     colorTexDef->height = 0;
@@ -374,9 +560,9 @@ void Ogre2DepthCamera::CreateDepthTexture()
     colorTexDef->preferDepthTexture = true;
     colorTexDef->fsaaExplicitResolve = false;
 
-    nodeDef->setNumTargetPass(2);
+    baseNodeDef->setNumTargetPass(2);
     Ogre::CompositorTargetDef *colorTargetDef =
-        nodeDef->addTargetPass("colorTexture");
+        baseNodeDef->addTargetPass("colorTexture");
     colorTargetDef->setNumPasses(2);
     {
       // clear pass
@@ -391,32 +577,86 @@ void Ogre2DepthCamera::CreateDepthTexture()
           colorTargetDef->addPass(Ogre::PASS_SCENE));
       passScene->mVisibilityMask = IGN_VISIBILITY_ALL
           & ~(IGN_VISIBILITY_GUI | IGN_VISIBILITY_SELECTABLE);
+      passScene->mShadowNode = "PbsMaterialsShadowNode";
     }
-
-    // rt_input target - converts depth to range
-    Ogre::CompositorTargetDef *inputTargetDef =
-        nodeDef->addTargetPass("rt_input");
-    inputTargetDef->setNumPasses(2);
+    // rt0 target - converts depth to xyz
+    Ogre::CompositorTargetDef *inTargetDef =
+        baseNodeDef->addTargetPass("rt0");
+    inTargetDef->setNumPasses(1);
     {
-      // clear pass
-      Ogre::CompositorPassClearDef *passClear =
-          static_cast<Ogre::CompositorPassClearDef *>(
-          inputTargetDef->addPass(Ogre::PASS_CLEAR));
-      passClear->mColourValue = Ogre::ColourValue(this->FarClipPlane(), 0, 1.0);
       // quad pass
       Ogre::CompositorPassQuadDef *passQuad =
           static_cast<Ogre::CompositorPassQuadDef *>(
-          inputTargetDef->addPass(Ogre::PASS_QUAD));
+          inTargetDef->addPass(Ogre::PASS_QUAD));
       passQuad->mMaterialName = this->dataPtr->depthMaterial->getName();
       passQuad->addQuadTextureSource(0, "depthTexture", 0);
       passQuad->addQuadTextureSource(1, "colorTexture", 0);
       passQuad->mFrustumCorners =
           Ogre::CompositorPassQuadDef::VIEW_SPACE_CORNERS;
     }
-    nodeDef->mapOutputChannel(0, "rt_input");
+
+    baseNodeDef->mapOutputChannel(0, "rt0");
+    baseNodeDef->mapOutputChannel(1, "rt1");
+//    baseNodeDef->mapOutputChannel(2, "colorTexture");
+
+    // Programmatically create the final pass node and use the cloned final
+    // depth material created earlier.
+    // The compositor node definition is equivalent to the following:
+    //
+    // compositor_node DepthCameraFinal
+    // {
+    //   in 0 rt_output
+    //   in 1 rt_input
+    //
+    //   target rt_output
+    //   {
+    //     pass render_quad
+    //     {
+    //       material DepthCameraFinal // Use copy instead of original
+    //       input 0 rt_input
+    //     }
+    //   }
+    // }
+
+    std::string finalNodeDefName = wsDefName + "/FinalNode";
+    this->dataPtr->ogreCompositorFinalNodeDef = finalNodeDefName;
+    Ogre::CompositorNodeDef *finalNodeDef =
+        ogreCompMgr->addNodeDefinition(finalNodeDefName);
+
+    // output texture
+    finalNodeDef->addTextureSourceName("rt_output", 0,
+        Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+    finalNodeDef->addTextureSourceName("rt_input", 1,
+        Ogre::TextureDefinitionBase::TEXTURE_INPUT);
+
+    finalNodeDef->setNumTargetPass(1);
+    // rt_output target - converts depth to xyz
+    Ogre::CompositorTargetDef *outputTargetDef =
+        finalNodeDef->addTargetPass("rt_output");
+    outputTargetDef->setNumPasses(1);
+    {
+      // quad pass
+      Ogre::CompositorPassQuadDef *passQuad =
+          static_cast<Ogre::CompositorPassQuadDef *>(
+          outputTargetDef->addPass(Ogre::PASS_QUAD));
+      passQuad->mMaterialName = this->dataPtr->depthFinalMaterial->getName();
+      passQuad->addQuadTextureSource(0, "rt_input", 0);
+    }
+    finalNodeDef->mapOutputChannel(0, "rt_output");
+
+    // Finally create the workspace.
+    // The compositor workspace definition is equivalent to the following:
+    //
+    // workspace DepthCameraWorkspace
+    // {
+    //   connect_output DepthCameraFinal 0
+    //   connect DepthCamera 0 DepthCameraFinal 1
+    // }
     Ogre::CompositorWorkspaceDef *workDef =
         ogreCompMgr->addWorkspaceDefinition(wsDefName);
-    workDef->connectExternal(0, nodeDef->getName(), 0);
+
+    workDef->connect(baseNodeDefName, 0,  finalNodeDefName, 1);
+    workDef->connectExternal(0, finalNodeDefName, 0);
   }
   Ogre::CompositorWorkspaceDef *wsDef =
       ogreCompMgr->getWorkspaceDefinition(wsDefName);
@@ -460,6 +700,18 @@ void Ogre2DepthCamera::PreRender()
 {
   if (!this->dataPtr->ogreDepthTexture)
     this->CreateDepthTexture();
+
+  // update depth camera render passes
+  Ogre2RenderTarget::UpdateRenderPassChain(
+      this->dataPtr->ogreCompositorWorkspace,
+      this->dataPtr->ogreCompositorWorkspaceDef,
+      this->dataPtr->ogreCompositorBaseNodeDef,
+      this->dataPtr->ogreCompositorFinalNodeDef,
+      this->dataPtr->renderPasses,
+      this->dataPtr->renderPassDirty);
+  for (auto &pass : this->dataPtr->renderPasses)
+    pass->PreRender();
+  this->dataPtr->renderPassDirty = false;
 }
 
 //////////////////////////////////////////////////
@@ -618,4 +870,33 @@ double Ogre2DepthCamera::NearClipPlane() const
 double Ogre2DepthCamera::FarClipPlane() const
 {
   return BaseDepthCamera::FarClipPlane();
+}
+
+//////////////////////////////////////////////////
+void Ogre2DepthCamera::AddRenderPass(const RenderPassPtr &_pass)
+{
+  // hack: check and only allow gaussian noise for depth cameras
+  // We create a new depth gaussion noise render pass object
+  // (class declared in this src file) so that we can change the shader material
+  // to use for applying noise to depth data.
+  // The proper solution would be to either add a new DepthGaussianNoisePass
+  // class or extend the Ogre2GaussianNoisePass to handle both color and
+  // depth cameras
+  std::shared_ptr<Ogre2GaussianNoisePass> pass =
+      std::dynamic_pointer_cast<Ogre2GaussianNoisePass>(_pass);
+  if (!pass)
+  {
+    ignerr << "Depth camera currently only supports a gaussian noise pass"
+           << std::endl;
+    return;
+  }
+
+  // create new depth noise pass
+  std::shared_ptr<Ogre2DepthGaussianNoisePass> depthNoisePass =
+    std::make_shared<Ogre2DepthGaussianNoisePass>();
+  depthNoisePass->SetMean(pass->Mean());
+  depthNoisePass->SetStdDev(pass->StdDev());
+
+  this->dataPtr->renderPasses.push_back(depthNoisePass);
+  this->dataPtr->renderPassDirty = true;
 }

--- a/ogre2/src/media/materials/programs/depth_camera_final_fs.glsl
+++ b/ogre2/src/media/materials/programs/depth_camera_final_fs.glsl
@@ -38,32 +38,32 @@ void main()
 
   vec3 point = p.xyz;
 
-//  // Clamp again in case render passes changed depth values
-//  // to be outside of min/max range
-//
-//  // clamp xyz
-//  if (point.x > far - tolerance)
-//  {
-//    if (isinf(max))
-//    {
-//      point = vec3(max);
-//    }
-//    else
-//    {
-//      point.x = max;
-//    }
-//  }
-//  else if (point.x < near + tolerance)
-//  {
-//    if (isinf(min))
-//    {
-//      point = vec3(min);
-//    }
-//    else
-//    {
-//      point.x = min;
-//    }
-//  }
+  // Clamp again in case render passes changed depth values
+  // to be outside of min/max range
+
+  // clamp xyz
+  if (point.x > far - tolerance)
+  {
+    if (isinf(max))
+    {
+      point = vec3(max);
+    }
+    else
+    {
+      point.x = max;
+    }
+  }
+  else if (point.x < near + tolerance)
+  {
+    if (isinf(min))
+    {
+      point = vec3(min);
+    }
+    else
+    {
+      point.x = min;
+    }
+  }
 
   fragColor = vec4(point, p.a);
 }

--- a/ogre2/src/media/materials/programs/depth_camera_final_fs.glsl
+++ b/ogre2/src/media/materials/programs/depth_camera_final_fs.glsl
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#version 330
+
+in block
+{
+  vec2 uv0;
+} inPs;
+
+uniform sampler2D inputTexture;
+
+out vec4 fragColor;
+
+uniform float near;
+uniform float far;
+uniform float min;
+uniform float max;
+
+void main()
+{
+  float tolerance = 1e-6;
+  vec4 p = texture(inputTexture, inPs.uv0);
+
+  vec3 point = p.xyz;
+
+//  // Clamp again in case render passes changed depth values
+//  // to be outside of min/max range
+//
+//  // clamp xyz
+//  if (point.x > far - tolerance)
+//  {
+//    if (isinf(max))
+//    {
+//      point = vec3(max);
+//    }
+//    else
+//    {
+//      point.x = max;
+//    }
+//  }
+//  else if (point.x < near + tolerance)
+//  {
+//    if (isinf(min))
+//    {
+//      point = vec3(min);
+//    }
+//    else
+//    {
+//      point.x = min;
+//    }
+//  }
+
+  fragColor = vec4(point, p.a);
+}

--- a/ogre2/src/media/materials/programs/depth_camera_final_vs.glsl
+++ b/ogre2/src/media/materials/programs/depth_camera_final_vs.glsl
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#version 330
+
+in vec4 vertex;
+in vec3 normal;
+in vec2 uv0;
+uniform mat4 worldViewProj;
+
+out gl_PerVertex
+{
+  vec4 gl_Position;
+};
+
+out block
+{
+  vec2 uv0;
+} outVs;
+
+out vec4 point;
+
+void main()
+{
+  gl_Position = worldViewProj * vertex;
+  outVs.uv0.xy = uv0.xy;
+}

--- a/ogre2/src/media/materials/programs/depth_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/depth_camera_fs.glsl
@@ -33,7 +33,6 @@ uniform float near;
 uniform float far;
 uniform float min;
 uniform float max;
-uniform float tolerance;
 uniform vec3 backgroundColor;
 
 float getDepth(vec2 uv)
@@ -55,6 +54,8 @@ float packFloat(vec4 color)
 
 void main()
 {
+  float tolerance = 1e-6;
+
   // get linear depth
   float d = getDepth(inPs.uv0);
 

--- a/ogre2/src/media/materials/programs/gaussian_noise_depth_fs.glsl
+++ b/ogre2/src/media/materials/programs/gaussian_noise_depth_fs.glsl
@@ -127,5 +127,3 @@ void main()
 
   fragColor = vec4(xyz, rgba);
 }
-
-

--- a/ogre2/src/media/materials/programs/gaussian_noise_depth_fs.glsl
+++ b/ogre2/src/media/materials/programs/gaussian_noise_depth_fs.glsl
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#version 330
+
+// This fragment shader will add Gaussian noise to an rgbd image.
+// The implementation is adapted from gaussian_noise_fs.glsl to work with
+// a float32 rgba texture that consists of [x, y, z, rgba] values
+
+// The input texture, which is set up by the Ogre Compositor infrastructure.
+uniform sampler2D RT;
+
+// Random values sampled on the CPU, which we'll use as offsets into our 2-D
+// pseudo-random sampler here.
+uniform vec3 offsets;
+// Mean of the Gaussian distribution that we want to sample from.
+uniform float mean;
+// Standard deviation of the Gaussian distribution that we want to sample from.
+uniform float stddev;
+
+
+// input params from vertex shader
+in block
+{
+  vec2 uv0;
+} inPs;
+
+// final output color
+out vec4 fragColor;
+
+#define PI 3.14159265358979323846264
+
+float rand(vec2 co)
+{
+  // This one-liner can be found in many places, including:
+  // http://stackoverflow.com/questions/4200224/random-noise-functions-for-glsl
+  // I can't find any explanation for it, but experimentally it does seem to
+  // produce approximately uniformly distributed values in the interval [0,1].
+  float r = fract(sin(dot(co.xy, vec2(12.9898,78.233))) * 43758.5453);
+
+  // Make sure that we don't return 0.0
+  return clamp(r, 0.001, 1.0);
+}
+
+vec4 gaussrand(vec2 co)
+{
+  // Box-Muller method for sampling from the normal distribution
+  // http://en.wikipedia.org/wiki/Normal_distribution#Generating_values_from_normal_distribution
+  // This method requires 2 uniform random inputs and produces 2
+  // Gaussian random outputs.  We'll take a 3rd random variable and use it to
+  // switch between the two outputs.
+
+  float U, V, R, Z;
+  // Add in the CPU-supplied random offsets to generate the 3 random values that
+  // we'll use.
+  U = rand(co + vec2(offsets.x, offsets.x));
+  V = rand(co + vec2(offsets.y, offsets.y));
+  R = rand(co + vec2(offsets.z, offsets.z));
+  // Switch between the two random outputs.
+  if(R < 0.5)
+    Z = sqrt(-2.0 * log(U)) * sin(2.0 * PI * V);
+  else
+    Z = sqrt(-2.0 * log(U)) * cos(2.0 * PI * V);
+
+  float oldZ = Z;
+
+  // Apply the stddev and mean.
+  Z = Z * stddev + mean;
+
+  // Return it as a vec4, to be added to the input ("true") color.
+  return vec4(Z, Z, oldZ, 0.0);
+}
+
+float pack(vec4 color)
+{
+  int rgba = (int(color.x * 255.0) << 24) +
+             (int(color.y * 255.0) << 16) +
+             (int(color.z * 255.0) << 8) +
+             int(color.w * 255.0);
+  return intBitsToFloat(rgba);
+}
+
+vec4 unpack(float color)
+{
+  int rgba = floatBitsToInt(color);
+  int r = rgba >> 24 & 0xFF;
+  int g = rgba >> 16 & 0xFF;
+  int b = rgba >> 8 & 0xFF;
+  int a = rgba & 0xFF;
+  return vec4(r/255.0, g/255.0, b/255.0, a/255.0);
+}
+
+void main()
+{
+  // Add the sampled noise to the input x, y, z, rgba values
+
+  // original value
+  vec4 p = texture(RT, inPs.uv0.xy);
+
+  // gaussian noise
+  float z = gaussrand(inPs.uv0.xy).x;
+
+  // apply noise to xyz
+  vec3 xyz =  p.xyz + vec3(z, z, z);
+
+  // apply noise to color
+  float n = pow(abs(z), 2.1);
+  if (z < 0)
+    n = -n;
+  vec4 color = unpack(p.a);
+  color = clamp(color + vec4(n, n, n, 0.0), 0.0, 1.0);
+  float rgba = pack(color);
+
+  fragColor = vec4(xyz, rgba);
+}
+
+

--- a/ogre2/src/media/materials/scripts/depth_camera.material
+++ b/ogre2/src/media/materials/scripts/depth_camera.material
@@ -56,3 +56,40 @@ material DepthCamera
     }
   }
 }
+
+
+vertex_program DepthCameraFinalVS glsl
+{
+  source depth_camera_final_vs.glsl
+  default_params
+  {
+    param_named_auto worldViewProj worldviewproj_matrix
+  }
+}
+
+fragment_program DepthCameraFinalFS glsl
+{
+  source depth_camera_final_fs.glsl
+
+  default_params
+  {
+    param_named inputTexture int 0
+  }
+}
+
+material DepthCameraFinal
+{
+  technique
+  {
+    pass
+    {
+      vertex_program_ref DepthCameraFinalVS { }
+      fragment_program_ref DepthCameraFinalFS { }
+      texture_unit inputTexture
+      {
+        filtering none
+        tex_address_mode clamp
+      }
+    }
+  }
+}

--- a/ogre2/src/media/materials/scripts/gaussian_noise.material
+++ b/ogre2/src/media/materials/scripts/gaussian_noise.material
@@ -59,3 +59,40 @@ material GaussianNoise
   }
 }
 
+
+fragment_program GaussianNoiseDepthFS glsl
+{
+  source gaussian_noise_depth_fs.glsl
+  default_params
+  {
+    param_named RT int 0
+    param_named mean float 0.0
+    param_named stddev float 1.0
+    param_named offsets float3 0.0 0.0 0.0
+  }
+}
+
+material GaussianNoiseDepth
+{
+  technique
+  {
+    pass
+    {
+      depth_check off
+      depth_write off
+      cull_hardware none
+
+      vertex_program_ref GaussianNoiseVS { }
+      fragment_program_ref GaussianNoiseDepthFS { }
+
+      texture_unit RT
+      {
+        tex_coord_set 0
+        tex_address_mode clamp
+        // filtering linear linear linear
+        filtering none
+      }
+    }
+  }
+}
+

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -23,6 +23,7 @@
 #include "test_config.h"  // NOLINT(build/include)
 
 #include "ignition/rendering/Camera.hh"
+#include "ignition/rendering/DepthCamera.hh"
 #include "ignition/rendering/GaussianNoisePass.hh"
 #include "ignition/rendering/Image.hh"
 #include "ignition/rendering/PixelFormat.hh"
@@ -31,6 +32,18 @@
 #include "ignition/rendering/RenderPassSystem.hh"
 #include "ignition/rendering/Scene.hh"
 
+#define DOUBLE_TOL 1e-6
+unsigned int g_depthCounter = 0;
+
+void OnNewRgbPointCloud(float *_scanDest, const float *_scan,
+                  unsigned int _width, unsigned int _height,
+                  unsigned int _channels,
+                  const std::string &/*_format*/)
+{
+  float f;
+  int size =  _width * _height * _channels;
+  memcpy(_scanDest, _scan, size * sizeof(f));
+}
 using namespace ignition;
 using namespace rendering;
 
@@ -39,6 +52,9 @@ class RenderPassTest: public testing::Test,
 {
   // Test and verify Gaussian noise pass is applied to a camera
   public: void GaussianNoise(const std::string &_renderEngine);
+
+  // Test and verify Gaussian noise pass is applied to a depth camera
+  public: void DepthGaussianNoise(const std::string &_renderEngine);
 };
 
 /////////////////////////////////////////////////
@@ -158,9 +174,230 @@ void RenderPassTest::GaussianNoise(const std::string &_renderEngine)
 }
 
 /////////////////////////////////////////////////
+void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
+{
+  int imgWidth = 10;
+  int imgHeight = 10;
+
+  double aspectRatio_ = imgWidth/imgHeight;
+
+  double unitBoxSize = 1.0;
+  ignition::math::Vector3d boxPosition(1.8, 0.0, 0.0);
+
+  // Optix is not supported
+  if (_renderEngine != "ogre2")
+  {
+    igndbg << "Engine '" << _renderEngine
+           << "' doesn't support render pass for depth cameras " << std::endl;
+    return;
+  }
+
+  // Setup ign-rendering with an empty scene
+  auto *engine = ignition::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ignition::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  // red background
+  scene->SetBackgroundColor(1.0, 0.0, 0.0);
+
+  // Create an scene with a box in it
+  scene->SetAmbientLight(1.0, 1.0, 1.0);
+  ignition::rendering::VisualPtr root = scene->RootVisual();
+
+  // create blue material
+  ignition::rendering::MaterialPtr blue = scene->CreateMaterial();
+  blue->SetAmbient(0.0, 0.0, 1.0);
+  blue->SetDiffuse(0.0, 0.0, 1.0);
+  blue->SetSpecular(0.0, 0.0, 1.0);
+
+  // create box visual
+  ignition::rendering::VisualPtr box = scene->CreateVisual();
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(boxPosition);
+  box->SetLocalRotation(0, 0, 0);
+  box->SetLocalScale(unitBoxSize, unitBoxSize, unitBoxSize);
+  box->SetMaterial(blue);
+  root->AddChild(box);
+  {
+    double farDist = 10.0;
+    double nearDist = 0.15;
+    double hfov_ = 1.05;
+    // Create depth camera
+    auto depthCamera = scene->CreateDepthCamera("DepthCamera");
+    ASSERT_NE(depthCamera, nullptr);
+
+    ignition::math::Pose3d testPose(ignition::math::Vector3d(0, 0, 0),
+        ignition::math::Quaterniond::Identity);
+    depthCamera->SetLocalPose(testPose);
+
+    // Configure depth camera
+    depthCamera->SetImageWidth(imgWidth);
+    EXPECT_EQ(depthCamera->ImageWidth(),
+      static_cast<unsigned int>(imgWidth));
+    depthCamera->SetImageHeight(imgHeight);
+    EXPECT_EQ(depthCamera->ImageHeight(),
+      static_cast<unsigned int>(imgHeight));
+    depthCamera->SetFarClipPlane(farDist);
+    EXPECT_NEAR(depthCamera->FarClipPlane(), farDist, DOUBLE_TOL);
+    depthCamera->SetNearClipPlane(nearDist);
+    EXPECT_NEAR(depthCamera->NearClipPlane(), nearDist, DOUBLE_TOL);
+    depthCamera->SetAspectRatio(aspectRatio_);
+    EXPECT_NEAR(depthCamera->AspectRatio(), aspectRatio_, DOUBLE_TOL);
+    depthCamera->SetHFOV(hfov_);
+    EXPECT_NEAR(depthCamera->HFOV().Radian(), hfov_, DOUBLE_TOL);
+
+    depthCamera->CreateDepthTexture();
+    scene->RootVisual()->AddChild(depthCamera);
+
+    // Add Gaussian noise
+    double noiseMean = 0.1;
+    double noiseStdDev = 0.01;
+    RenderPassSystemPtr rpSystem = engine->RenderPassSystem();
+    if (rpSystem)
+    {
+      // add gaussian noise pass
+      RenderPassPtr pass = rpSystem->Create<GaussianNoisePass>();
+      GaussianNoisePassPtr noisePass =
+          std::dynamic_pointer_cast<GaussianNoisePass>(pass);
+      noisePass->SetMean(noiseMean);
+      noisePass->SetStdDev(noiseStdDev);
+      depthCamera->AddRenderPass(noisePass);
+    }
+    else
+    {
+      ignwarn << "Engine '" << _renderEngine << "' does not support "
+              << "render pass  system" << std::endl;
+      return;
+    }
+
+    // rgb point cloud data callback
+    unsigned int pointCloudChannelCount = 4u;
+    float *pointCloudData = new float[
+        imgHeight * imgWidth * pointCloudChannelCount];
+    ignition::common::ConnectionPtr connection =
+      depthCamera->ConnectNewRgbPointCloud(
+          std::bind(&::OnNewRgbPointCloud, pointCloudData,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+
+    // Update once to create image
+    depthCamera->Update();
+
+    // compute mid, left, and right indices to be used later for retrieving data
+    // from point cloud image
+
+    // point cloud image indices
+    int midWidth = depthCamera->ImageWidth() * 0.5;
+    int midHeight = depthCamera->ImageHeight() * 0.5;
+    double expectedRangeAtMidPoint = boxPosition.X() - unitBoxSize * 0.5;
+
+    int pcMid = midHeight * depthCamera->ImageWidth() * pointCloudChannelCount
+        + (midWidth-1) * pointCloudChannelCount;
+    int pcLeft = midHeight * depthCamera->ImageWidth() * pointCloudChannelCount;
+    int pcRight = (midHeight+1)
+        * (depthCamera->ImageWidth() * pointCloudChannelCount)
+        - pointCloudChannelCount;
+
+    float maxVal = ignition::math::INF_D;
+
+    // values should be well within 4-sigma
+    float noiseTol = 4.0*noiseStdDev;
+    unsigned int colorNoiseTol = static_cast<unsigned int>(255.0*noiseTol);
+
+    // Verify Point Cloud XYZ values
+    {
+      // check mid point
+      float mx = pointCloudData[pcMid];
+      EXPECT_NEAR(expectedRangeAtMidPoint + noiseMean, mx, noiseTol);
+
+      // check left and right points
+      float lx = pointCloudData[pcLeft];
+      float ly = pointCloudData[pcLeft + 1];
+      float lz = pointCloudData[pcLeft + 2];
+      EXPECT_FLOAT_EQ(maxVal, lx);
+      EXPECT_FLOAT_EQ(maxVal, ly);
+      EXPECT_FLOAT_EQ(maxVal, lz);
+
+      float rx = pointCloudData[pcRight];
+      float ry = pointCloudData[pcRight + 1];
+      float rz = pointCloudData[pcRight + 2];
+      EXPECT_FLOAT_EQ(maxVal, rx);
+      EXPECT_FLOAT_EQ(maxVal, ry);
+      EXPECT_FLOAT_EQ(maxVal, rz);
+
+      // all points on the box should have similar z position
+      float mz = pointCloudData[pcMid + 2];
+      float midLeftZ = pointCloudData[pcMid + 2 - pointCloudChannelCount];
+      float midRightZ = pointCloudData[pcMid + 2 + pointCloudChannelCount];
+      EXPECT_NEAR(mz, midLeftZ, noiseTol);
+      EXPECT_NEAR(mz, midRightZ, noiseTol);
+
+      // Verify Point Cloud RGB values
+      // The mid point should be blue
+      float mc = pointCloudData[pcMid + 3];
+      uint32_t *mrgba = reinterpret_cast<uint32_t *>(&mc);
+      unsigned int mr = *mrgba >> 24 & 0xFF;
+      unsigned int mg = *mrgba >> 16 & 0xFF;
+      unsigned int mb = *mrgba >> 8 & 0xFF;
+      unsigned int ma = *mrgba >> 0 & 0xFF;
+      EXPECT_NEAR(0u, mr, colorNoiseTol);
+      EXPECT_NEAR(0u, mg, colorNoiseTol);
+      EXPECT_GT(mb, 0u);
+      EXPECT_EQ(255u, ma);
+
+      // Far left and right points should be red (background color)
+      float lc = pointCloudData[pcLeft + 3];
+      uint32_t *lrgba = reinterpret_cast<uint32_t *>(&lc);
+      unsigned int lr = *lrgba >> 24 & 0xFF;
+      unsigned int lg = *lrgba >> 16 & 0xFF;
+      unsigned int lb = *lrgba >> 8 & 0xFF;
+      unsigned int la = *lrgba >> 0 & 0xFF;
+
+      EXPECT_NEAR(255u, lr, colorNoiseTol);
+      EXPECT_NEAR(0u, lg, colorNoiseTol);
+      EXPECT_NEAR(0u, lb, colorNoiseTol);
+      EXPECT_EQ(255u, la);
+
+      float rc = pointCloudData[pcRight + 3];
+      uint32_t *rrgba = reinterpret_cast<uint32_t *>(&rc);
+      unsigned int rr = *rrgba >> 24 & 0xFF;
+      unsigned int rg = *rrgba >> 16 & 0xFF;
+      unsigned int rb = *rrgba >> 8 & 0xFF;
+      unsigned int ra = *rrgba >> 0 & 0xFF;
+
+      EXPECT_NEAR(255u, rr, colorNoiseTol);
+      EXPECT_NEAR(0u, rg, colorNoiseTol);
+      EXPECT_NEAR(0u, rb, colorNoiseTol);
+      EXPECT_EQ(255u, ra);
+    }
+
+    // Clean up
+    connection.reset();
+    if (pointCloudData)
+      delete [] pointCloudData;
+  }
+
+  engine->DestroyScene(scene);
+  ignition::rendering::unloadEngine(engine->Name());
+}
+
+/////////////////////////////////////////////////
 TEST_P(RenderPassTest, GaussianNoise)
 {
   GaussianNoise(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_P(RenderPassTest, DepthGaussianNoise)
+{
+  DepthGaussianNoise(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(GaussianNoise, RenderPassTest,


### PR DESCRIPTION
Depth cameras in ign-rendering generates both depth and color data using custom shader scripts so we can not apply regular image based Gaussian noise pass to its output. Instead, I updated Ogre2DepthCamera class to support its own render pass chain, and wrote a separate fragment shader that works with the depth camera data format. 

The Gaussian noise is applied individually to each component in the point cloud data, i.e. x, y, z, and r, g, b. 

Here's a [depth_noise.sdf](https://gist.github.com/iche033/898d7888462b2cdf264a0808942660b0) for testing in ign-gazebo (requires ignitionrobotics/ign-sensors#35). To launch:

```
ign gazebo -v 4 depth_noise.sdf
```

Select the `/camera/image` topic in the ImageDisplay plugin to see the following image output:

![depth_color_noise](https://user-images.githubusercontent.com/4000684/89588338-4d7b2a00-d7f8-11ea-98fd-bdd2e3bc3a0c.png)

As for the depth image, the effect is not very noticeable in the `/camera/depth_image` topic in ImageDisplay because I think the conversion of depth to color image normalizes the data and that reduces the effect of noise. Here's a better visualization in rviz that shows noise in the point cloud data generated by the depth camera:

![rgbd_noise](https://user-images.githubusercontent.com/4000684/89588634-e3af5000-d7f8-11ea-8437-a5f4a4544258.gif)




