### PR TITLE
Replace common::Time with std::chrono

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ ign_configure_project(VERSION_SUFFIX pre1)
 
 #--------------------------------------
 # Find ignition-math
-ign_find_package(ignition-math6 REQUIRED)
+ign_find_package(ignition-math6 REQUIRED VERSION 6.6)
 set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------

--- a/Migration.md
+++ b/Migration.md
@@ -6,6 +6,18 @@ notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
 
+## Ignition Rendering 3.X to 4.X
+
+### Deprecations
+
+1. **ignition::common::Time** deprecated in favor of **std::chrono::steady_clock::duration**
+    + Deprecated: `void BaseScene::SetSimTime(const common::Time &_time)`
+    + Replacement: `void BaseScene::SetTime(const std::chrono::steady_clock::duration &_time)`
+    + Deprecated: `common::Time SimTime() const`
+    + Replacement: `std::chrono::steady_clock::duration Time() const`
+    + Deprecated: `common::Time simTime`
+    + Replacement: `std::chrono::steady_clock::duration time`
+
 ## Ignition Rendering 2.X to 3.X
 
 ### Deletions

--- a/examples/gazebo_scene_viewer/SceneManager.cc
+++ b/examples/gazebo_scene_viewer/SceneManager.cc
@@ -19,6 +19,7 @@
 
 #include <ignition/common/MeshManager.hh>
 #include <ignition/common/Console.hh>
+#include <ignition/math/Helpers.hh>
 #include <ignition/rendering.hh>
 
 #include "SceneManager.hh"
@@ -1813,7 +1814,7 @@ void CurrentSceneManager::OnPoseUpdate(::ConstPosesStampedPtr &_posesMsg)
   // record pose timestamp
   int sec = _posesMsg->time().sec();
   int nsec = _posesMsg->time().nsec();
-  this->timePosesReceived = common::Time(sec, nsec);
+  this->timePosesReceived = math::secNsecToTimePoint(sec, nsec);
 
   // process each pose in message
   for (int i = 0; i < _posesMsg->pose_size(); ++i)
@@ -2053,7 +2054,7 @@ void NewSceneManager::ProcessPoses(const gazebo::msgs::PosesStamped &_posesMsg)
   // record pose timestamp
   int sec = _posesMsg.time().sec();
   int nsec = _posesMsg.time().nsec();
-  this->timePosesReceived = common::Time(sec, nsec);
+  this->timePosesReceived = math::secNsecToTimePoint(sec, nsec);
 
   // process each pose in list
   for (int i = 0; i < _posesMsg.pose_size(); ++i)

--- a/examples/gazebo_scene_viewer/SceneManager.cc
+++ b/examples/gazebo_scene_viewer/SceneManager.cc
@@ -860,7 +860,7 @@ void SubSceneManager::ProcessMessages()
 //! [process message]
 
   // flush changes to scene
-  this->activeScene->SetSimTime(this->timePosesReceived);
+  this->activeScene->SetTime(this->timePosesReceived);
   this->activeScene->PreRender();
 }
 
@@ -1812,9 +1812,8 @@ CurrentSceneManager::~CurrentSceneManager()
 void CurrentSceneManager::OnPoseUpdate(::ConstPosesStampedPtr &_posesMsg)
 {
   // record pose timestamp
-  int sec = _posesMsg->time().sec();
-  int nsec = _posesMsg->time().nsec();
-  this->timePosesReceived = math::secNsecToTimePoint(sec, nsec);
+  this->timePosesReceived = math::secNsecToDuration(
+      _posesMsg->time().sec(),  _posesMsg->time().nsec());
 
   // process each pose in message
   for (int i = 0; i < _posesMsg->pose_size(); ++i)
@@ -2052,9 +2051,8 @@ void NewSceneManager::ProcessPoses()
 void NewSceneManager::ProcessPoses(const gazebo::msgs::PosesStamped &_posesMsg)
 {
   // record pose timestamp
-  int sec = _posesMsg.time().sec();
-  int nsec = _posesMsg.time().nsec();
-  this->timePosesReceived = math::secNsecToTimePoint(sec, nsec);
+  this->timePosesReceived = math::secNsecToDuration(
+    _posesMsg.time().sec(), _posesMsg.time().nsec());
 
   // process each pose in list
   for (int i = 0; i < _posesMsg.pose_size(); ++i)

--- a/examples/gazebo_scene_viewer/SceneManagerPrivate.hh
+++ b/examples/gazebo_scene_viewer/SceneManagerPrivate.hh
@@ -379,7 +379,7 @@ namespace ignition
 
       protected: std::vector<ScenePtr> scenes;
 
-      protected: common::Time timePosesReceived;
+      protected: std::chrono::steady_clock::time_point timePosesReceived;
 
       protected: std::vector<gazebo::msgs::Light> lightMsgs;
 

--- a/examples/gazebo_scene_viewer/SceneManagerPrivate.hh
+++ b/examples/gazebo_scene_viewer/SceneManagerPrivate.hh
@@ -379,7 +379,7 @@ namespace ignition
 
       protected: std::vector<ScenePtr> scenes;
 
-      protected: std::chrono::steady_clock::time_point timePosesReceived;
+      protected: std::chrono::steady_clock::duration timePosesReceived;
 
       protected: std::vector<gazebo::msgs::Light> lightMsgs;
 

--- a/examples/ogre2_demo/GlutWindow.cc
+++ b/examples/ogre2_demo/GlutWindow.cc
@@ -279,12 +279,6 @@ void displayCB()
   glDrawPixels(imgw, imgh, GL_RGB, GL_UNSIGNED_BYTE, data);
 
   glutSwapBuffers();
-
-  // Uncomment to print FPS
-  // static ignition::common::Time previous;
-  // auto now = ignition::common::Time::SystemTime();
-  // std::cerr << (now - previous).Double() << std::endl;
-  // previous = now;
 }
 
 //////////////////////////////////////////////////
@@ -388,5 +382,3 @@ void run(std::vector<ir::CameraPtr> _cameras)
 
   glutMainLoop();
 }
