### PR TITLE
Update camera tracking tutorial

### DIFF
--- a/examples/camera_tracking/GlutWindow.cc
+++ b/examples/camera_tracking/GlutWindow.cc
@@ -377,8 +377,13 @@ void keyboardCB(unsigned char _key, int, int)
     }
     else if (_key == '2')
     {
-      cam->SetTrackTarget(node, g_trackOffset);
+      //! [camera track]
+      cam->SetTrackTarget(node, g_trackOffset, false);
+      //! [camera track]
+
+      //! [camera follow]
       cam->SetFollowTarget(node, g_followOffset, false);
+      //! [camera follow]
     }
     else if (_key == '3')
     {

--- a/tutorials/14_camera_tracking_tutorial.md
+++ b/tutorials/14_camera_tracking_tutorial.md
@@ -59,23 +59,12 @@ You'll see:
 
 ## Code
 
-There are two main methods in the `Camera` class that allow us to follow and track the object:
+There are two main functions in the `Camera` class that allow us to track and follow the object:
 
-**SetTrackTarget**: Set a node for camera to track. The camera will automatically change its orientation to face the target being tracked. If null is specified, tracking is disabled. In contrast to `SetFollowTarget` the camera does not change its position when tracking is enabled.
+[SetTrackTarget](https://ignitionrobotics.org/api/rendering/4.0/classignition_1_1rendering_1_1Camera.html#a492d6ad21711d6050ccda1a96676f8fe): Set a node for camera to track. The camera will automatically change its orientation to face the target being tracked. If a null node is specified, tracking is disabled. In contrast to `SetFollowTarget` the camera does not change its position when tracking is enabled.
 
 \snippet examples/camera_tracking/GlutWindow.cc camera track
 
-Parameters:
-    - \_target:	Target node to track
-    - \_offset:	Track a point that is at an offset relative to target
-    - \_worldFrame:	If true, the offset point to track will be treated in world frame and its position relative to the target node remains fixed regardless of the target node's rotation. Default is false, which means the camera tracks the point in target node's local frame.
-
-
-**SetFollowTarget**: Set a node for camera to follow. The camera will automatically update its position to keep itself at the specified offset distance from the target being followed. If null is specified, camera follow is disabled. In contrast to `SetTrackTarget`, the camera does not change its orientation when following is enabled.
+[SetFollowTarget](https://ignitionrobotics.org/api/rendering/4.0/classignition_1_1rendering_1_1Camera.html#ae5dac859964f1c47eba4d46d6d3ef9f9): Set a node for camera to follow. The camera will automatically update its position to keep itself at the specified offset distance from the target being followed. If a null node is specified, camera follow is disabled. In contrast to `SetTrackTarget`, the camera does not change its orientation when following is enabled.
 
 \snippet examples/camera_tracking/GlutWindow.cc camera follow
-
- Parameters:
-  - \_target:	Target node to follow
-  - \_offset:	Tether the camera at an offset distance from the target node
-  - \_worldFrame:	True to follow the target node at a distance that's fixed in world frame. Default is false which means the camera follows at fixed distance in target node's local frame.

--- a/tutorials/14_camera_tracking_tutorial.md
+++ b/tutorials/14_camera_tracking_tutorial.md
@@ -1,7 +1,6 @@
 \page camera_tracking Camera tracking
 
-This example allows you to move a box inside the world.
-Using the `W` and `S` keys you can move the box forward or backward. Pressing `A` or `D` rotates the box. You can also set up how to you want to track the object and fix the offset.
+This example shows a camera tracking a moving target. You can use the keyboard to move the target being tracked, toggle between different tracking modes, and adjust the tracking offsets.
 
 ## Compile and run the example
 
@@ -60,34 +59,22 @@ You'll see:
 
 ## Code
 
-There are three main methods in the `Camera` class that allow us to follow and track the object:
+There are two main methods in the `Camera` class that allow us to follow and track the object:
 
- - **SetTrackTarget**: Set a node for camera to track. The camera will automatically change its orientation to face the target being tracked. If null is specified, tracking is disabled. In contrast to `SetFollowTarget` the camera does not change its position when tracking is enabled.
- ```{.cpp}
- void SetTrackTarget(const NodePtr & 	_target,
-                       const math::Vector3d & 	_offset = math::Vector3d::Zero,
-                       const bool 	_worldFrame = false
- )
- ```
+**SetTrackTarget**: Set a node for camera to track. The camera will automatically change its orientation to face the target being tracked. If null is specified, tracking is disabled. In contrast to `SetFollowTarget` the camera does not change its position when tracking is enabled.
+
+\snippet examples/camera_tracking/GlutWindow.cc camera track
+
 Parameters:
     - \_target:	Target node to track
     - \_offset:	Track a point that is at an offset relative to target
     - \_worldFrame:	If true, the offset point to track will be treated in world frame and its position relative to the target node remains fixed regardless of the target node's rotation. Default is false, which means the camera tracks the point in target node's local frame.
- - **SetWorldPosition**: Set the world pose.
- ```{.cpp}
-void 	SetWorldPose (const math::Pose3d &_pose)
-void 	SetWorldPosition (double _x, double _y, double _z)
-void 	SetWorldPosition (const math::Vector3d &_position)
-void 	SetWorldRotation (double _r, double _p, double _y)
-void 	SetWorldRotation (double _w, double _x, double _y, double _z)
-void 	SetWorldRotation (const math::Quaterniond &_rotation)
- ```
- - **SetFollowTarget**: Set a node for camera to follow. The camera will automatically update its position to keep itself at the specified offset distance from the target being followed. If null is specified, camera follow is disabled. In contrast to `SetTrackTarget`, the camera does not change its orientation when following is enabled.
- ```{.cpp}
- void SetFollowTarget(const NodePtr & 	_target,
-                        const math::Vector3d & 	_offset = math::Vector3d::Zero,
-                        const bool 	_worldFrame = false )
- ```
+
+
+**SetFollowTarget**: Set a node for camera to follow. The camera will automatically update its position to keep itself at the specified offset distance from the target being followed. If null is specified, camera follow is disabled. In contrast to `SetTrackTarget`, the camera does not change its orientation when following is enabled.
+
+\snippet examples/camera_tracking/GlutWindow.cc camera follow
+
  Parameters:
   - \_target:	Target node to follow
   - \_offset:	Tether the camera at an offset distance from the target node


### PR DESCRIPTION
* updated description
* use references to code snippets in example instead of writing out the whole function signature
* removed the `SetWorld*` functions. They are useful but not particularly specific to camera tracking. Maybe it'll suit better in a separate tutorial on node transforms in ign-rendering

Signed-off-by: Ian Chen <ichen@osrfoundation.org>