### PR TITLE
Updated to work with ign-plugin

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -401,7 +401,12 @@ bool RenderEngineManagerPrivate::LoadEnginePlugin(
     return false;
   }
 
-  std::string pluginName = *pluginNames.begin();
+  std::string pluginName;
+  for (auto plugin: pluginNames) {
+    if (plugin.find("rendering") != std::string::npos) {
+      pluginName = plugin;
+    }
+  }
   if (pluginName.empty())
   {
     ignerr << "Failed to load plugin [" << _filename <<


### PR DESCRIPTION
This PR depends and needs a release from this other PR https://github.com/ignitionrobotics/ign-plugin/pull/30

All the symbols are loaded in the executable because of the `RTLD_GLOBAL`. This logic will filter the symbols

Signed-off-by: ahcorde <ahcorde@gmail.com>