-
-

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -77,12 +77,21 @@ namespace ignition
 
       /// \brief Get the last simulation update time
       /// \return The last simulation update time
+      public: virtual common::Time IGN_DEPRECATED(4) SimTime() const = 0;
+
+      /// \brief Get the last simulation update time
+      /// \return The last simulation update time
       public: virtual std::chrono::steady_clock::time_point
-        SimTime() const = 0;
+        Time() const = 0;
 
       /// \brief Set the last simulation update time
       /// \param[in] _time Latest simulation update time
-      public: virtual void SetSimTime(
+      public: virtual void IGN_DEPRECATED(4)
+        SetSimTime(const common::Time &_time) = 0;
+
+      /// \brief Set the last simulation update time
+      /// \param[in] _time Latest simulation update time
+      public: virtual void SetTime(
         const std::chrono::steady_clock::time_point &_time) = 0;
 
       /// \brief Get root Visual node. All nodes that are desired to be

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -81,7 +81,7 @@ namespace ignition
 
       /// \brief Get the last simulation update time
       /// \return The last simulation update time
-      public: virtual std::chrono::steady_clock::time_point
+      public: virtual std::chrono::steady_clock::duration
         Time() const = 0;
 
       /// \brief Set the last simulation update time
@@ -92,7 +92,7 @@ namespace ignition
       /// \brief Set the last simulation update time
       /// \param[in] _time Latest simulation update time
       public: virtual void SetTime(
-        const std::chrono::steady_clock::time_point &_time) = 0;
+        const std::chrono::steady_clock::duration &_time) = 0;
 
       /// \brief Get root Visual node. All nodes that are desired to be
       /// rendered in a scene should be added to this Visual or one of its

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -77,11 +77,13 @@ namespace ignition
 
       /// \brief Get the last simulation update time
       /// \return The last simulation update time
-      public: virtual common::Time SimTime() const = 0;
+      public: virtual std::chrono::steady_clock::time_point
+        SimTime() const = 0;
 
       /// \brief Set the last simulation update time
       /// \param[in] _time Latest simulation update time
-      public: virtual void SetSimTime(const common::Time &_time) = 0;
+      public: virtual void SetSimTime(
+        const std::chrono::steady_clock::time_point &_time) = 0;
 
       /// \brief Get root Visual node. All nodes that are desired to be
       /// rendered in a scene should be added to this Visual or one of its

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -617,7 +617,9 @@ namespace ignition
 
       protected: std::string name;
 
-      protected: std::chrono::steady_clock::duration simTime =
+      protected: common::Time IGN_DEPRECATED(4) simTime;
+
+      protected: std::chrono::steady_clock::duration time =
         std::chrono::steady_clock::duration::zero();
 
       protected: bool loaded;

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -55,10 +55,15 @@ namespace ignition
 
       public: virtual std::string Name() const override;
 
-      public: virtual std::chrono::steady_clock::time_point SimTime()
+      public: virtual void IGN_DEPRECATED(4)
+        SetSimTime(const common::Time &_time) override;
+
+      public: virtual common::Time IGN_DEPRECATED(4) SimTime() const override;
+
+      public: virtual std::chrono::steady_clock::time_point Time()
         const override;
 
