### PR TITLE
Add support for lightmaps in ogre2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-common
-ign_find_package(ignition-common3 REQUIRED COMPONENTS graphics events)
+ign_find_package(ignition-common3 REQUIRED
+  COMPONENTS graphics events
+  VERSION 3.9)
 set(IGN_COMMON_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------

--- a/include/ignition/rendering/Material.hh
+++ b/include/ignition/rendering/Material.hh
@@ -301,6 +301,23 @@ namespace ignition
       /// \brief Removes any emissive map mapped to this material
       public: virtual void ClearEmissiveMap() = 0;
 
+      /// \brief Determine if this material has a light map
+      /// \return True if this material has a light map
+      public: virtual bool HasLightMap() const = 0;
+
+      /// \brief Get the URI of the light map file
+      /// \return URI of the light map file
+      public: virtual std::string LightMap() const = 0;
+
+      /// \brief Set the material light map
+      /// \param[in] _name URI of the new light map file
+      /// \param[in] _uvSet Texture coordinate set to use
+      public: virtual void SetLightMap(const std::string &_name,
+          unsigned int _uvSet = 0u) = 0;
+
+      /// \brief Removes any light map mapped to this material
+      public: virtual void ClearLightMap() = 0;
+
       /// \brief Set the roughness value. Only affects material of type MT_PBS
       /// \param[in] _roughness Roughness to set to
       public: virtual void SetRoughness(const float _roughness) = 0;

--- a/include/ignition/rendering/Material.hh
+++ b/include/ignition/rendering/Material.hh
@@ -309,6 +309,10 @@ namespace ignition
       /// \return URI of the light map file
       public: virtual std::string LightMap() const = 0;
 
+      /// \brief Get the texture coordinate set used by lightmap
+      /// \return texture coordinate set of the light map
+      public: virtual unsigned int LightMapTexCoordSet() const = 0;
+
       /// \brief Set the material light map
       /// \param[in] _name URI of the new light map file
       /// \param[in] _uvSet Texture coordinate set to use

--- a/include/ignition/rendering/base/BaseMaterial.hh
+++ b/include/ignition/rendering/base/BaseMaterial.hh
@@ -239,6 +239,9 @@ namespace ignition
       public: virtual std::string LightMap() const override;
 
       // Documentation inherited
+      public: virtual unsigned int LightMapTexCoordSet() const override;
+
+      // Documentation inherited
       public: virtual void SetLightMap(const std::string &_lightMap,
           unsigned int uvSet = 0u) override;
 
@@ -850,6 +853,13 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
+    unsigned int BaseMaterial<T>::LightMapTexCoordSet() const
+    {
+      return 0u;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
     void BaseMaterial<T>::SetLightMap(const std::string &, unsigned int)
     {
       // no op
@@ -932,7 +942,8 @@ namespace ignition
       this->SetMetalness(_material->Metalness());
       this->SetEnvironmentMap(_material->EnvironmentMap());
       this->SetEmissiveMap(_material->EmissiveMap());
-      this->SetLightMap(_material->LightMap());
+      this->SetLightMap(_material->LightMap(),
+          _material->LightMapTexCoordSet());
       this->SetShaderType(_material->ShaderType());
       this->SetVertexShader(_material->VertexShader());
       this->SetFragmentShader(_material->FragmentShader());
@@ -975,7 +986,7 @@ namespace ignition
       this->SetMetalness(pbrMat->Metalness());
       this->SetEnvironmentMap(pbrMat->EnvironmentMap());
       this->SetEmissiveMap(pbrMat->EmissiveMap());
-      this->SetLightMap(pbrMat->LightMap());
+      this->SetLightMap(pbrMat->LightMap(), pbrMat->LightMapTexCoordSet());
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseMaterial.hh
+++ b/include/ignition/rendering/base/BaseMaterial.hh
@@ -233,6 +233,19 @@ namespace ignition
       public: virtual void ClearEmissiveMap() override;
 
       // Documentation inherited
+      public: virtual bool HasLightMap() const override;
+
+      // Documentation inherited
+      public: virtual std::string LightMap() const override;
+
+      // Documentation inherited
+      public: virtual void SetLightMap(const std::string &_lightMap,
+          unsigned int uvSet = 0u) override;
+
+      // Documentation inherited
+      public: virtual void ClearLightMap() override;
+
+      // Documentation inherited
       public: virtual void SetRoughness(const float _roughness) override;
 
       // Documentation inherited
@@ -823,6 +836,34 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
+    bool BaseMaterial<T>::HasLightMap() const
+    {
+      return false;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    std::string BaseMaterial<T>::LightMap() const
+    {
+      return std::string();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseMaterial<T>::SetLightMap(const std::string &, unsigned int)
+    {
+      // no op
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseMaterial<T>::ClearLightMap()
+    {
+      // no op
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
     void BaseMaterial<T>::SetRoughness(const float)
     {
       // no op
@@ -891,6 +932,7 @@ namespace ignition
       this->SetMetalness(_material->Metalness());
       this->SetEnvironmentMap(_material->EnvironmentMap());
       this->SetEmissiveMap(_material->EmissiveMap());
+      this->SetLightMap(_material->LightMap());
       this->SetShaderType(_material->ShaderType());
       this->SetVertexShader(_material->VertexShader());
       this->SetFragmentShader(_material->FragmentShader());
@@ -933,6 +975,7 @@ namespace ignition
       this->SetMetalness(pbrMat->Metalness());
       this->SetEnvironmentMap(pbrMat->EnvironmentMap());
       this->SetEmissiveMap(pbrMat->EmissiveMap());
+      this->SetLightMap(pbrMat->LightMap());
     }
 
     //////////////////////////////////////////////////

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
@@ -160,6 +160,9 @@ namespace ignition
       public: virtual std::string LightMap() const override;
 
       // Documentation inherited
+      public: virtual unsigned int LightMapTexCoordSet() const override;
+
+      // Documentation inherited
       public: virtual void SetLightMap(const std::string &_name,
           unsigned int _uvSet = 0u) override;
 
@@ -262,6 +265,9 @@ namespace ignition
 
       /// \brief Name of the light map
       protected: std::string lightMapName;
+
+      /// \brief Texture coorindate set used by the light map
+      protected: unsigned int lightMapUvSet = 0u;
 
       /// \brief Unique id assigned to ogre hlms datablock
       protected: std::string ogreDatablockId;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
@@ -154,6 +154,19 @@ namespace ignition
       public: virtual void ClearEmissiveMap() override;
 
       // Documentation inherited
+      public: virtual bool HasLightMap() const override;
+
+      // Documentation inherited
+      public: virtual std::string LightMap() const override;
+
+      // Documentation inherited
+      public: virtual void SetLightMap(const std::string &_name,
+          unsigned int _uvSet = 0u) override;
+
+      // Documentation inherited
+      public: virtual void ClearLightMap() override;
+
+      // Documentation inherited
       public: virtual float Roughness() const override;
 
       // Documentation inherited
@@ -246,6 +259,9 @@ namespace ignition
 
       /// \brief Name of the emissive map
       protected: std::string emissiveMapName;
+
+      /// \brief Name of the light map
+      protected: std::string lightMapName;
 
       /// \brief Unique id assigned to ogre hlms datablock
       protected: std::string ogreDatablockId;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ParticleEmitter.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ParticleEmitter.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2PARTICLEEMITTER_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2PARTICLEEMITTER_HH_
 
+#include <memory>
 #include <string>
 #include "ignition/rendering/base/BaseParticleEmitter.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -372,6 +372,48 @@ void Ogre2Material::ClearEmissiveMap()
 }
 
 //////////////////////////////////////////////////
+bool Ogre2Material::HasLightMap() const
+{
+  return !this->lightMapName.empty();
+}
+
+//////////////////////////////////////////////////
+std::string Ogre2Material::LightMap() const
+{
+  return this->lightMapName;
+}
+
+//////////////////////////////////////////////////
+void Ogre2Material::SetLightMap(const std::string &_name, unsigned int _uvSet)
+{
+  if (_name.empty())
+  {
+    this->ClearLightMap();
+    return;
+  }
+
+  this->lightMapName = _name;
+
+  // reserve detail map 3 for light map
+  Ogre::PbsTextureTypes type = Ogre::PBSM_DETAIL0;
+
+  // lightmap usually uses a different tex coord set
+  this->SetTextureMapImpl(this->lightMapName, type);
+
+  this->ogreDatablock->setTextureUvSource(type, _uvSet);
+
+  // PBSM_BLEND_OVERLAY and PBSM_BLEND_MULTIPLY2X produces better results
+  this->ogreDatablock->setDetailMapBlendMode(0, Ogre::PBSM_BLEND_OVERLAY);
+}
+
+//////////////////////////////////////////////////
+void Ogre2Material::ClearLightMap()
+{
+  this->lightMapName = "";
+  this->ogreDatablock->setTexture(Ogre::PBSM_DETAIL0, 0, Ogre::TexturePtr());
+}
+
+//////////////////////////////////////////////////
 void Ogre2Material::SetRoughness(const float _roughness)
 {
   this->ogreDatablock->setRoughness(_roughness);

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -151,17 +151,17 @@ void Ogre2Material::SetAlphaFromTexture(bool _enabled,
     double _alpha, bool _twoSided)
 {
   BaseMaterial::SetAlphaFromTexture(_enabled, _alpha, _twoSided);
+  Ogre::HlmsBlendblock block;
   if (_enabled)
   {
-    Ogre::HlmsBlendblock block;
     block.setBlendType(Ogre::SBT_TRANSPARENT_ALPHA);
     this->ogreDatablock->setAlphaTest(Ogre::CMPF_GREATER_EQUAL);
     this->ogreDatablock->setBlendblock(block);
-    this->ogreDatablock->setTwoSidedLighting(_twoSided);
   }
   else
   {
     this->ogreDatablock->setAlphaTest(Ogre::CMPF_ALWAYS_PASS);
+    this->ogreDatablock->setBlendblock(block);
   }
   this->ogreDatablock->setAlphaTestThreshold(_alpha);
   this->ogreDatablock->setTwoSidedLighting(_twoSided);
@@ -384,6 +384,12 @@ std::string Ogre2Material::LightMap() const
 }
 
 //////////////////////////////////////////////////
+unsigned int Ogre2Material::LightMapTexCoordSet() const
+{
+  return this->lightMapUvSet;
+}
+
+//////////////////////////////////////////////////
 void Ogre2Material::SetLightMap(const std::string &_name, unsigned int _uvSet)
 {
   if (_name.empty())
@@ -393,14 +399,15 @@ void Ogre2Material::SetLightMap(const std::string &_name, unsigned int _uvSet)
   }
 
   this->lightMapName = _name;
+  this->lightMapUvSet = _uvSet;
 
-  // reserve detail map 3 for light map
+  // reserve detail map 0 for light map
   Ogre::PbsTextureTypes type = Ogre::PBSM_DETAIL0;
 
   // lightmap usually uses a different tex coord set
   this->SetTextureMapImpl(this->lightMapName, type);
 
-  this->ogreDatablock->setTextureUvSource(type, _uvSet);
+  this->ogreDatablock->setTextureUvSource(type, this->lightMapUvSet);
 
   // PBSM_BLEND_OVERLAY and PBSM_BLEND_MULTIPLY2X produces better results
   this->ogreDatablock->setDetailMapBlendMode(0, Ogre::PBSM_BLEND_OVERLAY);
@@ -410,6 +417,7 @@ void Ogre2Material::SetLightMap(const std::string &_name, unsigned int _uvSet)
 void Ogre2Material::ClearLightMap()
 {
   this->lightMapName = "";
+  this->lightMapUvSet = 0u;
   this->ogreDatablock->setTexture(Ogre::PBSM_DETAIL0, 0, Ogre::TexturePtr());
 }
 
@@ -497,6 +505,17 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
 
   this->ogreDatablock->setTexture(_type, texLocation.xIdx, texLocation.texture,
       &samplerBlockRef);
+
+  // disable alpha from texture if texture does not have an alpha channel
+  // otherwise this becomes a transparent material
+  if (_type == Ogre::PBSM_DIFFUSE)
+  {
+    if (this->TextureAlphaEnabled() && !texLocation.texture->hasAlpha())
+    {
+      this->SetAlphaFromTexture(false, this->AlphaThreshold(),
+          this->TwoSidedEnabled());
+    }
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -333,11 +333,15 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
       // TODO(anyone): specular colors
 
       // two dimensional texture coordinates
-      if (subMesh.TexCoordCount() > 0)
+      // add all texture coordinate sets
+      for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
       {
-        vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
-            Ogre::VES_TEXTURE_COORDINATES, 0);
-        currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+        if (subMesh.TexCoordCountBySet(k) > 0)
+        {
+          vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
+              Ogre::VES_TEXTURE_COORDINATES, k);
+          currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+        }
       }
 
       // allocate the vertex buffer
@@ -375,6 +379,7 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
         *vertices++ = subMesh.Vertex(j).Y();
         *vertices++ = subMesh.Vertex(j).Z();
 
+        // Add all normals
         if (subMesh.NormalCount() > 0)
         {
           *vertices++ = subMesh.Normal(j).X();
@@ -382,10 +387,14 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
           *vertices++ = subMesh.Normal(j).Z();
         }
 
-        if (subMesh.TexCoordCount() > 0)
+        // Add all texture coordinate sets
+        for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
         {
-          *vertices++ = subMesh.TexCoord(j).X();
-          *vertices++ = subMesh.TexCoord(j).Y();
+          if (subMesh.TexCoordCountBySet(k) > 0u)
+          {
+            *vertices++ = subMesh.TexCoordBySet(j, k).X();
+            *vertices++ = subMesh.TexCoordBySet(j, k).Y();
+          }
         }
       }
 

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -429,9 +429,35 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(1u, copy->LightMapTexCoordSet());
   }
 
+  // test copying from a common material
+  // common::Material currently only has a subset of material properties
+  common::Material comMat;
+  comMat.SetAmbient(ambient);
+  comMat.SetDiffuse(diffuse);
+  comMat.SetSpecular(specular);
+  comMat.SetEmissive(emissive);
+  comMat.SetShininess(shininess);
+  comMat.SetTransparency(transparency);
+  comMat.SetAlphaFromTexture(alphaFromTexture, alphaThreshold,
+      twoSidedEnabled);
+  comMat.SetLighting(lightingEnabled);
+  comMat.SetTextureImage(textureName);
+  common::Pbr pbr;
+  pbr.SetType(common::PbrType::METAL);
+  pbr.SetRoughness(roughness);
+  pbr.SetMetalness(metalness);
+  pbr.SetAlbedoMap(textureName);
+  pbr.SetNormalMap(normalMapName);
+  pbr.SetRoughnessMap(roughnessMapName);
+  pbr.SetMetalnessMap(metalnessMapName);
+  pbr.SetEmissiveMap(emissiveMapName);
+  pbr.SetEnvironmentMap(envMapName);
+  pbr.SetLightMap(lightMapName, 1u);
+  comMat.SetPbrMaterial(pbr);
+
   MaterialPtr comCopy = scene->CreateMaterial("comCopy");
   EXPECT_TRUE(scene->MaterialRegistered("comCopy"));
-  comCopy->CopyFrom(material);
+  comCopy->CopyFrom(comMat);
   EXPECT_EQ(ambient, comCopy->Ambient());
   EXPECT_EQ(diffuse, comCopy->Diffuse());
   EXPECT_EQ(specular, comCopy->Specular());
@@ -441,7 +467,8 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   EXPECT_EQ(alphaFromTexture, comCopy->TextureAlphaEnabled());
   EXPECT_DOUBLE_EQ(alphaThreshold, comCopy->AlphaThreshold());
   EXPECT_EQ(twoSidedEnabled, comCopy->TwoSidedEnabled());
-  EXPECT_DOUBLE_EQ(reflectivity, comCopy->Reflectivity());
+  // \todo(anyon) add reflectivity to common::Material?
+  // EXPECT_DOUBLE_EQ(reflectivity, comCopy->Reflectivity());
   EXPECT_EQ(lightingEnabled, comCopy->LightingEnabled());
   EXPECT_EQ(textureName, comCopy->Texture());
   EXPECT_TRUE(comCopy->HasTexture());

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -36,6 +36,12 @@ using namespace rendering;
 class MaterialTest : public testing::Test,
                      public testing::WithParamInterface<const char *>
 {
+  // Documentation inherited
+  public: void SetUp() override
+  {
+    ignition::common::Console::SetVerbosity(4);
+  }
+
   /// \brief Test material basic API
   public: void MaterialProperties(const std::string &_renderEngine);
 
@@ -423,32 +429,6 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(1u, copy->LightMapTexCoordSet());
   }
 
-  // test copying from a common material
-  // common::Material currently only has a subset of material properties
-  common::Material comMat;
-  comMat.SetAmbient(ambient);
-  comMat.SetDiffuse(ambient);
-  comMat.SetSpecular(ambient);
-  comMat.SetEmissive(ambient);
-  comMat.SetShininess(shininess);
-  comMat.SetTransparency(transparency);
-  comMat.SetAlphaFromTexture(alphaFromTexture, alphaThreshold,
-      twoSidedEnabled);
-  comMat.SetLighting(lightingEnabled);
-  comMat.SetTextureImage(textureName);
-  common::Pbr pbr;
-  pbr.SetType(common::PbrType::METAL);
-  pbr.SetRoughness(roughness);
-  pbr.SetMetalness(metalness);
-  pbr.SetAlbedoMap(textureName);
-  pbr.SetNormalMap(normalMapName);
-  pbr.SetRoughnessMap(roughnessMapName);
-  pbr.SetMetalnessMap(metalnessMapName);
-  pbr.SetEmissiveMap(emissiveMapName);
-  pbr.SetLightMap(lightMapName, 2u);
-  pbr.SetEnvironmentMap(envMapName);
-  comMat.SetPbrMaterial(pbr);
-
   MaterialPtr comCopy = scene->CreateMaterial("comCopy");
   EXPECT_TRUE(scene->MaterialRegistered("comCopy"));
   comCopy->CopyFrom(material);
@@ -479,7 +459,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(emissiveMapName, comCopy->EmissiveMap());
     EXPECT_TRUE(comCopy->HasLightMap());
     EXPECT_EQ(lightMapName, comCopy->LightMap());
-    EXPECT_EQ(2u, comCopy->LightMapTexCoordSet());
+    EXPECT_EQ(1u, comCopy->LightMapTexCoordSet());
     EXPECT_TRUE(comCopy->HasEnvironmentMap());
     EXPECT_EQ(envMapName, comCopy->EnvironmentMap());
   }

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -245,6 +245,20 @@ void MaterialTest::MaterialProperties(const std::string &_renderEngine)
     EXPECT_EQ(noSuchEmissiveMapName, material->EmissiveMap());
     EXPECT_TRUE(material->HasEmissiveMap());
 
+    // light map
+    std::string lightMapName = textureName;
+    material->SetLightMap(lightMapName);
+    EXPECT_EQ(lightMapName, material->LightMap());
+    EXPECT_TRUE(material->HasLightMap());
+
+    material->ClearLightMap();
+    EXPECT_FALSE(material->HasLightMap());
+
+    std::string noSuchLightMapName = "no_such_light.png";
+    material->SetLightMap(noSuchLightMapName);
+    EXPECT_EQ(noSuchLightMapName, material->LightMap());
+    EXPECT_TRUE(material->HasLightMap());
+
     // roughness
     float roughness = 0.3;
     material->SetRoughness(roughness);
@@ -308,6 +322,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   std::string metalnessMapName = "metalness_" + textureName;
   std::string envMapName = "env_" + textureName;
   std::string emissiveMapName = "emissive_" + textureName;
+  std::string lightMapName = "light_" + textureName;
   enum ShaderType shaderType = ShaderType::ST_PIXEL;
 
   material->SetAmbient(ambient);
@@ -332,6 +347,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   material->SetMetalnessMap(metalnessMapName);
   material->SetEnvironmentMap(envMapName);
   material->SetEmissiveMap(emissiveMapName);
+  material->SetLightMap(lightMapName);
   material->SetRoughness(roughness);
   material->SetMetalness(metalness);
 
@@ -367,6 +383,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(metalnessMapName, clone->MetalnessMap());
     EXPECT_EQ(envMapName, clone->EnvironmentMap());
     EXPECT_EQ(emissiveMapName, clone->EmissiveMap());
+    EXPECT_EQ(lightMapName, clone->LightMap());
   }
 
   // test copying a material
@@ -400,6 +417,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(metalnessMapName, copy->MetalnessMap());
     EXPECT_EQ(envMapName, copy->EnvironmentMap());
     EXPECT_EQ(emissiveMapName, copy->EmissiveMap());
+    EXPECT_EQ(lightMapName, copy->LightMap());
   }
 
   // test copying from a common material
@@ -424,6 +442,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   pbr.SetRoughnessMap(roughnessMapName);
   pbr.SetMetalnessMap(metalnessMapName);
   pbr.SetEmissiveMap(emissiveMapName);
+  pbr.SetLightMap(lightMapName);
   pbr.SetEnvironmentMap(envMapName);
   comMat.SetPbrMaterial(pbr);
 
@@ -455,6 +474,8 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(metalnessMapName, comCopy->MetalnessMap());
     EXPECT_TRUE(comCopy->HasEmissiveMap());
     EXPECT_EQ(emissiveMapName, comCopy->EmissiveMap());
+    EXPECT_TRUE(comCopy->HasLightMap());
+    EXPECT_EQ(lightMapName, comCopy->LightMap());
     EXPECT_TRUE(comCopy->HasEnvironmentMap());
     EXPECT_EQ(envMapName, comCopy->EnvironmentMap());
   }

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -247,8 +247,9 @@ void MaterialTest::MaterialProperties(const std::string &_renderEngine)
 
     // light map
     std::string lightMapName = textureName;
