### PR TITLE
👩‍🌾 Make flaky VisualAt test more verbose

### DIFF
--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -227,8 +227,14 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
   camera->SetHFOV(IGN_PI / 2);
   root->AddChild(camera);
 
-  // render a frame
-  camera->Update();
+  // render a few frames
+  for (auto i = 0; i < 30; ++i)
+  {
+    camera->Update();
+  }
+
+  EXPECT_EQ(800u, camera->ImageWidth());
+  EXPECT_EQ(600u, camera->ImageHeight());
 
   for (auto x = 0u; x < camera->ImageWidth(); x = x + 100)
   {
@@ -236,12 +242,16 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
 
     if (x <= 100)
     {
-     EXPECT_EQ(nullptr, vis);
+      EXPECT_EQ(nullptr, vis);
     }
     else if (x > 100 && x <= 300)
     {
-      ASSERT_NE(nullptr, vis);
-      EXPECT_EQ("sphere", vis->Name());
+      // Don't end test here on failure, this condition is flaky
+      EXPECT_NE(nullptr, vis) << x;
+      if (vis)
+      {
+        EXPECT_EQ("sphere", vis->Name());
+      }
     }
     else if (x > 300 && x <= 400)
     {
@@ -249,8 +259,12 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
     }
     else if (x > 400 && x <= 700)
     {
-      ASSERT_NE(nullptr, vis);
-      EXPECT_EQ("box", vis->Name());
+      // Don't end test here on failure, this condition is flaky
+      EXPECT_NE(nullptr, vis) << x;
+      if (vis)
+      {
+        EXPECT_EQ("box", vis->Name());
+      }
     }
     else
     {


### PR DESCRIPTION
This test has been flaky for a while, see history:

https://build.osrfoundation.org/job/ignition_rendering-ci-ign-rendering3-bionic-amd64/lastBuild/testReport/(root)/Camera_CameraTest/VisualAt_ogre2/history/

I can't reproduce the failure locally even running the test hundreds of times. So in this PR, I'm changing some conditions so the next time the test flakes, we should at least have more information about how it fails.