### PR TITLE
Remove some windows warnings

### DIFF
--- a/include/ignition/rendering/MeshDescriptor.hh
+++ b/include/ignition/rendering/MeshDescriptor.hh
@@ -65,12 +65,16 @@ namespace ignition
       public: const common::Mesh *mesh = nullptr;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Name of the registered Mesh
       public: std::string meshName;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief Name of the sub-mesh to be loaded. An empty string signifies
       /// all sub-meshes should be loaded.
       public: std::string subMeshName;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Denotes if the loaded sub-mesh vertices should be centered
       public: bool centerSubMesh = false;


### PR DESCRIPTION
This PR is related with this other PR https://github.com/ignitionrobotics/ign-sensors/pull/58

There are some Windows warning comming from this package. https://build.osrfoundation.org/job/ign_sensors-pr-win/508/msbuild/new/

Signed-off-by: ahcorde <ahcorde@gmail.com>