### PR TITLE
Move Ogre to private link

### DIFF
--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -37,8 +37,8 @@ set_property(
 target_link_libraries(${ogre_target}
   PUBLIC
     ${ignition-common${IGN_COMMON_VER}_LIBRARIES}
-    IgnOGRE::IgnOGRE
   PRIVATE
+    IgnOGRE::IgnOGRE
     ignition-plugin${IGN_PLUGIN_VER}::register
     ${OPENGL_LIBRARIES}
     )


### PR DESCRIPTION
This makes `ign-gui4` happy and it matches how `ogre2` is built in `ign-rendering`.

Signed-off-by: Nate Koenig <nate@openrobotics.org>