### PR TITLE
Add unversioned symlinks for engine plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ if (OGRE2_FOUND)
   set(HAVE_OGRE2 TRUE)
 endif()
 
+# Plugin install dirs
+set(IGNITION_RENDERING_ENGINE_INSTALL_DIR
+  ${CMAKE_INSTALL_PREFIX}/${IGN_LIB_INSTALL_DIR}/ign-${IGN_DESIGNATION}-${PROJECT_VERSION_MAJOR}/engine-plugins
+)
+
 #--------------------------------------
 # Find dependencies that we ignore for Visual Studio
 if(NOT MSVC)

--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -51,10 +51,14 @@ set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name
 set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 if (WIN32)
-  # create_symlink requires cmake 3.13 on windows
-  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+  # disable MSVC inherit via dominance warning
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
+  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned} 
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${unversioned})")
+else()
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 endif()
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 add_subdirectory(media)

--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -2,7 +2,9 @@
 # "gtest_sources" variable.
 ign_get_libsources_and_unittests(sources gtest_sources)
 
-ign_add_component(ogre SOURCES ${sources} GET_TARGET_NAME ogre_target)
+set(engine_name "ogre")
+
+ign_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME ogre_target)
 
 if(OGRE_VERSION VERSION_LESS 1.10.3)
   add_definitions(-DOGRE_VERSION_LT_1_10_3)
@@ -35,6 +37,9 @@ target_link_libraries(${ogre_target}
 # Build the unit tests
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources} LIB_DEPS ${ogre_target})
 
+# Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
+install(TARGETS ${ogre_target} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
+
 if(WIN32)
   # tests needs .dll in the same directory
   add_custom_command(TARGET ${ogre_target} POST_BUILD
@@ -42,5 +47,14 @@ if(WIN32)
     $<TARGET_FILE:${ogre_target}> ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
+set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
+set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+if (WIN32)
+  # create_symlink requires cmake 3.13 on windows
+  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+endif()
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 add_subdirectory(media)

--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -2,7 +2,9 @@
 # "gtest_sources" variable.
 ign_get_libsources_and_unittests(sources gtest_sources)
 
-ign_add_component(ogre2 SOURCES ${sources} GET_TARGET_NAME ogre2_target)
+set(engine_name "ogre2")
+
+ign_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME ogre2_target)
 
 find_package(OpenGL)
 
@@ -21,6 +23,19 @@ target_link_libraries(${ogre2_target}
     ignition-plugin${IGN_PLUGIN_VER}::register
     ${OPENGL_LIBRARIES}
     IgnOGRE2::IgnOGRE2)
+
+set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
+set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+# Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
+install(TARGETS ${ogre2_target} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
+
+if (WIN32)
+  # create_symlink requires cmake 3.13 on windows
+  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+endif()
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 # Build the unit tests
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources} LIB_DEPS ${ogre2_target})

--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -31,11 +31,15 @@ set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-
 install(TARGETS ${ogre2_target} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 if (WIN32)
-  # create_symlink requires cmake 3.13 on windows
-  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+  # disable MSVC inherit via dominance warning
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
+  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned} 
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${unversioned})")
+else()
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 endif()
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 # Build the unit tests
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources} LIB_DEPS ${ogre2_target})

--- a/optix/src/CMakeLists.txt
+++ b/optix/src/CMakeLists.txt
@@ -9,7 +9,9 @@ link_directories(${CUDA_LIBRARY_DIRS})
 include_directories("${PROJECT_SOURCE_DIR}/optix/include")
 include_directories(SYSTEM ${OptiX_INCLUDE_DIRS})
 
-ign_add_component(optix SOURCES ${sources} GET_TARGET_NAME optix_target)
+set(engine_name optix)
+
+ign_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME optix_target)
 
 set(cuda_sources
   OptixBox.cu
@@ -43,6 +45,18 @@ target_link_libraries(${optix_target}
 # Build the unit tests
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources})
 
+# Note that plugins are currently being installed in 2 places: /lib and the engine-plugins dir
+install(TARGETS ${optix_target} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
+
+set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
+set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
+
+if (WIN32)
+  # create_symlink requires cmake 3.13 on windows
+  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+endif()
+EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 if("${CUDA_VERSION}" VERSION_LESS "9")
   set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode arch=compute_20,code=sm_20)

--- a/optix/src/CMakeLists.txt
+++ b/optix/src/CMakeLists.txt
@@ -52,11 +52,15 @@ set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name
 set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 if (WIN32)
-  # create_symlink requires cmake 3.13 on windows
-  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+  # disable MSVC inherit via dominance warning
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
+  INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned} 
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${unversioned})")
+else()
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
+  INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 endif()
-EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})
-INSTALL(FILES ${PROJECT_BINARY_DIR}/${unversioned} DESTINATION ${IGNITION_RENDERING_ENGINE_INSTALL_DIR})
 
 if("${CUDA_VERSION}" VERSION_LESS "9")
   set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-gencode arch=compute_20,code=sm_20)


### PR DESCRIPTION
Another step towards getting full support for custom render engines from command line.  This PR symlinks binaries that don't contain the version number (same as how physics is doing for `dartsim` and `tpe`) so the user will not have to specify the version of ignition-rendering they are currently using when specifying an engine binary name.  More progress towards getting https://github.com/ignitionrobotics/ign-rendering/issues/100 resolved

Signed-off-by: John Shepherd <john@openrobotics.org>