-      public: virtual void SetSimTime(
+      public: virtual void SetTime(
         const std::chrono::steady_clock::time_point &_time) override;
 
       public: virtual void SetAmbientLight(double _r, double _g, double _b,

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -55,9 +55,11 @@ namespace ignition
 
       public: virtual std::string Name() const override;
 
-      public: virtual common::Time SimTime() const override;
+      public: virtual std::chrono::steady_clock::time_point SimTime()
+        const override;
 
-      public: virtual void SetSimTime(const common::Time &_time) override;
+      public: virtual void SetSimTime(
+        const std::chrono::steady_clock::time_point &_time) override;
 
       public: virtual void SetAmbientLight(double _r, double _g, double _b,
                   double _a = 1.0) override;
@@ -610,7 +612,7 @@ namespace ignition
 
       protected: std::string name;
 
-      protected: common::Time simTime;
+      protected: std::chrono::steady_clock::time_point simTime;
 
       protected: bool loaded;
 

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -60,11 +60,11 @@ namespace ignition
 
       public: virtual common::Time IGN_DEPRECATED(4) SimTime() const override;
 
-      public: virtual std::chrono::steady_clock::time_point Time()
+      public: virtual std::chrono::steady_clock::duration Time()
         const override;
 
       public: virtual void SetTime(
-        const std::chrono::steady_clock::time_point &_time) override;
+        const std::chrono::steady_clock::duration &_time) override;
 
       public: virtual void SetAmbientLight(double _r, double _g, double _b,
                   double _a = 1.0) override;
@@ -617,7 +617,8 @@ namespace ignition
 
       protected: std::string name;
 
-      protected: std::chrono::steady_clock::time_point simTime;
+      protected: std::chrono::steady_clock::duration simTime =
+        std::chrono::steady_clock::duration::zero();
 
       protected: bool loaded;
 

--- a/src/Scene_TEST.cc
+++ b/src/Scene_TEST.cc
@@ -45,6 +45,9 @@ class SceneTest : public testing::Test,
 
   /// \brief Test creating and destroying materials
   public: void Materials(const std::string &_renderEngine);
+
+  /// \brief Test setting and getting Time
+  public: void Time(const std::string &_renderEngine);
 };
 
 /////////////////////////////////////////////////
@@ -645,6 +648,40 @@ void SceneTest::Materials(const std::string &_renderEngine)
 }
 
 /////////////////////////////////////////////////
