### PR TITLE
⬆️  4.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-rendering4 VERSION 4.0.0)
+project(ignition-rendering4 VERSION 4.1.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,31 @@
 
 ### Ignition Rendering 4.X
 
-### Ignition Rendering 4.X.X
+### Ignition Rendering 4.X.X (20XX-XX-XX)
+
+### Ignition Rendering 4.1.0 (2020-11-04)
+
+1. Improve fork experience
+    * [Pull request #165](https://github.com/ignitionrobotics/ign-rendering/pull/165)
+
+1. Add Custom Render Engine support
+    * [Pull request 161](https://github.com/ignitionrobotics/ign-rendering/pull/161)
+    * [Pull request 154](https://github.com/ignitionrobotics/ign-rendering/pull/154)
+    * [Pull request 142](https://github.com/ignitionrobotics/ign-rendering/pull/142)
+    * [Pull request 141](https://github.com/ignitionrobotics/ign-rendering/pull/141)
+
+1. Update tutorials
+    * [Pull request #159](https://github.com/ignitionrobotics/ign-rendering/pull/159)
+    * [Pull request #153](https://github.com/ignitionrobotics/ign-rendering/pull/153)
+
+1. Limit number of shadow casting lights in ogre2
+    * [Pull Request 155](https://github.com/ignitionrobotics/ign-rendering/pull/155)
+
+1. Ogre2 depth camera fix
+    * [Pull Request 138](https://github.com/ignitionrobotics/ign-rendering/pull/138)
+
+1. Add support for Gaussian noise render pass in Ogre2DepthCamera
+    * [Pull Request 122](https://github.com/ignitionrobotics/ign-rendering/pull/122)
 
 ### Ignition Rendering 4.0.0 (2020-09-29)
 

--- a/Migration.md
+++ b/Migration.md
@@ -6,6 +6,13 @@ notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
 
+## Ignition Rendering 4.0 to 4.1
+
+## ABI break
+
+1. **ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh**
+    + Medium severity ABI break with the addition of the `AddRenderPass` override.
+
 ## Ignition Rendering 3.X to 4.X
 
 ### Deprecations


### PR DESCRIPTION
Needed by https://github.com/ignitionrobotics/ign-gazebo/pull/441


Added a note to the migration guide about the ABI break, see: https://github.com/ignitionrobotics/ign-rendering/pull/122#issuecomment-717560255

Comparison to 4.0.0:

https://github.com/ignitionrobotics/ign-rendering/compare/ignition-rendering4_4.0.0...ign-rendering4