### PR TITLE
👩‍🌾 Clear all Windows warnings

### DIFF
--- a/examples/actor_animation/GlutWindow.cc
+++ b/examples/actor_animation/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/camera_tracking/GlutWindow.cc
+++ b/examples/camera_tracking/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/custom_scene_viewer/DemoWindow.cc
+++ b/examples/custom_scene_viewer/DemoWindow.cc
@@ -18,13 +18,13 @@
 #if defined(__APPLE__)
   #include <OpenGL/gl.h>
   #include <GLUT/glut.h>
-#elif not defined(_WIN32)
+#elif !defined(_WIN32)
   #include <GL/glew.h>
   #include <GL/gl.h>
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/gazebo_scene_viewer/CameraWindow.cc
+++ b/examples/gazebo_scene_viewer/CameraWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/mesh_viewer/GlutWindow.cc
+++ b/examples/mesh_viewer/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/mouse_picking/GlutWindow.cc
+++ b/examples/mouse_picking/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/ogre2_demo/GlutWindow.cc
+++ b/examples/ogre2_demo/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/render_pass/GlutWindow.cc
+++ b/examples/render_pass/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/simple_demo/GlutWindow.cc
+++ b/examples/simple_demo/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/text_geom/GlutWindow.cc
+++ b/examples/text_geom/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/thermal_camera/GlutWindow.cc
+++ b/examples/thermal_camera/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/transform_control/GlutWindow.cc
+++ b/examples/transform_control/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/examples/view_control/GlutWindow.cc
+++ b/examples/view_control/GlutWindow.cc
@@ -25,7 +25,7 @@
   #include <GL/glut.h>
 #endif
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   #include <GL/glx.h>
 #endif
 

--- a/include/ignition/rendering/MeshDescriptor.hh
+++ b/include/ignition/rendering/MeshDescriptor.hh
@@ -63,7 +63,6 @@ namespace ignition
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief common::Mesh object
       public: const common::Mesh *mesh = nullptr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Name of the registered Mesh
       public: std::string meshName;
@@ -71,6 +70,7 @@ namespace ignition
       /// \brief Name of the sub-mesh to be loaded. An empty string signifies
       /// all sub-meshes should be loaded.
       public: std::string subMeshName;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Denotes if the loaded sub-mesh vertices should be centered
       public: bool centerSubMesh = false;

--- a/include/ignition/rendering/RayQuery.hh
+++ b/include/ignition/rendering/RayQuery.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_RAYQUERY_HH_
 #define IGNITION_RENDERING_RAYQUERY_HH_
 
+#include <ignition/common/SuppressWarning.hh>
 #include <ignition/math/Vector3.hh>
 
 #include "ignition/rendering/config.hh"
@@ -37,7 +38,9 @@ namespace ignition
       public: double distance = -1;
 
       /// \brief Intersection point in 3d space
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public: math::Vector3d point;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Intersected object id
       public: unsigned int objectId = 0;

--- a/include/ignition/rendering/RenderEnginePlugin.hh
+++ b/include/ignition/rendering/RenderEnginePlugin.hh
@@ -21,6 +21,8 @@
 #include <memory>
 #include <string>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Export.hh"
 
@@ -52,7 +54,9 @@ namespace ignition
       public: virtual RenderEngine *Engine() const = 0;
 
       /// \brief Pointer to private data class
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public: std::unique_ptr<RenderEnginePluginPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/rendering/RenderPassSystem.hh
+++ b/include/ignition/rendering/RenderPassSystem.hh
@@ -22,6 +22,8 @@
 #include <string>
 #include <typeinfo>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Export.hh"
 #include "ignition/rendering/RenderPass.hh"
@@ -78,11 +80,13 @@ namespace ignition
       private: RenderPassPtr CreateImpl(const std::string &_type);
 
       /// \brief A map of render pass type id name to its factory class
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: static std::map<std::string, RenderPassFactory *> renderPassMap;
 
       /// \internal
       /// \brief Pointer to private data class
       private: std::unique_ptr<RenderPassSystemPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
 
     /// \brief Render pass registration macro

--- a/include/ignition/rendering/ShaderParam.hh
+++ b/include/ignition/rendering/ShaderParam.hh
@@ -21,6 +21,8 @@
 #include <cstdint>
 #include <memory>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Export.hh"
 
@@ -86,7 +88,9 @@ namespace ignition
       public: bool Value(int *_value) const;
 
       /// \brief private implementation
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: std::unique_ptr<ShaderParamPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/rendering/TransformController.hh
+++ b/include/ignition/rendering/TransformController.hh
@@ -19,6 +19,8 @@
 
 #include <memory>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Plane.hh>
 #include <ignition/math/Vector3.hh>
@@ -210,7 +212,9 @@ namespace ignition
           const math::Planed &_plane, math::Vector3d &_result);
 
       /// \brief Private data pointer
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public: std::unique_ptr<TransformControllerPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -24,6 +24,7 @@
 
 #include <ignition/common/Event.hh>
 #include <ignition/common/Console.hh>
+#include <ignition/common/SuppressWarning.hh>
 
 #include "ignition/rendering/Camera.hh"
 #include "ignition/rendering/Image.hh"
@@ -185,6 +186,7 @@ namespace ignition
 
       protected: virtual RenderTargetPtr RenderTarget() const = 0;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: common::EventT<void(const void *, unsigned int, unsigned int,
                      unsigned int, const std::string &)> newFrameEvent;
 
@@ -221,6 +223,7 @@ namespace ignition
 
       /// \brief Target node to follow
       protected: NodePtr followNode;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Follow target in world frame.
       protected: bool followWorldFrame = false;

--- a/include/ignition/rendering/base/BaseDepthCamera.hh
+++ b/include/ignition/rendering/base/BaseDepthCamera.hh
@@ -30,7 +30,7 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     template <class T>
-    class IGNITION_RENDERING_VISIBLE BaseDepthCamera :
+    class BaseDepthCamera :
       public virtual DepthCamera,
       public virtual BaseCamera<T>,
       public virtual T

--- a/include/ignition/rendering/base/BaseGizmoVisual.hh
+++ b/include/ignition/rendering/base/BaseGizmoVisual.hh
@@ -21,6 +21,7 @@
 #include <map>
 #include <string>
 #include <ignition/common/MeshManager.hh>
+#include <ignition/common/SuppressWarning.hh>
 
 #include "ignition/rendering/base/BaseScene.hh"
 #include "ignition/rendering/base/BaseNode.hh"
@@ -92,6 +93,7 @@ namespace ignition
       /// \brief Current gizmo mode
       protected: TransformMode mode = TransformMode::TM_NONE;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief A map of gizmo axis and their visuals
       protected: std::map<unsigned int, VisualPtr> visuals;
 
@@ -109,6 +111,7 @@ namespace ignition
 
       /// \brief A map of axis enums to materials
       protected: std::map<unsigned int, MaterialPtr> materials;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Material used by axes
       protected: enum AxisMaterial
@@ -531,15 +534,15 @@ namespace ignition
       common::MeshManager *meshMgr = common::MeshManager::Instance();
       std::string rotMeshName = "gizmo_rotate";
       if (!meshMgr->HasMesh(rotMeshName))
-        meshMgr->CreateTube(rotMeshName, 1.0, 1.02, 0.02, 1, 64, IGN_PI);
+        meshMgr->CreateTube(rotMeshName, 1.0f, 1.02f, 0.02f, 1, 64, IGN_PI);
 
       std::string rotFullMeshName = "gizmo_rotate_full";
       if (!meshMgr->HasMesh(rotFullMeshName))
-        meshMgr->CreateTube(rotFullMeshName, 1.0, 1.02, 0.02, 1, 64, 2*IGN_PI);
+        meshMgr->CreateTube(rotFullMeshName, 1.0f, 1.02f, 0.02f, 1, 64, 2*IGN_PI);
 
       std::string rotHandleMeshName = "gizmo_rotate_handle";
       if (!meshMgr->HasMesh(rotHandleMeshName))
-        meshMgr->CreateTube(rotHandleMeshName, 0.95, 1.07, 0.1, 1, 64, IGN_PI);
+        meshMgr->CreateTube(rotHandleMeshName, 0.95f, 1.07f, 0.1f, 1, 64, IGN_PI);
 
       VisualPtr rotVis = this->Scene()->CreateVisual();
 

