### PR TITLE
Adding option for visibility

### DIFF
--- a/ogre/include/ignition/rendering/ogre/OgreLidarVisual.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreLidarVisual.hh
@@ -81,6 +81,9 @@ namespace ignition
       /// \brief Clear data stored by dynamiclines
       private: void ClearVisualData();
 
+      // Documentation inherited
+      public: virtual void SetVisible(bool _visible) override;
+
       /// \brief Lidar Visual should only be created by scene.
       private: friend class OgreScene;
 

--- a/ogre/src/OgreLidarVisual.cc
+++ b/ogre/src/OgreLidarVisual.cc
@@ -55,6 +55,9 @@ class ignition::rendering::OgreLidarVisualPrivate
 
   /// \brief True if new points data is received
   public: bool receivedData = false;
+
+  /// \brief The visibility of the visual
+  public: bool visible = true;
 };
 
 using namespace ignition;
@@ -482,6 +485,11 @@ void OgreLidarVisual::Update()
     }
     verticalAngle += this->verticalAngleStep;
   }
+
+  // The newly created dynamic lines are having default visibility as true.
+  // The visibility needs to be set as per the current value after the new
+  // renderables are created.
+  this->SetVisible(this->dataPtr->visible);
 }
 
 //////////////////////////////////////////////////
@@ -494,4 +502,11 @@ unsigned int OgreLidarVisual::PointCount() const
 std::vector<double> OgreLidarVisual::Points() const
 {
   return this->dataPtr->lidarPoints;
+}
+
+//////////////////////////////////////////////////
+void OgreLidarVisual::SetVisible(bool _visible)
+{
+  this->dataPtr->visible = _visible;
+  this->ogreNode->setVisible(this->dataPtr->visible);
 }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2LidarVisual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2LidarVisual.hh
@@ -75,6 +75,9 @@ namespace ignition
       /// \brief Clear data stored by dynamiclines
       private: void ClearVisualData();
 
+      // Documentation inherited
+      public: virtual void SetVisible(bool _visible) override;
+
       /// \brief Lidar Visual should only be created by scene.
       private: friend class Ogre2Scene;
 

--- a/ogre2/src/Ogre2LidarVisual.cc
+++ b/ogre2/src/Ogre2LidarVisual.cc
@@ -52,6 +52,9 @@ class ignition::rendering::Ogre2LidarVisualPrivate
 
   /// \brief True if new points data is received
   public: bool receivedData = false;
+
+  /// \brief The visibility of the visual
+  public: bool visible = true;
 };
 
 using namespace ignition;
@@ -429,6 +432,11 @@ void Ogre2LidarVisual::Update()
     }
     verticalAngle += this->verticalAngleStep;
   }
+
+  // The newly created dynamic lines are having default visibility as true.
+  // The visibility needs to be set as per the current value after the new
+  // renderables are created.
+  this->SetVisible(this->dataPtr->visible);
 }
 
 //////////////////////////////////////////////////
@@ -441,4 +449,11 @@ unsigned int Ogre2LidarVisual::PointCount() const
 std::vector<double> Ogre2LidarVisual::Points() const
 {
   return this->dataPtr->lidarPoints;
+}
+
+//////////////////////////////////////////////////
+void Ogre2LidarVisual::SetVisible(bool _visible)
+{
+  this->dataPtr->visible = _visible;
+  this->ogreNode->setVisible(this->dataPtr->visible);
 }


### PR DESCRIPTION
@iche033  Please see this PR to solve the issue in [ign-gazebo/#301](https://github.com/ignitionrobotics/ign-gazebo/pull/301)

I have added to the API to set and get the visible state of the visual. I could not access the existing visibility status of the ogre node as they have not provided API's for the same. [[link]](https://forums.ogre3d.org/viewtopic.php?t=23694) 