-    material->SetLightMap(lightMapName);
+    material->SetLightMap(lightMapName, 1u);
     EXPECT_EQ(lightMapName, material->LightMap());
+    EXPECT_EQ(1u, material->LightMapTexCoordSet());
     EXPECT_TRUE(material->HasLightMap());
 
     material->ClearLightMap();
@@ -347,7 +348,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   material->SetMetalnessMap(metalnessMapName);
   material->SetEnvironmentMap(envMapName);
   material->SetEmissiveMap(emissiveMapName);
-  material->SetLightMap(lightMapName);
+  material->SetLightMap(lightMapName, 1u);
   material->SetRoughness(roughness);
   material->SetMetalness(metalness);
 
@@ -384,6 +385,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(envMapName, clone->EnvironmentMap());
     EXPECT_EQ(emissiveMapName, clone->EmissiveMap());
     EXPECT_EQ(lightMapName, clone->LightMap());
+    EXPECT_EQ(1u, clone->LightMapTexCoordSet());
   }
 
   // test copying a material
@@ -418,6 +420,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(envMapName, copy->EnvironmentMap());
     EXPECT_EQ(emissiveMapName, copy->EmissiveMap());
     EXPECT_EQ(lightMapName, copy->LightMap());
+    EXPECT_EQ(1u, copy->LightMapTexCoordSet());
   }
 
   // test copying from a common material