--- a/include/ignition/rendering/base/BaseGizmoVisual.hh
+++ b/include/ignition/rendering/base/BaseGizmoVisual.hh
@@ -538,11 +538,17 @@ namespace ignition
 
       std::string rotFullMeshName = "gizmo_rotate_full";
       if (!meshMgr->HasMesh(rotFullMeshName))
-        meshMgr->CreateTube(rotFullMeshName, 1.0f, 1.02f, 0.02f, 1, 64, 2*IGN_PI);
+      {
+        meshMgr->CreateTube(rotFullMeshName, 1.0f, 1.02f, 0.02f, 1, 64,
+            2 * IGN_PI);
+      }
 
       std::string rotHandleMeshName = "gizmo_rotate_handle";
       if (!meshMgr->HasMesh(rotHandleMeshName))
-        meshMgr->CreateTube(rotHandleMeshName, 0.95f, 1.07f, 0.1f, 1, 64, IGN_PI);
+      {
+        meshMgr->CreateTube(rotHandleMeshName, 0.95f, 1.07f, 0.1f, 1, 64,
+            IGN_PI);
+      }
 
       VisualPtr rotVis = this->Scene()->CreateVisual();
 

--- a/include/ignition/rendering/base/BaseMarker.hh
+++ b/include/ignition/rendering/base/BaseMarker.hh
@@ -17,6 +17,8 @@
 #ifndef IGNITION_RENDERING_BASEMARKER_HH_
 #define IGNITION_RENDERING_BASEMARKER_HH_
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/Marker.hh"
 #include "ignition/rendering/base/BaseObject.hh"
 #include "ignition/rendering/base/BaseRenderTypes.hh"
@@ -81,8 +83,10 @@ namespace ignition
                   const ignition::math::Vector3d &_value) override;
 
       /// \brief Life time of a marker
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: std::chrono::steady_clock::duration lifetime =
           std::chrono::steady_clock::duration::zero();
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Layer at which the marker will reside
       protected: int32_t layer = 0;

--- a/include/ignition/rendering/base/BaseObject.hh
+++ b/include/ignition/rendering/base/BaseObject.hh
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <string>
+#include <ignition/common/SuppressWarning.hh>
 #include "ignition/rendering/Object.hh"
 
 namespace ignition
@@ -28,7 +29,9 @@ namespace ignition
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
     class IGNITION_RENDERING_VISIBLE BaseObject :
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public virtual std::enable_shared_from_this<BaseObject>,
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
       public virtual Object
     {
       protected: BaseObject();
@@ -56,7 +59,9 @@ namespace ignition
 
       protected: unsigned int id;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: std::string name;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/rendering/base/BaseRenderEngine.hh
+++ b/include/ignition/rendering/base/BaseRenderEngine.hh
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <ignition/common/SuppressWarning.hh>
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/Storage.hh"
 
@@ -112,12 +113,14 @@ namespace ignition
 
       protected: unsigned int nextSceneId;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief a list of paths that render engines use to locate their
       /// resources
       protected: std::vector<std::string> resourcePaths;
 
       /// \brief Render pass system for this render engine.
       protected: RenderPassSystemPtr renderPassSystem;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/SuppressWarning.hh>
 
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/Scene.hh"
@@ -34,7 +35,9 @@ namespace ignition
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
     class IGNITION_RENDERING_VISIBLE BaseScene :
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public std::enable_shared_from_this<BaseScene>,
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
       public virtual Scene
     {
       protected: BaseScene(unsigned int _id, const std::string &_name);
@@ -549,7 +552,9 @@ namespace ignition
 
       protected: unsigned int id;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: std::string name;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       protected: common::Time simTime;
 
@@ -574,7 +579,9 @@ namespace ignition
 
       private: unsigned int nextObjectId;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: NodeStorePtr nodes;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/include/ignition/rendering/base/BaseThermalCamera.hh
+++ b/include/ignition/rendering/base/BaseThermalCamera.hh
@@ -83,10 +83,10 @@ namespace ignition
           unsigned int, const std::string &)>  _subscriber) override;
 
       /// \brief Ambient temperature of the environment
-      protected: float ambient = 0.0;
+      protected: float ambient = 0.0f;
 
       /// \brief Ambient temperature range
-      protected: float ambientRange = 0.0;
+      protected: float ambientRange = 0.0f;
 
       /// \brief Minimum temperature
       protected: float minTemp = -ignition::math::INF_F;
@@ -95,10 +95,10 @@ namespace ignition
       protected: float maxTemp = ignition::math::INF_F;
 
       /// \brief Linear resolution. Defaults to 10mK.
-      protected: float resolution = 0.01;
+      protected: float resolution = 0.01f;
 
       /// \brief Range of heat source temperature variation
-      protected: float heatSourceTempRange = 0.0;
+      protected: float heatSourceTempRange = 0.0f;
     };
 
     //////////////////////////////////////////////////

--- a/ogre/include/ignition/rendering/ogre/OgreGaussianNoisePass.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreGaussianNoisePass.hh
@@ -19,6 +19,8 @@
 
 #include <memory>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/base/BaseGaussianNoisePass.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
 #include "ignition/rendering/ogre/OgreRenderPass.hh"
@@ -59,8 +61,10 @@ namespace ignition
       public: Ogre::CompositorInstance *gaussianNoiseInstance = nullptr;
 
       /// \brief Gaussian noise compositor listener
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       public: std::shared_ptr<GaussianNoiseCompositorListener>
           gaussianNoiseCompositorListener;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
     }
   }

--- a/ogre/include/ignition/rendering/ogre/OgreGeometry.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreGeometry.hh
@@ -17,6 +17,8 @@
 #ifndef IGNITION_RENDERING_OGRE_OGREGEOMETRY_HH_
 #define IGNITION_RENDERING_OGRE_OGREGEOMETRY_HH_
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/base/BaseGeometry.hh"
 #include "ignition/rendering/ogre/OgreObject.hh"
 
@@ -46,7 +48,9 @@ namespace ignition
 
       protected: virtual void SetParent(OgreVisualPtr _parent);
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: OgreVisualPtr parent;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       private: friend class OgreVisual;
     };

--- a/ogre/include/ignition/rendering/ogre/OgreGpuRays.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreGpuRays.hh
@@ -23,6 +23,8 @@
 #include <memory>
 #include <sstream>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/RenderTypes.hh"
 #include "ignition/rendering/base/BaseGpuRays.hh"
 #include "ignition/rendering/ogre/OgreConversions.hh"
@@ -183,7 +185,9 @@ namespace ignition
 
       /// \internal
       /// \brief Pointer to private data.
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: std::unique_ptr<OgreGpuRaysPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       private: friend class OgreScene;
     };

--- a/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
@@ -18,10 +18,10 @@
 #define IGNITION_RENDERING_OGRE_OGREINCLUDES_HH_
 
 // This disables warning messages for OGRE
-#pragma GCC system_header
-
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#ifndef _MSC_VER
+  #pragma GCC system_header
+#else
+  #pragma warning(push, 0)
 #endif
 
 // This prevents some deprecation #warning messages on OSX 10.9

--- a/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
@@ -20,6 +20,10 @@
 // This disables warning messages for OGRE
 #pragma GCC system_header
 
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
+
 // This prevents some deprecation #warning messages on OSX 10.9
 #pragma clang diagnostic ignored "-W#warnings"
 
@@ -77,6 +81,10 @@
   #include <Overlay/OgreOverlaySystem.h>
 #else
   #include <OgreFontManager.h>
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 
 #endif

--- a/ogre/include/ignition/rendering/ogre/OgreMaterial.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreMaterial.hh
@@ -19,6 +19,8 @@
 
 #include <string>
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/base/BaseMaterial.hh"
 #include "ignition/rendering/ogre/OgreObject.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
@@ -186,6 +188,7 @@ namespace ignition
 
       protected: virtual void Init() override;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: Ogre::MaterialPtr ogreMaterial;
 
       protected: Ogre::Technique *ogreTechnique = nullptr;
@@ -216,6 +219,7 @@ namespace ignition
 
       /// \brief Parameters to be bound to the fragment shader
       protected: ShaderParamsPtr fragmentShaderParams;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       private: friend class OgreScene;
     };

--- a/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
@@ -39,7 +39,17 @@ namespace ignition
 
     /// \brief Helper class to assign unique colors to renderables
     class IGNITION_RENDERING_OGRE_VISIBLE OgreMaterialSwitcher :
