### PR TITLE
Revert IgnOGRE Windows fix, it breaks downstream libraries

### DIFF
--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -37,10 +37,10 @@ set_property(
 target_link_libraries(${ogre_target}
   PUBLIC
     ${ignition-common${IGN_COMMON_VER}_LIBRARIES}
-    IgnOGRE::IgnOGRE
   PRIVATE
     ignition-plugin${IGN_PLUGIN_VER}::register
     ${OPENGL_LIBRARIES}
+    IgnOGRE::IgnOGRE
     )
 
 # Build the unit tests


### PR DESCRIPTION
This was introduced in https://github.com/ignitionrobotics/ign-rendering/pull/206, and now trying to compile `ign-gui3` against it I get:

```
CMake Error at src/plugins/CMakeLists.txt:29 (add_library):
  Target "Grid3D" links to target "IgnOGRE::IgnOGRE" but the target was not               
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?       
Call Stack (most recent call first): 
  src/plugins/CMakeLists.txt:77 (ign_gui_add_library)
  src/plugins/grid_3d/CMakeLists.txt:1 (ign_gui_add_plugin)
                                    
                                     
CMake Error at src/plugins/CMakeLists.txt:29 (add_library):
  Target "Scene3D" links to target "IgnOGRE::IgnOGRE" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?            
Call Stack (most recent call first):  
  src/plugins/CMakeLists.txt:77 (ign_gui_add_library)
  src/plugins/scene3d/CMakeLists.txt:1 (ign_gui_add_plugin)  
``` 

I originally did it to fix a Windows warning. Let's see how CI comes back. If Windows is still complaining, we may need a different fix.