+void SceneTest::Time(const std::string &_renderEngine)
+{
+  auto engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    return;
+  }
+
+  auto scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  std::chrono::steady_clock::duration duration =
+    std::chrono::steady_clock::duration::zero();
+
+  EXPECT_EQ(duration, scene->Time());
+
+  duration = std::chrono::seconds(23);
+
+  scene->SetTime(duration);
+  EXPECT_EQ(duration, scene->Time());
+
+  duration = std::chrono::seconds(1) + std::chrono::milliseconds(123);
+  scene->SetTime(duration);
+  EXPECT_EQ(duration, scene->Time());
+
+  duration = std::chrono::hours(24) +
+             std::chrono::seconds(6) +
+             std::chrono::milliseconds(123);
+  scene->SetTime(duration);
+  EXPECT_EQ(duration, scene->Time());
+}
+
+/////////////////////////////////////////////////
 TEST_P(SceneTest, Scene)
 {
   Scene(GetParam());
@@ -678,6 +715,12 @@ TEST_P(SceneTest, NodeCycle)
 TEST_P(SceneTest, Materials)
 {
   Materials(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_P(SceneTest, Time)
+{
+  Time(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(Scene, SceneTest,

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -118,15 +118,36 @@ std::string BaseScene::Name() const
 }
 
 //////////////////////////////////////////////////
-std::chrono::steady_clock::time_point BaseScene::SimTime() const
+std::chrono::steady_clock::time_point BaseScene::Time() const
 {
   return this->simTime;
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetSimTime(const std::chrono::steady_clock::time_point &_time)
+void BaseScene::SetTime(const std::chrono::steady_clock::time_point &_time)
 {
   this->simTime = _time;
+}
+
+//////////////////////////////////////////////////
+common::Time BaseScene::SimTime() const
+{
+  std::pair<int64_t, int64_t> secsAndNsecs =
+    math::timePointToSecNsec(this->simTime);
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return common::Time(secsAndNsecs.first, secsAndNsecs.second);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+}
+
+//////////////////////////////////////////////////
+void BaseScene::SetSimTime(const common::Time &_time)
+{
+  this->simTime = math::secNsecToTimePoint(_time.sec, _time.nsec);
 }
 
 //////////////////////////////////////////////////

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -118,13 +118,13 @@ std::string BaseScene::Name() const
 }
 
 //////////////////////////////////////////////////
-common::Time BaseScene::SimTime() const
+std::chrono::steady_clock::time_point BaseScene::SimTime() const
 {
   return this->simTime;
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetSimTime(const common::Time &_time)
+void BaseScene::SetSimTime(const std::chrono::steady_clock::time_point &_time)
 {
   this->simTime = _time;
 }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -45,6 +45,11 @@
 using namespace ignition;
 using namespace rendering;
 
+// Prevent deprecation warnings for simTime
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 //////////////////////////////////////////////////
 BaseScene::BaseScene(unsigned int _id, const std::string &_name) :
   id(_id),
@@ -60,6 +65,9 @@ BaseScene::BaseScene(unsigned int _id, const std::string &_name) :
 BaseScene::~BaseScene()
 {
 }
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 //////////////////////////////////////////////////
 void BaseScene::Load()
@@ -120,35 +128,33 @@ std::string BaseScene::Name() const
 //////////////////////////////////////////////////
 std::chrono::steady_clock::duration BaseScene::Time() const
 {
-  return this->simTime;
+  return this->time;
 }
 
 //////////////////////////////////////////////////
 void BaseScene::SetTime(const std::chrono::steady_clock::duration &_time)
 {
-  this->simTime = _time;
+  this->time = _time;
 }
 
 //////////////////////////////////////////////////
-common::Time BaseScene::SimTime() const
-{
-  std::pair<int64_t, int64_t> secsAndNsecs =
-    math::durationToSecNsec(this->simTime);
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-  return common::Time(secsAndNsecs.first, secsAndNsecs.second);
+common::Time BaseScene::SimTime() const
+{
+  return this->simTime;
+}
+
+////////////////////////////////////////////////////
+void BaseScene::SetSimTime(const common::Time &_time)
+{
+  this->simTime = _time;
+}
 #ifndef _WIN32
 # pragma GCC diagnostic pop
 #endif
-}
-
-//////////////////////////////////////////////////
-void BaseScene::SetSimTime(const common::Time &_time)
-{
-  this->simTime = math::secNsecToDuration(_time.sec, _time.nsec);
-}
 
 //////////////////////////////////////////////////
 VisualPtr BaseScene::VisualAt(const CameraPtr &_camera,

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -118,13 +118,13 @@ std::string BaseScene::Name() const
 }
 
 //////////////////////////////////////////////////
-std::chrono::steady_clock::time_point BaseScene::Time() const
+std::chrono::steady_clock::duration BaseScene::Time() const
 {
   return this->simTime;
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetTime(const std::chrono::steady_clock::time_point &_time)
+void BaseScene::SetTime(const std::chrono::steady_clock::duration &_time)
 {
   this->simTime = _time;
 }
@@ -133,7 +133,7 @@ void BaseScene::SetTime(const std::chrono::steady_clock::time_point &_time)
 common::Time BaseScene::SimTime() const
 {
   std::pair<int64_t, int64_t> secsAndNsecs =
-    math::timePointToSecNsec(this->simTime);
+    math::durationToSecNsec(this->simTime);
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -147,7 +147,7 @@ common::Time BaseScene::SimTime() const
 //////////////////////////////////////////////////
 void BaseScene::SetSimTime(const common::Time &_time)
 {
-  this->simTime = math::secNsecToTimePoint(_time.sec, _time.nsec);
+  this->simTime = math::secNsecToDuration(_time.sec, _time.nsec);
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -169,8 +169,6 @@ void GpuRaysTest::RaysUnitBox(const std::string &_renderEngine)
   const int hRayCount = 320;
   const int vRayCount = 1;
 
-  common::Time waitTime = common::Time(WAIT_TIME);
-
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
@@ -341,8 +339,6 @@ void GpuRaysTest::LaserVertical(const std::string &_renderEngine)
   double maxRange = 5.0;
   unsigned int hRayCount = 640;
   unsigned int vRayCount = 4;
-
-  common::Time waitTime = common::Time(WAIT_TIME);
 
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);


### PR DESCRIPTION
This PR is part of this issue https://github.com/ignitionrobotics/ign-common/issues/61. The idea it's to deprecate the class `common::Time` in favor of `std::chrono`.

Depends on:
 - https://github.com/ignitionrobotics/ign-math/pull/150

Signed-off-by: ahcorde <ahcorde@gmail.com>