### PR TITLE
minor change in LidarVisual for the case when sensor data is more than sensor range

### DIFF
--- a/ogre/src/OgreLidarVisual.cc
+++ b/ogre/src/OgreLidarVisual.cc
@@ -361,7 +361,7 @@ void OgreLidarVisual::Update()
       // calculate range of the ray
       double r = this->dataPtr->lidarPoints[ j * this->horizontalCount + i];
 
-      bool inf = std::isinf(r);
+      bool inf = (std::isinf(r) || r >= this->maxRange);
       ignition::math::Quaterniond ray(
         ignition::math::Vector3d(0.0, -verticalAngle, horizontalAngle));
 
@@ -374,13 +374,13 @@ void OgreLidarVisual::Update()
 
       // Compute the start point of the ray
       ignition::math::Vector3d startPt =
-                  (axis * minRange) + this->offset.Pos();
+                  (axis * this->minRange) + this->offset.Pos();
 
       // Compute the end point of the ray
       ignition::math::Vector3d pt =
                   (axis * hitRange) + this->offset.Pos();
 
-      double noHitRange = inf ? maxRange : hitRange;
+      double noHitRange = inf ? this->maxRange : hitRange;
 
       // Compute the end point of the no-hit ray
       ignition::math::Vector3d noHitPt =

--- a/ogre2/src/Ogre2LidarVisual.cc
+++ b/ogre2/src/Ogre2LidarVisual.cc
@@ -309,7 +309,7 @@ void Ogre2LidarVisual::Update()
       // calculate range of the ray
       double r = this->dataPtr->lidarPoints[ j * this->horizontalCount + i];
 
-      bool inf = std::isinf(r);
+      bool inf = (std::isinf(r) || r >= this->maxRange);
       ignition::math::Quaterniond ray(
         ignition::math::Vector3d(0.0, -verticalAngle, horizontalAngle));
 
@@ -322,13 +322,13 @@ void Ogre2LidarVisual::Update()
 
       // Compute the start point of the ray
       ignition::math::Vector3d startPt =
-                  (axis * minRange) + this->offset.Pos();
+                  (axis * this->minRange) + this->offset.Pos();
 
       // Compute the end point of the ray
       ignition::math::Vector3d pt =
                   (axis * hitRange) + this->offset.Pos();
 
-      double noHitRange = inf ? maxRange : hitRange;
+      double noHitRange = inf ? this->maxRange : hitRange;
 
       // Compute the end point of the no-hit ray
       ignition::math::Vector3d noHitPt =


### PR DESCRIPTION
This PR attempts to fix the case when the data given to the sensor happens to contain a range value which is greater than, or exactly equal to the sensor range.
For rays when the sensor does not hit anything in the range, it returns `inf` for the ray. However, when we add adding noise to the measurements defaults the `inf` reading exactly equal to  `maxRange` of the sensor. This causes the lidar visual to display the rays, although they are not hitting any object.

Additionally, if a point is a finite value (even if it is greater than the maxRange), the LidarVisual showed it since the only criteria of determining if the sensor ray was hitting or not was if the value returned by the sensor was `inf`.