### PR TITLE
Fix transparency issue for textures without alpha channel

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ParticleEmitter.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ParticleEmitter.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2PARTICLEEMITTER_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2PARTICLEEMITTER_HH_
 
+#include <memory>
 #include <string>
 #include "ignition/rendering/base/BaseParticleEmitter.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -151,17 +151,17 @@ void Ogre2Material::SetAlphaFromTexture(bool _enabled,
     double _alpha, bool _twoSided)
 {
   BaseMaterial::SetAlphaFromTexture(_enabled, _alpha, _twoSided);
+  Ogre::HlmsBlendblock block;
   if (_enabled)
   {
-    Ogre::HlmsBlendblock block;
-    block.setBlendType(Ogre::SBT_TRANSPARENT_ALPHA);
     this->ogreDatablock->setAlphaTest(Ogre::CMPF_GREATER_EQUAL);
+    block.setBlendType(Ogre::SBT_TRANSPARENT_ALPHA);
     this->ogreDatablock->setBlendblock(block);
-    this->ogreDatablock->setTwoSidedLighting(_twoSided);
   }
   else
   {
     this->ogreDatablock->setAlphaTest(Ogre::CMPF_ALWAYS_PASS);
+    this->ogreDatablock->setBlendblock(block);
   }
   this->ogreDatablock->setAlphaTestThreshold(_alpha);
   this->ogreDatablock->setTwoSidedLighting(_twoSided);
@@ -455,6 +455,17 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
 
   this->ogreDatablock->setTexture(_type, texLocation.xIdx, texLocation.texture,
       &samplerBlockRef);
+
+  // disable alpha from texture if texture does not have an alpha channel
+  // otherwise this becomes a transparent material
+  if (_type == Ogre::PBSM_DIFFUSE)
+  {
+    if (this->TextureAlphaEnabled() && !texLocation.texture->hasAlpha())
+    {
+      this->SetAlphaFromTexture(false, this->AlphaThreshold(),
+          this->TwoSidedEnabled());
+    }
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
When `SetAlphaFromTexture(true)` is invoked on a material with texture that does not have an alpha channel, it causes the visual with the assigned material to be completely transparent. The fix is to do a check to make sure the texture does have an alpha channel, and if not we disable using alpha from the texture.

These changes were included in pull request #182 for ign-rendering5, which are necessary for displaying the `Indoor Lighting` model. 

Another test: launch ign-gazebo and insert the [DronePlatformX1](https://app.ignitionrobotics.org/OpenRobotics/fuel/models/DronePlatformX1) model. Without these changes, the model is transparent.