-      public Ogre::MaterialManager::Listener, Ogre::RenderTargetListener
+// Ogre::MaterialManager::Listener isn't a dll-interface class, this may cause
+// issues
+#ifdef _MSC_VER
+ #pragma warning(push)
+ #pragma warning(disable:4275)
+#endif
+      public Ogre::MaterialManager::Listener,
+#ifdef _MSC_VER
+ #pragma warning(pop)
+#endif
+      Ogre::RenderTargetListener
     {
       /// \brief Constructor
       public: OgreMaterialSwitcher();

--- a/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
@@ -21,6 +21,7 @@
 #include <map>
 #include <string>
 
+#include <ignition/common/SuppressWarning.hh>
 #include <ignition/math/Color.hh>
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/ogre/Export.hh"
@@ -92,7 +93,9 @@ namespace ignition
 
       /// \brief Color dictionary that maps the unique color value to
       /// renderable name
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: std::map<unsigned int, std::string> colorDict;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief Increment unique color value that will be assigned to the
       /// next renderable

--- a/ogre/include/ignition/rendering/ogre/OgreNode.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreNode.hh
@@ -17,6 +17,8 @@
 #ifndef IGNITION_RENDERING_OGRE_OGRENODE_HH_
 #define IGNITION_RENDERING_OGRE_OGRENODE_HH_
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/base/BaseNode.hh"
 #include "ignition/rendering/ogre/OgreRenderTypes.hh"
 #include "ignition/rendering/ogre/OgreObject.hh"
@@ -87,7 +89,9 @@ namespace ignition
 
       protected: virtual void Init() override;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: OgreNodePtr parent;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       protected: Ogre::SceneNode *ogreNode = nullptr;
 

--- a/ogre/include/ignition/rendering/ogre/OgreObject.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreObject.hh
@@ -17,6 +17,8 @@
 #ifndef IGNITION_RENDERING_OGRE_OGREOBJECT_HH_
 #define IGNITION_RENDERING_OGRE_OGREOBJECT_HH_
 
+#include <ignition/common/SuppressWarning.hh>
+
 #include "ignition/rendering/base/BaseObject.hh"
 #include "ignition/rendering/ogre/OgreRenderTypes.hh"
 #include "ignition/rendering/ogre/Export.hh"
@@ -36,7 +38,9 @@ namespace ignition
 
       public: virtual ScenePtr Scene() const;
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       protected: OgreScenePtr scene;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       private: friend class OgreScene;
     };

--- a/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
@@ -167,7 +167,7 @@ namespace ignition
       /// \brief Paths to ogre plugins
       private: std::vector<std::string> ogrePaths;
 
-#if not (__APPLE__ || _WIN32)
+#if not defined(__APPLE__) && not defined(_WIN32)
       private: void *dummyDisplay = nullptr;
 
       private: void *dummyContext = nullptr;

--- a/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
@@ -167,7 +167,7 @@ namespace ignition
       /// \brief Paths to ogre plugins
       private: std::vector<std::string> ogrePaths;
 
-#if (not defined(__APPLE__) && not defined(_WIN32))
+#if !defined(__APPLE__) && !defined(_WIN32)
       private: void *dummyDisplay = nullptr;
 
       private: void *dummyContext = nullptr;

--- a/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
@@ -167,7 +167,7 @@ namespace ignition
       /// \brief Paths to ogre plugins
       private: std::vector<std::string> ogrePaths;
 
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if (not defined(__APPLE__) && not defined(_WIN32))
       private: void *dummyDisplay = nullptr;
 
       private: void *dummyContext = nullptr;

--- a/ogre/include/ignition/rendering/ogre/OgreRenderTargetMaterial.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderTargetMaterial.hh
@@ -44,7 +44,16 @@ namespace ignition
     /// material provided to this class's constructor.
     class IGNITION_RENDERING_OGRE_VISIBLE  OgreRenderTargetMaterial :
       public Ogre::RenderTargetListener,
+// Ogre::MaterialManager::Listener isn't a dll-interface class, this may cause
+// issues
+#ifdef _MSC_VER
+ #pragma warning(push)
+ #pragma warning(disable:4275)
+#endif
       public Ogre::MaterialManager::Listener
+#ifdef _MSC_VER
+ #pragma warning(pop)
+#endif
     {
       /// \brief constructor
       /// \param[in] _scene the scene manager responsible for rendering

--- a/ogre/include/ignition/rendering/ogre/OgreRenderTargetMaterial.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderTargetMaterial.hh
@@ -24,6 +24,13 @@
 #include "ignition/rendering/ogre/OgreRenderTypes.hh"
 #include "ignition/rendering/ogre/Export.hh"
 
+// Ogre::MaterialManager::Listener isn't a dll-interface class, this may cause
+// issues
+#ifdef _MSC_VER
+ #pragma warning(push)
+ #pragma warning(disable:4275)
+#endif
+
 namespace ignition
 {
   namespace rendering
@@ -44,16 +51,7 @@ namespace ignition
     /// material provided to this class's constructor.
     class IGNITION_RENDERING_OGRE_VISIBLE  OgreRenderTargetMaterial :
       public Ogre::RenderTargetListener,
-// Ogre::MaterialManager::Listener isn't a dll-interface class, this may cause
-// issues
-#ifdef _MSC_VER
- #pragma warning(push)
- #pragma warning(disable:4275)
-#endif
       public Ogre::MaterialManager::Listener
-#ifdef _MSC_VER
- #pragma warning(pop)
-#endif
     {
       /// \brief constructor
       /// \param[in] _scene the scene manager responsible for rendering
@@ -107,5 +105,9 @@ namespace ignition
     }
   }
 }
+
+#ifdef _MSC_VER
+ #pragma warning(pop)
+#endif
 
 #endif

--- a/ogre/include/ignition/rendering/ogre/OgreSelectionBuffer.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreSelectionBuffer.hh
@@ -37,7 +37,7 @@ namespace ignition
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
     // forward declaration
-    struct OgreSelectionBufferPrivate;
+    class OgreSelectionBufferPrivate;
 
     /// \brief Generates a selection buffer object for a given camera.
     /// The selection buffer is used of entity selection. On setup, a unique

--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -2,6 +2,15 @@
 # "gtest_sources" variable.
 ign_get_libsources_and_unittests(sources gtest_sources)
 
+if (MSVC)
+  # Warning #4251 is the "dll-interface" warning that tells you when types used
+  # by a class are not being exported. These generated source files have private
+  # members that don't get exported, so they trigger this warning. However, the
+  # warning is not important since those members do not need to be interfaced
+  # with.
+  set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251")
+endif()
+
 set(engine_name "ogre")
 
 ign_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME ogre_target)
@@ -54,7 +63,7 @@ if (WIN32)
   # disable MSVC inherit via dominance warning
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
   INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned} 
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned}
   ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${unversioned})")
 else()
   EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})

