### PR TITLE
Add temperature variations to thermal camera readings based on color

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
@@ -199,6 +199,12 @@ namespace ignition
       // Documentation inherited
       public: virtual void SetDepthWriteEnabled(bool _enabled) override;
 
+      /// \brief Helper function to convert an ogre Pbs datablck to Unlit datablock
+      /// \param[in] _in Input pbs datablock
+      /// \param[out] _out Output unlit datablock
+      public: static void PbsToUnlitDatablock(Ogre::HlmsPbsDatablock *_in,
+          Ogre::HlmsUnlitDatablock *_out);
+
       /// \brief Set the texture map for this material
       /// \param[in] _texture Name of the texture.
       /// \param[in] _type Type of texture, i.e. diffuse, normal, roughness,

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -579,18 +579,23 @@ Ogre::HlmsUnlitDatablock *Ogre2Material::UnlitDatablock()
 void Ogre2Material::FillUnlitDatablock(Ogre::HlmsUnlitDatablock *_datablock)
     const
 {
-  auto tex = this->ogreDatablock->getTexture(Ogre::PBSM_DIFFUSE);
-  if (tex)
-    _datablock->setTexture(0, 0, tex);
-  auto samplerblock = this->ogreDatablock->getSamplerblock(Ogre::PBSM_DIFFUSE);
-  if (samplerblock)
-    _datablock->setSamplerblock(0, *samplerblock);
-  _datablock->setMacroblock(
-      this->ogreDatablock->getMacroblock());
-  _datablock->setBlendblock(
-      this->ogreDatablock->getBlendblock());
+  PbsToUnlitDatablock(this->ogreDatablock, _datablock);
+}
 
-  _datablock->setUseColour(true);
-  Ogre::Vector3 c = this->ogreDatablock->getDiffuse();
-  _datablock->setColour(Ogre::ColourValue(c.x, c.y, c.z));
+//////////////////////////////////////////////////
+void Ogre2Material::PbsToUnlitDatablock(Ogre::HlmsPbsDatablock *_in,
+    Ogre::HlmsUnlitDatablock *_out)
+{
+  auto tex = _in->getTexture(Ogre::PBSM_DIFFUSE);
+  if (tex)
+    _out->setTexture(0, 0, tex);
+  auto samplerblock = _in->getSamplerblock(Ogre::PBSM_DIFFUSE);
+  if (samplerblock)
+    _out->setSamplerblock(0, *samplerblock);
+  _out->setMacroblock(_in->getMacroblock());
+  _out->setBlendblock(_in->getBlendblock());
+
+  _out->setUseColour(true);
+  Ogre::Vector3 c = _in->getDiffuse();
+  _out->setColour(Ogre::ColourValue(c.x, c.y, c.z));
 }

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -253,8 +253,6 @@ void Ogre2ThermalCameraMaterialSwitcher::preRenderTargetUpdate(
         // only accept positive temperature (in kelvin)
         if (temp >= 0.0)
         {
-          // set visibility flag so thermal camera can see it
-          // item->addVisibilityFlags(0x10000000);
           for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
           {
             Ogre::SubItem *subItem = item->getSubItem(i);

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -263,6 +263,10 @@ void Ogre2ThermalCameraMaterialSwitcher::preRenderTargetUpdate(
               // normalize temperature value
               float color = temp * 100.0 /
                   static_cast<float>(std::numeric_limits<uint16_t>::max());
+
+              // set g, b, a to 0. This will be used by shaders to determine
+              // if particular fragment is a heat source or not
+              // see media/materials/programs/thermal_camera_fs.glsl
               subItem->setCustomParameter(this->customParamIdx,
                   Ogre::Vector4(color, 0, 0, 0.0));
             }
@@ -679,7 +683,6 @@ void Ogre2ThermalCamera::CreateThermalTexture()
     thermalTexDef->uav = false;
     thermalTexDef->automipmaps = false;
     thermalTexDef->hwGammaWrite = Ogre::TextureDefinitionBase::BoolFalse;
-    // thermalTexDef->depthBufferId = Ogre::DepthBuffer::POOL_NON_SHAREABLE;
     // set to default pool so that when the colorTexture pass is rendered, its
     // depth data get populated to depthTexture
     thermalTexDef->depthBufferId = Ogre::DepthBuffer::POOL_DEFAULT;

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -160,6 +160,10 @@ class ignition::rendering::Ogre2ThermalCameraPrivate
   /// \brief Pointer to material switcher
   public: std::unique_ptr<Ogre2ThermalCameraMaterialSwitcher>
       thermalMaterialSwitcher = nullptr;
+
+  /// \brief Add variation to temperature values based on object rgb values
+  /// This only affects objects that are not heat sources
+  public: bool rgbToTemp = true;
 };
 
 using namespace ignition;
@@ -607,6 +611,8 @@ void Ogre2ThermalCamera::CreateThermalTexture()
       static_cast<float>(this->ambientRange));
   psParams->setNamedConstant("heatSourceTempRange",
       static_cast<float>(this->heatSourceTempRange));
+  psParams->setNamedConstant("rgbToTemp",
+      static_cast<int>(this->dataPtr->rgbToTemp));
 
   // Create thermal camera compositor
   auto engine = Ogre2RenderEngine::Instance();
@@ -710,9 +716,7 @@ void Ogre2ThermalCamera::CreateThermalTexture()
           colorTargetDef->addPass(Ogre::PASS_CLEAR));
       passClear->mColourValue = Ogre::ColourValue(0, 0, 0);
       // scene pass