@@ -442,7 +445,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   pbr.SetRoughnessMap(roughnessMapName);
   pbr.SetMetalnessMap(metalnessMapName);
   pbr.SetEmissiveMap(emissiveMapName);
-  pbr.SetLightMap(lightMapName);
+  pbr.SetLightMap(lightMapName, 2u);
   pbr.SetEnvironmentMap(envMapName);
   comMat.SetPbrMaterial(pbr);
 
@@ -476,6 +479,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
     EXPECT_EQ(emissiveMapName, comCopy->EmissiveMap());
     EXPECT_TRUE(comCopy->HasLightMap());
     EXPECT_EQ(lightMapName, comCopy->LightMap());
+    EXPECT_EQ(2u, comCopy->LightMapTexCoordSet());
     EXPECT_TRUE(comCopy->HasEnvironmentMap());
     EXPECT_EQ(envMapName, comCopy->EnvironmentMap());
   }


### PR DESCRIPTION
depends on ignitionrobotics/ign-common#132

main changes:
* updated mesh factory to create mesh with multiple texture coordinate sets
* added lightmap APIs to Material - users can choose which texture coordinate set to use for the lightmap
* To keep things simple, lightmap is currently blended with the base albedo map using the Overlay bend mode (here's a [description](https://helpx.adobe.com/photoshop/using/blending-modes.html) of the different blend modes).
* fixed a transparency issue that happens when a grayscale albedo map is used.