--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -37,10 +37,10 @@ set_property(
 target_link_libraries(${ogre_target}
   PUBLIC
     ${ignition-common${IGN_COMMON_VER}_LIBRARIES}
+    IgnOGRE::IgnOGRE
   PRIVATE
     ignition-plugin${IGN_PLUGIN_VER}::register
     ${OPENGL_LIBRARIES}
-    IgnOGRE::IgnOGRE
     )
 
 # Build the unit tests

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -17,7 +17,9 @@
 
 #if (_WIN32)
   /* Needed for std::min */
-  #define NOMINMAX
+  #ifndef NOMIMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
 #endif
 #include <ignition/math/Helpers.hh>
@@ -313,7 +315,7 @@ void OgreDepthCamera::UpdateRenderTarget(OgreRenderTexturePtr _target,
   // Which normally equates to infinite distance. We don't want this. So
   // we have to set the distance every time.
   this->ogreCamera->setFarClipDistance(this->FarClipPlane());
-  this->ogreCamera->setNearClipDistance(1e-4);
+  this->ogreCamera->setNearClipDistance(1e-4f);
 
   Ogre::AutoParamDataSource autoParamDataSource;
 
@@ -383,10 +385,10 @@ void OgreDepthCamera::PostRender()
 
   // color data
   unsigned int colorChannelCount = 3;
-  int bgColorR = this->scene->BackgroundColor().R() * 255;
-  int bgColorG = this->scene->BackgroundColor().G() * 255;
-  int bgColorB = this->scene->BackgroundColor().B() * 255;
-  int bgColorA = this->scene->BackgroundColor().A() * 255;
+  int bgColorR = static_cast<int>(this->scene->BackgroundColor().R() * 255);
+  int bgColorG = static_cast<int>(this->scene->BackgroundColor().G() * 255);
+  int bgColorB = static_cast<int>(this->scene->BackgroundColor().B() * 255);
+  int bgColorA = static_cast<int>(this->scene->BackgroundColor().A() * 255);
   if (this->dataPtr->outputPoints)
   {
     PixelFormat colorFormat = this->dataPtr->colorTexture->Format();

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -17,7 +17,7 @@
 
 #if (_WIN32)
   /* Needed for std::min */
-  #ifndef NOMIMAX
+  #ifndef NOMINMAX
     #define NOMINMAX
   #endif
   #include <windows.h>

--- a/ogre/src/OgreGpuRays.cc
+++ b/ogre/src/OgreGpuRays.cc
@@ -344,13 +344,13 @@ void OgreGpuRays::ConfigureCameras()
     if ((horzRangeCountPerCamera / this->rangeCountRatio) >
          vertRangeCountPerCamera)
     {
-      vertRangeCountPerCamera =
-          std::round(horzRangeCountPerCamera / this->rangeCountRatio);
+      vertRangeCountPerCamera = static_cast<unsigned int>(
+          std::round(horzRangeCountPerCamera / this->rangeCountRatio));
     }
     else
     {
-      horzRangeCountPerCamera =
-          round(vertRangeCountPerCamera * this->rangeCountRatio);
+      horzRangeCountPerCamera = static_cast<unsigned int>(std::round(
+          vertRangeCountPerCamera * this->rangeCountRatio));
     }
   }
   else
@@ -468,7 +468,7 @@ void OgreGpuRays::CreateGpuRaysTextures()
   Ogre::Matrix4 p = this->BuildScaledOrthoMatrix(
       0, static_cast<float>(this->dataPtr->w2nd / 10.0),
       0, static_cast<float>(this->dataPtr->h2nd / 10.0),
-      0.01, 0.02);
+      0.01f, 0.02f);
 
   this->dataPtr->orthoCam->setCustomProjectionMatrix(true, p);
 
@@ -724,9 +724,9 @@ void OgreGpuRays::CreateOrthoCam()
 
   if (this->dataPtr->orthoCam)
   {
-    this->dataPtr->orthoCam->setNearClipDistance(0.01);
-    this->dataPtr->orthoCam->setFarClipDistance(0.02);
-    this->dataPtr->orthoCam->setRenderingDistance(0.02);
+    this->dataPtr->orthoCam->setNearClipDistance(0.01f);
+    this->dataPtr->orthoCam->setFarClipDistance(0.02f);
+    this->dataPtr->orthoCam->setRenderingDistance(0.02f);
 
     this->dataPtr->orthoCam->setProjectionType(Ogre::PT_ORTHOGRAPHIC);
   }
@@ -837,7 +837,8 @@ void OgreGpuRays::CreateMesh()
       double delta = hstep * i;
 
       // index of texture that contains the depth value
-      unsigned int texture = delta / this->CosHorzFOV();
+      unsigned int texture = static_cast<unsigned int>(
+          delta / this->CosHorzFOV());
 
       // cap texture index and horizontal angle
       if (texture > this->dataPtr->textureCount-1)

--- a/ogre/src/OgreMaterialSwitcher.cc
+++ b/ogre/src/OgreMaterialSwitcher.cc
@@ -28,7 +28,7 @@ using namespace rendering;
 OgreMaterialSwitcher::OgreMaterialSwitcher()
   : lastTechnique(nullptr)
 {
-  this->currentColor = ignition::math::Color(0.0, 0.0, 0.1);
+  this->currentColor = ignition::math::Color(0.0f, 0.0f, 0.1f);
 }
 
 /////////////////////////////////////////////////

--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -18,7 +18,6 @@
 
 #include <sstream>
 
-
 #include <ignition/common/Console.hh>
 #include <ignition/common/Material.hh>
 #include <ignition/common/MeshManager.hh>

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -676,7 +676,7 @@ std::string OgreRenderEngine::CreateRenderWindow(const std::string &_handle,
     return std::string();
   }
 
-  if (window)
+  if (nullptr != window)
   {
     window->setActive(true);
     window->setVisible(true);

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -16,7 +16,7 @@
  */
 
 // Not Apple or Windows
-#if (not defined(__APPLE__) && not defined(_WIN32))
+#if !defined(__APPLE__) && !defined(_WIN32)
 # include <X11/Xlib.h>
 # include <X11/Xutil.h>
 # include <GL/glx.h>
@@ -46,7 +46,7 @@
 
 class ignition::rendering::OgreRenderEnginePrivate
 {
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   public: XVisualInfo *dummyVisual = nullptr;
 #endif
 
@@ -119,7 +119,7 @@ void OgreRenderEngine::Destroy()
   delete this->ogreLogManager;
   this->ogreLogManager = nullptr;
 
-#if (not defined(__APPLE__) && not defined(_WIN32))
+#if (!defined(__APPLE__) && !defined(_WIN32))
   if (this->dummyDisplay)
   {
     Display *x11Display = static_cast<Display*>(this->dummyDisplay);
@@ -337,7 +337,7 @@ void OgreRenderEngine::CreateLogger()
 //////////////////////////////////////////////////
 void OgreRenderEngine::CreateContext()
 {
-#if (not defined(__APPLE__) && not defined(_WIN32))
+#if (!defined(__APPLE__) && !defined(_WIN32))
   // create X11 display
   this->dummyDisplay = XOpenDisplay(0);
   Display *x11Display = static_cast<Display*>(this->dummyDisplay);

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -16,7 +16,7 @@
  */
 
 // Not Apple or Windows
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if (not defined(__APPLE__) && not defined(_WIN32))
 # include <X11/Xlib.h>
 # include <X11/Xutil.h>
 # include <GL/glx.h>
@@ -119,7 +119,7 @@ void OgreRenderEngine::Destroy()
   delete this->ogreLogManager;
   this->ogreLogManager = nullptr;
 
-#if not (__APPLE__ || _WIN32)
+#if (not defined(__APPLE__) && not defined(_WIN32))
   if (this->dummyDisplay)
   {
     Display *x11Display = static_cast<Display*>(this->dummyDisplay);
@@ -337,7 +337,7 @@ void OgreRenderEngine::CreateLogger()
 //////////////////////////////////////////////////
 void OgreRenderEngine::CreateContext()
 {
-#if not (__APPLE__ || _WIN32)
+#if (not defined(__APPLE__) && not defined(_WIN32))
   // create X11 display
   this->dummyDisplay = XOpenDisplay(0);
   Display *x11Display = static_cast<Display*>(this->dummyDisplay);

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -18,12 +18,16 @@
 #ifndef _WIN32
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
+#else
+# pragma warning(push, 0)
 #endif
 // leave this out of OgreIncludes as it conflicts with other files requiring
 // gl.h
 #include <OgreGLFBORenderTexture.h>
 #ifndef _WIN32
 # pragma GCC diagnostic pop
+#else
+# pragma warning(pop)
 #endif
 
 

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -68,6 +68,9 @@ OgreRenderTarget::~OgreRenderTarget()
 //////////////////////////////////////////////////
 void OgreRenderTarget::Copy(Image &_image) const
 {
+  if (nullptr == this->RenderTarget())
+    return;
+
   // TODO(anyone): handle Bayer conversions
   // TODO(anyone): handle ogre version differences
 
@@ -201,7 +204,7 @@ void OgreRenderTarget::SetMaterial(MaterialPtr _material)
 //////////////////////////////////////////////////
 void OgreRenderTarget::RebuildMaterial()
 {
-  if (this->material)
+  if (this->material && this->RenderTarget())
   {
     OgreMaterial *ogreMaterial = dynamic_cast<OgreMaterial*>(
         this->material.get());
@@ -233,6 +236,13 @@ void OgreRenderTarget::UpdateRenderPassChain()
 Ogre::Viewport *OgreRenderTarget::Viewport(const int _viewportId) const
 {
   Ogre::RenderTarget *ogreRenderTarget = this->RenderTarget();
+
+  if (nullptr == ogreRenderTarget)
+  {
+    ignerr << "Failed to get viewport: null render target" << std::endl;
+    return nullptr;
+  }
+
   return ogreRenderTarget->getViewport(_viewportId);
 }
 
@@ -240,6 +250,13 @@ Ogre::Viewport *OgreRenderTarget::Viewport(const int _viewportId) const
 Ogre::Viewport *OgreRenderTarget::AddViewport(Ogre::Camera *_camera)
 {
   Ogre::RenderTarget *ogreRenderTarget = this->RenderTarget();
+
+  if (nullptr == ogreRenderTarget)
+  {
+    ignerr << "Failed to add viewport: null render target" << std::endl;
+    return nullptr;
+  }
+
   return ogreRenderTarget->addViewport(_camera);
 }
 
@@ -247,6 +264,13 @@ Ogre::Viewport *OgreRenderTarget::AddViewport(Ogre::Camera *_camera)
 void OgreRenderTarget::SetAutoUpdated(const bool _value)
 {
   Ogre::RenderTarget *ogreRenderTarget = this->RenderTarget();
+
+  if (nullptr == ogreRenderTarget)
+  {
+    ignerr << "Failed to set auto update: null render target" << std::endl;
+    return;
+  }
+
   ogreRenderTarget->setAutoUpdated(_value);
 }
 
@@ -254,6 +278,13 @@ void OgreRenderTarget::SetAutoUpdated(const bool _value)
 void OgreRenderTarget::SetUpdate(const bool _value)
 {
   Ogre::RenderTarget *ogreRenderTarget = this->RenderTarget();
+
+  if (nullptr == ogreRenderTarget)
+  {
+    ignerr << "Failed to set update: null render target" << std::endl;
+    return;
+  }
+
   ogreRenderTarget->update(_value);
 }
 
@@ -373,6 +404,13 @@ void OgreRenderTexture::PostRender()
 void OgreRenderTexture::Buffer(float *_buffer)
 {
   Ogre::RenderTarget *ogreRenderTarget = this->RenderTarget();
+
+  if (nullptr == ogreRenderTarget)
+  {
+    ignerr << "Failed to set buffer: null render target" << std::endl;
+    return;
+  }
+
   ogreRenderTarget->swapBuffers();
 
   Ogre::HardwarePixelBufferSharedPtr pcdPixelBuffer;
@@ -423,6 +461,13 @@ void OgreRenderWindow::RebuildTarget()
 
   Ogre::RenderWindow *window =
       dynamic_cast<Ogre::RenderWindow *>(this->ogreRenderWindow);
+
+  if (nullptr == window)
+  {
+    ignerr << "Failed to cast render window." << std::endl;
+    return;
+  }
+
   window->resize(this->width, this->height);
   window->windowMovedOrResized();
 }
@@ -437,6 +482,13 @@ void OgreRenderWindow::BuildTarget()
           this->height,
           this->ratio,
           this->antiAliasing);
+
+  if (renderTargetName.empty())
+  {
+    ignerr << "Failed to build target." << std::endl;
+    return;
+  }
+
   this->ogreRenderWindow =
       engine->OgreRoot()->getRenderTarget(renderTargetName);
 }

--- a/ogre/src/OgreSelectionBuffer.cc
+++ b/ogre/src/OgreSelectionBuffer.cc
@@ -201,8 +201,8 @@ Ogre::Entity *OgreSelectionBuffer::OnSelectionClick(const int _x, const int _y)
 
   // 1x1 selection buffer, adapted from rviz
   // http://docs.ros.org/indigo/api/rviz/html/c++/selection__manager_8cpp.html
-  unsigned int width = 1;
-  unsigned int height = 1;
+  float width = 1.0f;
+  float height = 1.0f;
   float x1 = static_cast<float>(_x) /
       static_cast<float>(targetWidth - 1) - 0.5f;
   float y1 = static_cast<float>(_y) /

--- a/ogre/src/OgreText.cc
+++ b/ogre/src/OgreText.cc
@@ -380,7 +380,7 @@ void OgreMovableText::SetFontNameImpl(const std::string &_newFontName)
 #if OGRE_VERSION_LT_1_10_1
       this->ogreMaterial.setNull();
 #else
-      this->ogreMaterial == nullptr;
+      this->ogreMaterial = nullptr;
 #endif
     }
 

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -17,7 +17,9 @@
 
 #if (_WIN32)
   /* Needed for std::min */
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
 #endif
 

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -230,13 +230,13 @@ Ogre::Technique *OgreThermalCameraMaterialSwitcher::handleSchemeNotFound(
     {
       try
       {
-        temp = std::get<double>(tempAny);
+        temp = static_cast<float>(std::get<double>(tempAny));
       }
       catch(...)
       {
         try
         {
-          temp = std::get<int>(tempAny);
+          temp = static_cast<float>(std::get<int>(tempAny));
         }
         catch(std::bad_variant_access &e)
         {
@@ -412,7 +412,7 @@ void OgreThermalCamera::CreateThermalTexture()
   // without being clipped.
   double nearPlane = this->NearClipPlane();
   double farPlane = this->FarClipPlane();
-  this->ogreCamera->setNearClipDistance(1e-4);
+  this->ogreCamera->setNearClipDistance(1e-4f);
   this->ogreCamera->setFarClipDistance(farPlane);
 
   // create thermal material

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Includes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Includes.hh
@@ -18,10 +18,10 @@
 #define IGNITION_RENDERING_OGRE2_OGRE2INCLUDES_HH_
 
 // This disables warning messages for OGRE
-#pragma GCC system_header
-
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#ifndef _MSC_VER
+  #pragma GCC system_header
+#else
+  #pragma warning(push, 0)
 #endif
 
 // This prevents some deprecation #warning messages on OSX 10.9

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Includes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Includes.hh
@@ -20,6 +20,10 @@
 // This disables warning messages for OGRE
 #pragma GCC system_header
 
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
+
 // This prevents some deprecation #warning messages on OSX 10.9
 #pragma clang diagnostic ignored "-W#warnings"
 
@@ -94,5 +98,9 @@
 // #include <Terrain/OgreTerrainMaterialGeneratorA.h>
 // #include <Terrain/OgreTerrain.h>
 // #include <Terrain/OgreTerrainGroup.h>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -2,6 +2,15 @@
 # "gtest_sources" variable.
 ign_get_libsources_and_unittests(sources gtest_sources)
 
+if (MSVC)
+  # Warning #4251 is the "dll-interface" warning that tells you when types used
+  # by a class are not being exported. These generated source files have private
+  # members that don't get exported, so they trigger this warning. However, the
+  # warning is not important since those members do not need to be interfaced
+  # with.
+  set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251")
+endif()
+
 set(engine_name "ogre2")
 
 ign_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME ogre2_target)
@@ -34,7 +43,7 @@ if (WIN32)
   # disable MSVC inherit via dominance warning
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4250")
   INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E copy
-  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned} 
+  ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${versioned}
   ${IGNITION_RENDERING_ENGINE_INSTALL_DIR}\/${unversioned})")
 else()
   EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink ${versioned} ${unversioned})

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -17,7 +17,9 @@
 
 #if (_WIN32)
   /* Needed for std::min */
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
 #endif
 

--- a/ogre2/src/Ogre2DynamicRenderable.cc
+++ b/ogre2/src/Ogre2DynamicRenderable.cc
@@ -17,7 +17,13 @@
 
 // Note this include is placed in the src file because
 // otherwise ogre produces compile errors
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include "ignition/common/Console.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -17,7 +17,13 @@
 
 // Note this include is placed in the src file because
 // otherwise ogre produces compile errors
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>

--- a/ogre2/src/Ogre2Mesh.cc
+++ b/ogre2/src/Ogre2Mesh.cc
@@ -17,7 +17,13 @@
 
 // Note this include is placed in the src file because
 // otherwise ogre produces compile errors
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <ignition/common/Console.hh>
 

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -16,7 +16,7 @@
  */
 
 // Not Apple or Windows
-#if (not defined(__APPLE__) && not defined(_WIN32))
+#if !defined(__APPLE__) && !defined(_WIN32)
 # include <X11/Xlib.h>
 # include <X11/Xutil.h>
 # include <GL/glx.h>
@@ -43,7 +43,7 @@
 
 class ignition::rendering::Ogre2RenderEnginePrivate
 {
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   public: XVisualInfo *dummyVisual = nullptr;
 #endif
 

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -16,7 +16,7 @@
  */
 
 // Not Apple or Windows
-#if not defined(__APPLE__) && not defined(_WIN32)
+#if (not defined(__APPLE__) && not defined(_WIN32))
 # include <X11/Xlib.h>
 # include <X11/Xutil.h>
 # include <GL/glx.h>

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -17,7 +17,13 @@
 
 // leave this out of OgreIncludes as it conflicts with other files requiring
 // gl.h
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
 #include <OgreGL3PlusFBORenderTexture.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <ignition/common/Console.hh>
 

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -17,7 +17,9 @@
 
 #if (_WIN32)
   /* Needed for std::min */
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
   #include <windows.h>
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,15 @@ set_property(
 # "gtest_sources" variable.
 ign_get_libsources_and_unittests(sources gtest_sources)
 
+if (MSVC)
+  # Warning #4251 is the "dll-interface" warning that tells you when types used
+  # by a class are not being exported. These generated source files have private
+  # members that don't get exported, so they trigger this warning. However, the
+  # warning is not important since those members do not need to be interfaced
+  # with.
+  set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251")
+endif()
+
 add_subdirectory(base)
 
 # Create the library target.

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -73,7 +73,7 @@ void CameraTest::ViewProjectionMatrix(const std::string &_renderEngine)
 
   EXPECT_GT(camera->AspectRatio(), 0);
   camera->SetAspectRatio(1.7777);
-  EXPECT_DOUBLE_EQ(1.7777, camera->AspectRatio());
+  EXPECT_NEAR(1.7777, camera->AspectRatio(), 1e-6);
 
   camera->SetAntiAliasing(1u);
   EXPECT_EQ(1u, camera->AntiAliasing());

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -73,7 +73,7 @@ void CameraTest::ViewProjectionMatrix(const std::string &_renderEngine)
 
   EXPECT_GT(camera->AspectRatio(), 0);
   camera->SetAspectRatio(1.7777);
-  EXPECT_FLOAT_EQ(1.7777, camera->AspectRatio());
+  EXPECT_DOUBLE_EQ(1.7777, camera->AspectRatio());
 
   camera->SetAntiAliasing(1u);
   EXPECT_EQ(1u, camera->AntiAliasing());

--- a/src/Grid_TEST.cc
+++ b/src/Grid_TEST.cc
@@ -1,4 +1,5 @@
-/* * Copyright (C) 2017 Open Source Robotics Foundation
+/*
+ * Copyright (C) 2017 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,9 +79,9 @@ void GridTest::Grid(const std::string &_renderEngine)
   grid->SetMaterial(mat);
   MaterialPtr gridMat = grid->Material();
   ASSERT_NE(nullptr, gridMat);
-  EXPECT_EQ(math::Color(0.6, 0.7, 0.8), gridMat->Ambient());
-  EXPECT_EQ(math::Color(0.3, 0.8, 0.2), gridMat->Diffuse());
-  EXPECT_EQ(math::Color(0.4, 0.9, 1.0), gridMat->Specular());
+  EXPECT_EQ(math::Color(0.6f, 0.7f, 0.8f), gridMat->Ambient());
+  EXPECT_EQ(math::Color(0.3f, 0.8f, 0.2f), gridMat->Diffuse());
+  EXPECT_EQ(math::Color(0.4f, 0.9f, 1.0f), gridMat->Specular());
 
   // Clean up
   engine->DestroyScene(scene);

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -76,11 +76,11 @@ void LightTest::Light(const std::string &_renderEngine)
 
   // attenuation
   light->SetAttenuationConstant(0.6);
-  EXPECT_FLOAT_EQ(0.6, light->AttenuationConstant());
+  EXPECT_DOUBLE_EQ(0.6, light->AttenuationConstant());
   light->SetAttenuationLinear(0.2);
-  EXPECT_FLOAT_EQ(0.2, light->AttenuationLinear());
+  EXPECT_DOUBLE_EQ(0.2, light->AttenuationLinear());
   light->SetAttenuationQuadratic(0.01);
-  EXPECT_FLOAT_EQ(0.01, light->AttenuationQuadratic());
+  EXPECT_DOUBLE_EQ(0.01, light->AttenuationQuadratic());
   light->SetAttenuationRange(10);
   EXPECT_DOUBLE_EQ(10, light->AttenuationRange());
 
@@ -122,7 +122,7 @@ void LightTest::Light(const std::string &_renderEngine)
   spotLight->SetOuterAngle(math::Angle(0.2));
   EXPECT_EQ(math::Angle(0.2), spotLight->OuterAngle());
   spotLight->SetFalloff(0.2);
-  EXPECT_FLOAT_EQ(0.2, spotLight->Falloff());
+  EXPECT_DOUBLE_EQ(0.2, spotLight->Falloff());
 
   // remove lights
   scene->DestroyLightById(light->Id());

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -75,12 +75,13 @@ void LightTest::Light(const std::string &_renderEngine)
   EXPECT_FALSE(light->CastShadows());
 
   // attenuation
+  // Checking near because Ogre stores it as float
   light->SetAttenuationConstant(0.6);
-  EXPECT_DOUBLE_EQ(0.6, light->AttenuationConstant());
+  EXPECT_NEAR(0.6, light->AttenuationConstant(), 1e-6);
   light->SetAttenuationLinear(0.2);
-  EXPECT_DOUBLE_EQ(0.2, light->AttenuationLinear());
+  EXPECT_NEAR(0.2, light->AttenuationLinear(), 1e-6);
   light->SetAttenuationQuadratic(0.01);
-  EXPECT_DOUBLE_EQ(0.01, light->AttenuationQuadratic());
+  EXPECT_NEAR(0.01, light->AttenuationQuadratic(), 1e-6);
   light->SetAttenuationRange(10);
   EXPECT_DOUBLE_EQ(10, light->AttenuationRange());
 
@@ -122,7 +123,7 @@ void LightTest::Light(const std::string &_renderEngine)
   spotLight->SetOuterAngle(math::Angle(0.2));
   EXPECT_EQ(math::Angle(0.2), spotLight->OuterAngle());
   spotLight->SetFalloff(0.2);
-  EXPECT_DOUBLE_EQ(0.2, spotLight->Falloff());
+  EXPECT_NEAR(0.2, spotLight->Falloff(), 1e-6);
 
   // remove lights
   scene->DestroyLightById(light->Id());

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -236,12 +236,12 @@ void MaterialTest::MaterialProperties(const std::string &_renderEngine)
     EXPECT_TRUE(material->HasEmissiveMap());
 
     // roughness
-    float roughness = 0.3;
+    float roughness = 0.3f;
     material->SetRoughness(roughness);
     EXPECT_FLOAT_EQ(roughness, material->Roughness());
 
     // metalness
-    float metalness = 0.9;
+    float metalness = 0.9f;
     material->SetMetalness(metalness);
     EXPECT_FLOAT_EQ(metalness, material->Metalness());
   }
@@ -272,10 +272,10 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   MaterialPtr material = scene->CreateMaterial();
   ASSERT_TRUE(material != nullptr);
 
-  math::Color ambient(0.5, 0.2, 0.4, 1.0);
-  math::Color diffuse(0.1, 0.9, 0.3, 1.0);
-  math::Color specular(0.8, 0.7, 0.0, 1.0);
-  math::Color emissive(0.6, 0.4, 0.2, 1.0);
+  math::Color ambient(0.5f, 0.2f, 0.4f, 1.0f);
+  math::Color diffuse(0.1f, 0.9f, 0.3f, 1.0f);
+  math::Color specular(0.8f, 0.7f, 0.0f, 1.0f);
+  math::Color emissive(0.6f, 0.4f, 0.2f, 1.0f);
   double shininess = 0.8;
   double transparency = 0.3;
   double reflectivity = 0.5;
@@ -285,8 +285,8 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   bool lightingEnabled = false;
   bool depthCheckEnabled = false;
   bool depthWriteEnabled = false;
-  float roughness = 0.5;
-  float metalness = 0.1;
+  float roughness = 0.5f;
+  float metalness = 0.1f;
 
   std::string textureName =
     common::joinPaths(TEST_MEDIA_PATH, "texture.png");

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -68,38 +68,38 @@ void MaterialTest::MaterialProperties(const std::string &_renderEngine)
   EXPECT_TRUE(scene->MaterialRegistered("unique"));
 
   // ambient
-  math::Color ambient(0.5, 0.2, 0.4, 1.0);
+  math::Color ambient(0.5f, 0.2f, 0.4f, 1.0f);
   material->SetAmbient(ambient);
   EXPECT_EQ(ambient, material->Ambient());
 
-  ambient.Set(0.55, 0.22, 0.44, 1.0);
+  ambient.Set(0.55f, 0.22f, 0.44f, 1.0f);
   material->SetAmbient(ambient.R(), ambient.G(), ambient.B(), ambient.A());
   EXPECT_EQ(ambient, material->Ambient());
 
   // diffuse
-  math::Color diffuse(0.1, 0.9, 0.3, 1.0);
+  math::Color diffuse(0.1f, 0.9f, 0.3f, 1.0f);
   material->SetDiffuse(diffuse);
   EXPECT_EQ(diffuse, material->Diffuse());
 
-  diffuse.Set(0.11, 0.99, 0.33, 1.0);
+  diffuse.Set(0.11f, 0.99f, 0.33f, 1.0f);
   material->SetDiffuse(diffuse.R(), diffuse.G(), diffuse.B(), diffuse.A());
   EXPECT_EQ(diffuse, material->Diffuse());
 
   // specular
-  math::Color specular(0.8, 0.7, 0.0, 1.0);
+  math::Color specular(0.8f, 0.7f, 0.0f, 1.0f);
   material->SetSpecular(specular);
   EXPECT_EQ(specular, material->Specular());
 
-  specular.Set(0.88, 0.77, 0.66, 1.0);
+  specular.Set(0.88f, 0.77f, 0.66f, 1.0f);
   material->SetSpecular(specular.R(), specular.G(), specular.B(), specular.A());
   EXPECT_EQ(specular, material->Specular());
 
   // emissive
-  math::Color emissive(0.6, 0.4, 0.2, 1.0);
+  math::Color emissive(0.6f, 0.4f, 0.2f, 1.0f);
   material->SetEmissive(emissive);
   EXPECT_EQ(emissive, material->Emissive());
 
-  emissive.Set(0.66, 0.44, 0.22, 1.0);
+  emissive.Set(0.66f, 0.44f, 0.22f, 1.0f);
   material->SetEmissive(emissive.R(), emissive.G(), emissive.B(), emissive.A());
   EXPECT_EQ(emissive, material->Emissive());
 

--- a/src/OrbitViewController.cc
+++ b/src/OrbitViewController.cc
@@ -41,8 +41,8 @@ class ignition::rendering::OrbitViewControllerPrivate
 using namespace ignition;
 using namespace rendering;
 
-static const float PITCH_LIMIT_LOW = -IGN_PI*0.5 + 0.001;
-static const float PITCH_LIMIT_HIGH = IGN_PI*0.5 - 0.001;
+static const float PITCH_LIMIT_LOW = -IGN_PI*0.5f + 0.001f;
+static const float PITCH_LIMIT_HIGH = IGN_PI*0.5f - 0.001f;
 
 //////////////////////////////////////////////////
 OrbitViewController::OrbitViewController()

--- a/src/OrbitViewController.cc
+++ b/src/OrbitViewController.cc
@@ -41,8 +41,8 @@ class ignition::rendering::OrbitViewControllerPrivate
 using namespace ignition;
 using namespace rendering;
 
-static const float PITCH_LIMIT_LOW = -IGN_PI*0.5f + 0.001f;
-static const float PITCH_LIMIT_HIGH = IGN_PI*0.5f - 0.001f;
+static const float PITCH_LIMIT_LOW = -static_cast<float>(IGN_PI)*0.5f + 0.001f;
+static const float PITCH_LIMIT_LOW = static_cast<float>(IGN_PI)*0.5f - 0.001f;
 
 //////////////////////////////////////////////////
 OrbitViewController::OrbitViewController()

--- a/src/OrbitViewController.cc
+++ b/src/OrbitViewController.cc
@@ -42,7 +42,7 @@ using namespace ignition;
 using namespace rendering;
 
 static const float PITCH_LIMIT_LOW = -static_cast<float>(IGN_PI)*0.5f + 0.001f;
-static const float PITCH_LIMIT_LOW = static_cast<float>(IGN_PI)*0.5f - 0.001f;
+static const float PITCH_LIMIT_HIGH = static_cast<float>(IGN_PI)*0.5f - 0.001f;
 
 //////////////////////////////////////////////////
 OrbitViewController::OrbitViewController()

--- a/src/Text_TEST.cc
+++ b/src/Text_TEST.cc
@@ -74,13 +74,13 @@ void TextTest::Text(const std::string &_renderEngine)
   text->SetTextString("abc def");
   EXPECT_EQ("abc def", text->TextString());
 
-  text->SetCharHeight(1.8);
+  text->SetCharHeight(1.8f);
   EXPECT_FLOAT_EQ(1.8, text->CharHeight());
 
-  text->SetSpaceWidth(1.5);
+  text->SetSpaceWidth(1.5f);
   EXPECT_FLOAT_EQ(1.5, text->SpaceWidth());
 
-  text->SetBaseline(0.5);
+  text->SetBaseline(0.5f);
   EXPECT_FLOAT_EQ(0.5, text->Baseline());
 
   text->SetTextAlignment(TextHorizontalAlign::CENTER, TextVerticalAlign::TOP);
@@ -90,24 +90,24 @@ void TextTest::Text(const std::string &_renderEngine)
   text->SetShowOnTop(true);
   EXPECT_TRUE(text->ShowOnTop());
 
-  text->SetColor(math::Color(1, 0.2, 0.3, 1.0));
-  EXPECT_EQ(math::Color(1, 0.2, 0.3, 1.0), text->Color());
+  text->SetColor(math::Color(1.0f, 0.2f, 0.3f, 1.0f));
+  EXPECT_EQ(math::Color(1.0f, 0.2f, 0.3f, 1.0f), text->Color());
 
   // create material
   MaterialPtr mat = scene->CreateMaterial();
-  mat->SetAmbient(0.6, 0.7, 0.8);
-  mat->SetDiffuse(0.3, 0.8, 0.2);
-  mat->SetSpecular(0.4, 0.9, 1.0);
+  mat->SetAmbient(0.6f, 0.7f, 0.8f);
+  mat->SetDiffuse(0.3f, 0.8f, 0.2f);
+  mat->SetSpecular(0.4f, 0.9f, 1.0f);
 
   text->SetMaterial(mat);
   MaterialPtr textMat = text->Material();
   ASSERT_NE(nullptr, textMat);
-  EXPECT_EQ(math::Color(0.6, 0.7, 0.8), textMat->Ambient());
-  EXPECT_EQ(math::Color(0.3, 0.8, 0.2), textMat->Diffuse());
-  EXPECT_EQ(math::Color(0.4, 0.9, 1.0), textMat->Specular());
+  EXPECT_EQ(math::Color(0.6f, 0.7f, 0.8f), textMat->Ambient());
+  EXPECT_EQ(math::Color(0.3f, 0.8f, 0.2f), textMat->Diffuse());
+  EXPECT_EQ(math::Color(0.4f, 0.9f, 1.0f), textMat->Specular());
 
   // color is affected by material but currently only by the diffuse component
-  EXPECT_EQ(math::Color(0.3, 0.8, 0.2, 1.0), text->Color());
+  EXPECT_EQ(math::Color(0.3f, 0.8f, 0.2f, 1.0f), text->Color());
 
   // Clean up
   engine->DestroyScene(scene);

--- a/src/Text_TEST.cc
+++ b/src/Text_TEST.cc
@@ -75,13 +75,13 @@ void TextTest::Text(const std::string &_renderEngine)
   EXPECT_EQ("abc def", text->TextString());
 
   text->SetCharHeight(1.8f);
-  EXPECT_FLOAT_EQ(1.8, text->CharHeight());
+  EXPECT_FLOAT_EQ(1.8f, text->CharHeight());
 
   text->SetSpaceWidth(1.5f);
-  EXPECT_FLOAT_EQ(1.5, text->SpaceWidth());
+  EXPECT_FLOAT_EQ(1.5f, text->SpaceWidth());
 
   text->SetBaseline(0.5f);
-  EXPECT_FLOAT_EQ(0.5, text->Baseline());
+  EXPECT_FLOAT_EQ(0.5f, text->Baseline());
 
   text->SetTextAlignment(TextHorizontalAlign::CENTER, TextVerticalAlign::TOP);
   EXPECT_EQ(TextHorizontalAlign::CENTER, text->HorizontalAlignment());

--- a/src/ThermalCamera_TEST.cc
+++ b/src/ThermalCamera_TEST.cc
@@ -56,19 +56,19 @@ void ThermalCameraTest::ThermalCamera(const std::string &_renderEngine)
   camera->SetAmbientTemperature(ambient);
   EXPECT_FLOAT_EQ(ambient, camera->AmbientTemperature());
 
-  float range = 3.35;
+  float range = 3.35f;
   camera->SetAmbientTemperatureRange(range);
   EXPECT_FLOAT_EQ(range, camera->AmbientTemperatureRange());
 
-  float minTemp = 250.05;
+  float minTemp = 250.05f;
   camera->SetMinTemperature(minTemp);
   EXPECT_FLOAT_EQ(minTemp, camera->MinTemperature());
 
-  float maxTemp = 380.06;
+  float maxTemp = 380.06f;
   camera->SetMaxTemperature(maxTemp);
   EXPECT_FLOAT_EQ(maxTemp, camera->MaxTemperature());
 
-  float resolution = 0.04;
+  float resolution = 0.04f;
   camera->SetLinearResolution(resolution);
   EXPECT_FLOAT_EQ(resolution, camera->LinearResolution());
 

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -71,9 +71,9 @@ void VisualTest::Material(const std::string &_renderEngine)
   EXPECT_EQ(nullptr, visual->Material());
 
   // create material
-  math::Color ambient(0.5, 0.2, 0.4, 1.0);
-  math::Color diffuse(0.1, 0.9, 0.3, 1.0);
-  math::Color specular(0.8, 0.7, 0.0, 1.0);
+  math::Color ambient(0.5f, 0.2f, 0.4f, 1.0f);
+  math::Color diffuse(0.1f, 0.9f, 0.3f, 1.0f);
+  math::Color specular(0.8f, 0.7f, 0.0f, 1.0f);
   double transparency = 0.3;
   MaterialPtr material = scene->CreateMaterial("unique");
   ASSERT_NE(nullptr, material);
@@ -101,9 +101,9 @@ void VisualTest::Material(const std::string &_renderEngine)
   EXPECT_DOUBLE_EQ(transparency, cloneMat->Transparency());
 
   // create another material
-  math::Color ambient2(0.0, 0.0, 1.0, 1.0);
-  math::Color diffuse2(1.0, 0.0, 1.0, 1.0);
-  math::Color specular2(0.0, 1.0, 0.0, 1.0);
+  math::Color ambient2(0.0f, 0.0f, 1.0f, 1.0f);
+  math::Color diffuse2(1.0f, 0.0f, 1.0f, 1.0f);
+  math::Color specular2(0.0f, 1.0f, 0.0f, 1.0f);
   double transparency2 = 0;
   MaterialPtr material2 = scene->CreateMaterial("unique2");
   ASSERT_NE(nullptr, material2);

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -344,6 +344,7 @@ void VisualTest::UserData(const std::string &_renderEngine)
   EXPECT_THROW(
   {
     auto res = std::get<int>(value);
+    igndbg << res << std::endl;
   }, std::bad_variant_access);
 
   // Clean up

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -341,7 +341,10 @@ void VisualTest::UserData(const std::string &_renderEngine)
   EXPECT_EQ(stringValue, std::get<std::string>(value));
 
   // test invalid access
-  EXPECT_THROW(std::get<int>(value), std::bad_variant_access);
+  EXPECT_THROW(
+  {
+    auto res = std::get<int>(value);
+  }, std::bad_variant_access);
 
   // Clean up
   engine->DestroyScene(scene);

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -174,8 +174,8 @@ void DepthCameraTest::DepthCameraBoxes(
     // from depth and point cloud image
 
     // depth image indices
-    int midWidth = depthCamera->ImageWidth() * 0.5;
-    int midHeight = depthCamera->ImageHeight() * 0.5;
+    int midWidth = static_cast<int>(depthCamera->ImageWidth() * 0.5);
+    int midHeight = static_cast<int>(depthCamera->ImageHeight() * 0.5);
     int mid = midHeight * depthCamera->ImageWidth() + midWidth -1;
     double expectedRangeAtMidPoint = boxPosition.X() - unitBoxSize * 0.5;
     int left = midHeight * depthCamera->ImageWidth();

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -297,8 +297,8 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
     // from point cloud image
 
     // point cloud image indices
-    int midWidth = depthCamera->ImageWidth() * 0.5;
-    int midHeight = depthCamera->ImageHeight() * 0.5;
+    int midWidth = static_cast<int>(depthCamera->ImageWidth() * 0.5);
+    int midHeight = static_cast<int>(depthCamera->ImageHeight() * 0.5);
     double expectedRangeAtMidPoint = boxPosition.X() - unitBoxSize * 0.5;
 
     int pcMid = midHeight * depthCamera->ImageWidth() * pointCloudChannelCount

--- a/test/integration/scene.cc
+++ b/test/integration/scene.cc
@@ -71,9 +71,9 @@ void SceneTest::AddRemoveVisuals(const std::string &_renderEngine)
   root->AddChild(camera);
 
   // create material assigned to all geoms
-  math::Color ambient(0.5, 0.2, 0.4, 1.0);
-  math::Color diffuse(0.1, 0.9, 0.3, 1.0);
-  math::Color specular(0.8, 0.7, 0.0, 1.0);
+  math::Color ambient(0.5f, 0.2f, 0.4f, 1.0f);
+  math::Color diffuse(0.1f, 0.9f, 0.3f, 1.0f);
+  math::Color specular(0.8f, 0.7f, 0.0f, 1.0f);
   double transparency = 0.3;
   MaterialPtr material = scene->CreateMaterial("mat");
   ASSERT_NE(nullptr, material);

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -171,8 +171,8 @@ void ThermalCameraTest::ThermalCameraBoxes(
     thermalCamera->Update();
 
     // thermal image indices
-    int midWidth = thermalCamera->ImageWidth() * 0.5;
-    int midHeight = thermalCamera->ImageHeight() * 0.5;
+    int midWidth = static_cast<int>(thermalCamera->ImageWidth() * 0.5);
+    int midHeight = static_cast<int>(thermalCamera->ImageHeight() * 0.5);
     int mid = midHeight * thermalCamera->ImageWidth() + midWidth -1;
     int left = midHeight * thermalCamera->ImageWidth();
     int right = (midHeight+1) * thermalCamera->ImageWidth() - 1;

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -145,9 +145,9 @@ void ThermalCameraTest::ThermalCameraBoxes(
 
     // thermal-specific params
     // set room temperature: 294 ~ 298 Kelvin
-    float ambientTemp = 296.0;
-    float ambientTempRange = 4.0;
-    float linearResolution = 0.01;
+    float ambientTemp = 296.0f;
+    float ambientTempRange = 4.0f;
+    float linearResolution = 0.01f;
     thermalCamera->SetAmbientTemperature(ambientTemp);
     EXPECT_FLOAT_EQ(ambientTemp, thermalCamera->AmbientTemperature());
     thermalCamera->SetAmbientTemperatureRange(ambientTempRange);


### PR DESCRIPTION
It was about time! 8k warnings gone!

The warnings follow these general categories:

* Warnings from Ogre 1 / 2 source code
* C4251: the good old "missing DLL interfaces". I started suppressing them one by one but eventually gave in to the blanket suppression in `CMakeLists`. This alone corresponds to **95%** of all warnings!
* Type conversion warnings
* A couple of _discarding return value of function with 'nodiscard' attribute_ - one of which was actually a bug (`this->ogreMaterial == nullptr;)`
* C4275: :warning: I'm not sure that suppressing this one is a final solution, I think that `Ogre::MaterialManager::Listener` should be in the dll interface like all other classes we're inheriting from.
* `inconsistent dll linkage` for `BaseDepthCamera` - removed the visibility since it's a header-only class and shouldn't need it
* :warning: : the `OgreSelectionBufferPrivate` class was declared as `struct` but defined as `class`. I'm not sure if fixing this doesn't break ABI.
* There were a few GCC pragmas that Windows could still see and didn't like them
* Windows wasn't liking some of our preprocessor directives (_unexpected tokens following preprocessor directive - expected a newline_), so I changed them until it was satisfied

Unfortunately, CI isn't blue yet because of #201 :cry: I added some nullptr checks to see if that would be improved with no luck...

Test build before PR with no warnings: https://build.osrfoundation.org/job/ign_rendering-pr-win/1175/

---

https://github.com/osrf/buildfarmer/issues/145