-      Ogre::CompositorPassSceneDef *passScene =
-          static_cast<Ogre::CompositorPassSceneDef *>(
-          colorTargetDef->addPass(Ogre::PASS_SCENE));
+      colorTargetDef->addPass(Ogre::PASS_SCENE);
     }
 
     // rt_input target - converts to thermal

--- a/ogre2/src/media/materials/programs/heat_signature_fs.glsl
+++ b/ogre2/src/media/materials/programs/heat_signature_fs.glsl
@@ -46,5 +46,8 @@ float mapNormalized(float num)
 void main()
 {
   float heat = texture(RT, inPs.uv0.xy).x;
+
+  // set g, b, a to 0. This will be used by thermal_camera_fs.glsl to determine
+  // if a particular fragment is a heat source or not
   fragColor = vec4(mapNormalized(heat), 0, 0, 0.0);
 }

--- a/ogre2/src/media/materials/programs/heat_signature_fs.glsl
+++ b/ogre2/src/media/materials/programs/heat_signature_fs.glsl
@@ -46,5 +46,5 @@ float mapNormalized(float num)
 void main()
 {
   float heat = texture(RT, inPs.uv0.xy).x;
-  fragColor = vec4(mapNormalized(heat), 0, 0, 1.0);
+  fragColor = vec4(mapNormalized(heat), 0, 0, 0.0);
 }

--- a/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
@@ -92,7 +92,7 @@ void main()
     if (heat > 0.0 && !isHeatSource)
     {
       // convert to grayscale: darker = warmer
-      float gray = rgba.r * 0.3 + rgba.g * 0.59 + rgba.b*0.11;
+      float gray = rgba.r * 0.299 + rgba.g * 0.587 + rgba.b*0.114;
       dNorm = 1.0 - gray;
     }
   }

--- a/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
@@ -92,6 +92,7 @@ void main()
     if (heat > 0.0 && !isHeatSource)
     {
       // convert to grayscale: darker = warmer
+      // (https://docs.opencv.org/3.4/de/d25/imgproc_color_conversions.html)
       float gray = rgba.r * 0.299 + rgba.g * 0.587 + rgba.b*0.114;
       dNorm = 1.0 - gray;
     }


### PR DESCRIPTION
The thermal camera class has functions to set heat source and ambient temperature range. This was simulated by varying an object's temperature based on its depth value (distance from the camera). This PR provides an alternative way to vary an object's temperature based on its color value.

Non-heat source objects, i.e visuals without a uniform temperature or heat signature, will now have variations in their thermal readings as a function of color - the darker the object the warmer the object. See https://github.com/ignitionrobotics/ign-gazebo/pull/578 for an example output

Note: This is not how a physical thermal camera works. The goal is to provide automated way of simulating enough temperature differences so that thermal data processing algorithms are able to segment out different objects in the scene.