### PR TITLE
Fix unloading render engines

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -131,6 +131,16 @@ bool RenderEngineManager::HasEngine(const std::string &_name) const
 {
   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->enginesMutex);
   auto iter = this->dataPtr->engines.find(_name);
+
+  if (iter == this->dataPtr->engines.end())
+  {
+    // Check if the provided name is a name of a default engine, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultEngines.find(_name);
+    if (defaultIt != this->dataPtr->defaultEngines.end())
+      iter = this->dataPtr->engines.find(defaultIt->second);
+  }
+
   return iter != this->dataPtr->engines.end();
 }
 
@@ -141,7 +151,19 @@ bool RenderEngineManager::IsEngineLoaded(const std::string &_name) const
   auto iter = this->dataPtr->engines.find(_name);
 
   if (iter == this->dataPtr->engines.end())
-    return false;
+  {
+    // Check if the provided name is a name of a default engine, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultEngines.find(_name);
+    if (defaultIt != this->dataPtr->defaultEngines.end())
+    {
+      iter = this->dataPtr->engines.find(defaultIt->second);
+      if (iter == this->dataPtr->engines.end())
+        return false;
+    }
+    else
+      return false;
+  }
 
   return nullptr != iter->second;
 }
@@ -154,8 +176,22 @@ std::vector<std::string> RenderEngineManager::LoadedEngines() const
   for (auto [name, engine] :  // NOLINT(whitespace/braces)
       this->dataPtr->engines)
   {
+    std::string n = name;
     if (nullptr != engine)
-      engines.push_back(name);
+    {
+      // ign-rendering3 changed loaded engine names to the actual lib name
+      // for backward compatibility, return engine name if it is one of the
+      // default engines
+      for (const auto &it : this->dataPtr->defaultEngines)
+      {
+        if (it.second == name)
+        {
+          n = it.first;
+          break;
+        }
+      }
+      engines.push_back(n);
+    }
   }
   return engines;
 }
@@ -206,8 +242,17 @@ bool RenderEngineManager::UnloadEngine(const std::string &_name)
 
   if (iter == this->dataPtr->engines.end())
   {
-    ignerr << "No render-engine registered with name: " << _name << std::endl;
-    return false;
+    // Check if the provided name is a name of a default engine, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultEngines.find(_name);
+    if (defaultIt != this->dataPtr->defaultEngines.end())
+      iter = this->dataPtr->engines.find(defaultIt->second);
+
+    if (iter == this->dataPtr->engines.end())
+    {
+      ignerr << "No render-engine registered with name: " << _name << std::endl;
+      return false;
+    }
   }
 
   return this->dataPtr->UnloadEngine(iter);
@@ -354,7 +399,7 @@ bool RenderEngineManagerPrivate::UnloadEngine(EngineIter _iter)
 
   engine->Destroy();
 
-  return this->UnloadEnginePlugin(engine->Name());
+  return this->UnloadEnginePlugin(_iter->first);
 }
 
 //////////////////////////////////////////////////

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -179,8 +179,8 @@ std::vector<std::string> RenderEngineManager::LoadedEngines() const
     std::string n = name;
     if (nullptr != engine)
     {
-      // ign-rendering3 changed loaded engine names to the actual lib name
-      // for backward compatibility, return engine name if it is one of the
+      // ign-rendering3 changed loaded engine names to the actual lib name.
+      // For backward compatibility, return engine name if it is one of the
       // default engines
       for (const auto &it : this->dataPtr->defaultEngines)
       {


### PR DESCRIPTION
The tests are still unloading the render engines using the engine name (`ogre2`) as opposed to the library name (`ign-rendering-ogre2`). The changes add an additional logic to translate the engine name to lib name before unloading the engines.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>