### PR TITLE
Updates to tutorials

### DIFF
--- a/tutorials/11_gazebo_scene_viewer_tutorial.md
+++ b/tutorials/11_gazebo_scene_viewer_tutorial.md
@@ -24,9 +24,10 @@ The following list will describe some methods:
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/gazebo_scene_viewer
 mkdir build
 cd build

--- a/tutorials/12_mesh_viewer_tutorial.md
+++ b/tutorials/12_mesh_viewer_tutorial.md
@@ -2,9 +2,10 @@
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/mesh_viewer
 mkdir build
 cd build

--- a/tutorials/13_custom_scene_viewer.md
+++ b/tutorials/13_custom_scene_viewer.md
@@ -22,9 +22,10 @@ There are some scenes that are not available in Ogre because we have not or we c
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/custom_scene_viewer
 mkdir build
 cd build

--- a/tutorials/14_camera_tracking_tutorial.md
+++ b/tutorials/14_camera_tracking_tutorial.md
@@ -5,9 +5,10 @@ Using the `W` and `S` keys you can move the box forward or backward. Pressing `A
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/camera_tracking
 mkdir build
 cd build
@@ -19,33 +20,38 @@ To run the example:
 
 ```{.sh}
 ./camera_tracking
+```
+
+You'll see:
+
+```{.sh}
 ===============================
-  TAB - Switch render engines  
-  ESC - Exit                   
+  TAB - Switch render engines
+  ESC - Exit
 
-  W: Move box forward          
-  S: Move box backward         
-  A: Rotate box to the left    
-  D: Rotate box to the right   
+  W: Move box forward
+  S: Move box backward
+  A: Rotate box to the left
+  D: Rotate box to the right
 
-  1: Camera tracking only      
-  2: Camera tracking and       
-     following                 
-  3: Camera tracking and       
-     following (world frame)   
+  1: Camera tracking only
+  2: Camera tracking and
+     following
+  3: Camera tracking and
+     following (world frame)
 
-  T: Toggle smooth tracking    
-  F: Toggle smooth following   
+  T: Toggle smooth tracking
+  F: Toggle smooth following
 
-  Track offset                 
-  u/U: +- 0.1 on X             
-  i/I: +- 0.1 on Y             
-  o/O: +- 0.1 on Z             
+  Track offset
+  u/U: +- 0.1 on X
+  i/I: +- 0.1 on Y
+  o/O: +- 0.1 on Z
 
-  Follow offset                
-  j/J: +- 0.1 on X             
-  k/K: +- 0.1 on Y             
-  l/L: +- 0.1 on Z             
+  Follow offset
+  j/J: +- 0.1 on X
+  k/K: +- 0.1 on Y
+  l/L: +- 0.1 on Z
 ===============================
 
 ```

--- a/tutorials/15_custom_shaders_tutorial.md
+++ b/tutorials/15_custom_shaders_tutorial.md
@@ -4,18 +4,24 @@ This example will create two images (RGB and Depth) based on the scene. The scen
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
-cd ign-rendering/examples/camera_tracking
+git clone https://github.com/ignitionrobotics/ign-rendering
+cd ign-rendering/examples/custom_shaders
 mkdir build
 cd build
 cmake ..
 make
 ```
 
+```{.sh}
+./custom_shaders
 ```
-./camera_tracking
+
+You'll see:
+
+```{.sh}
 Image saved: depth.png
 Image saved: regular.png
 ```

--- a/tutorials/17_render_pass_tutorial.md
+++ b/tutorials/17_render_pass_tutorial.md
@@ -4,9 +4,10 @@ This example shows how to add gaussian mode to the camera
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/render_pass
 mkdir build
 cd build
@@ -17,11 +18,16 @@ Execute the example:
 
 ```{.sh}
 ./render_pass
+```
+
+You'll see:
+
+```{.sh}
 [Msg] Loading plugin [ignition-rendering4-ogre]
 Engine 'optix' is not supported
 ===============================
-  TAB - Switch render engines  
-  ESC - Exit                   
+  TAB - Switch render engines
+  ESC - Exit
 ===============================
 ```
 

--- a/tutorials/18_simple_demo_tutorial.md
+++ b/tutorials/18_simple_demo_tutorial.md
@@ -4,9 +4,10 @@ This example shows how move the camera automatically.
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/simple_demo
 mkdir build
 cd build
@@ -17,11 +18,16 @@ Execute the example:
 
 ```{.sh}
 ./simple_demo
+```
+
+You'll see:
+
+```{.sh}
 [Msg] Loading plugin [ignition-rendering4-ogre]
 Engine 'optix' is not supported
 ===============================
-  TAB - Switch render engines  
-  ESC - Exit                   
+  TAB - Switch render engines
+  ESC - Exit
 ===============================
 ```
 

--- a/tutorials/19_text_geom_tutorial.md
+++ b/tutorials/19_text_geom_tutorial.md
@@ -1,12 +1,13 @@
-\page text_geom Text geom
+\page text_geom Text geometry
 
 This example shows how to include text in the scene.
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/text_geom
 mkdir build
 cd build
@@ -17,11 +18,16 @@ Execute the example:
 
 ```{.sh}
 ./text_geom
+```
+
+You'll see:
+
+```{.sh}
 [Msg] Loading plugin [ignition-rendering4-ogre]
 Engine 'optix' is not supported
 ===============================
-  TAB - Switch render engines  
-  ESC - Exit                   
+  TAB - Switch render engines
+  ESC - Exit
 ===============================
 ```
 @image html img/text_geom.png

--- a/tutorials/20_particles_tutorial.md
+++ b/tutorials/20_particles_tutorial.md
@@ -4,9 +4,10 @@ This example shows how to include a particle emitter in the scene.
 
 ## Compile and run the example
 
-Create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
 
 ```{.sh}
+git clone https://github.com/ignitionrobotics/ign-rendering
 cd ign-rendering/examples/particles_demo
 mkdir build
 cd build
@@ -17,6 +18,11 @@ Execute the example:
 
 ```{.sh}
 ./particles_demo
+```
+
+You'll see:
+
+```{.sh}
 [Msg] Loading plugin [ignition-rendering4-ogre2]
 ===============================
   TAB - Switch render engines


### PR DESCRIPTION
* Instruct user to clone this repository: users landing in https://ignitionrobotics.org/api/rendering/4.0/tutorials.html don't know where to start from otherwise
* Split command from command results, so it's clearer to the user what they need to do
* Fix the custom shaders tutorial - it was telling the user to compile the camera tracking

I updated many tutorials, but I only walked through these ones:

* custom shaders
* particles
* text geometry
* render pass

There may be more things to fix on the other ones.