### PR TITLE
Backport ogre2 depth camera fix

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -207,8 +207,11 @@ void Ogre2DepthGaussianNoisePass::CreateRenderPass()
   nodeDef->setNumTargetPass(1);
   Ogre::CompositorTargetDef *inputTargetDef =
       nodeDef->addTargetPass("rt_output");
-  inputTargetDef->setNumPasses(1);
+  inputTargetDef->setNumPasses(2);
   {
+    // clear pass
+    inputTargetDef->addPass(Ogre::PASS_CLEAR);
+
     // quad pass
     Ogre::CompositorPassQuadDef *passQuad =
         static_cast<Ogre::CompositorPassQuadDef *>(
@@ -467,11 +470,14 @@ void Ogre2DepthCamera::CreateDepthTexture()
     //   }
     //   target rt0
     //   {
+    //     pass clear
+    //     {
+    //     }
     //     pass render_quad
     //     {
     //       material DepthCamera // Use copy instead of original
-    //       input 0 depthTexture0
-    //       input 1 colorTexture0
+    //       input 0 depthTexture
+    //       input 1 colorTexture
     //       quad_normals camera_far_corners_view_space
     //     }
     //   }
@@ -586,8 +592,15 @@ void Ogre2DepthCamera::CreateDepthTexture()
     // rt0 target - converts depth to xyz
     Ogre::CompositorTargetDef *inTargetDef =
         baseNodeDef->addTargetPass("rt0");
-    inTargetDef->setNumPasses(1);
+    inTargetDef->setNumPasses(2);
     {
+      // clear pass
+      Ogre::CompositorPassClearDef *passClear =
+          static_cast<Ogre::CompositorPassClearDef *>(
+          inTargetDef->addPass(Ogre::PASS_CLEAR));
+      passClear->mColourValue = Ogre::ColourValue(this->FarClipPlane(),
+          this->FarClipPlane(), this->FarClipPlane());
+
       // quad pass
       Ogre::CompositorPassQuadDef *passQuad =
           static_cast<Ogre::CompositorPassQuadDef *>(
@@ -613,6 +626,9 @@ void Ogre2DepthCamera::CreateDepthTexture()
     //
     //   target rt_output
     //   {
+    //     pass clear
+    //     {
+    //     }
     //     pass render_quad
     //     {
     //       material DepthCameraFinal // Use copy instead of original
@@ -636,8 +652,15 @@ void Ogre2DepthCamera::CreateDepthTexture()
     // rt_output target - converts depth to xyz
     Ogre::CompositorTargetDef *outputTargetDef =
         finalNodeDef->addTargetPass("rt_output");
-    outputTargetDef->setNumPasses(1);
+    outputTargetDef->setNumPasses(2);
     {
+      // clear pass
+      Ogre::CompositorPassClearDef *passClear =
+          static_cast<Ogre::CompositorPassClearDef *>(
+          outputTargetDef->addPass(Ogre::PASS_CLEAR));
+      passClear->mColourValue = Ogre::ColourValue(this->FarClipPlane(),
+          this->FarClipPlane(), this->FarClipPlane());
+
       // quad pass
       Ogre::CompositorPassQuadDef *passQuad =
           static_cast<Ogre::CompositorPassQuadDef *>(
@@ -739,7 +762,7 @@ void Ogre2DepthCamera::PostRender()
 
   // blit data from gpu to cpu
   auto rt = this->dataPtr->ogreDepthTexture->getBuffer()->getRenderTarget();
-  rt->copyContentsToMemory(dstBox, Ogre::RenderTarget::FB_FRONT);
+  rt->copyContentsToMemory(dstBox, Ogre::RenderTarget::FB_AUTO);
 
   if (!this->dataPtr->depthImage)
   {


### PR DESCRIPTION
backport changes from pull request #130 to fix #129 

ign-rendering2 does not run ogre2 test on jenkins so there shouldn't be a change in the CI build results. However, ign-sensors2 and ign-gazebo2 both run rendering tests with ogre2, so this change should fix their depth and rgb camera test failures on ubuntu CI builds