### PR TITLE
Fixed spelling Desconstructor -> Destructor

### DIFF
--- a/examples/gazebo_scene_viewer/SceneManager.hh
+++ b/examples/gazebo_scene_viewer/SceneManager.hh
@@ -45,7 +45,7 @@ namespace ignition
       /// \brief Constructor
       public: SceneManager();
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: ~SceneManager();
 
       /// \brief Load resources

--- a/include/ignition/rendering/ArrowVisual.hh
+++ b/include/ignition/rendering/ArrowVisual.hh
@@ -31,7 +31,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE ArrowVisual :
       public virtual CompositeVisual
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~ArrowVisual() { }
 
       /// \brief Get arrow-head visual

--- a/include/ignition/rendering/AxisVisual.hh
+++ b/include/ignition/rendering/AxisVisual.hh
@@ -31,7 +31,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE AxisVisual :
       public virtual CompositeVisual
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~AxisVisual() { }
 
       /// \brief set true to show the axis heads, false otherwise

--- a/include/ignition/rendering/Camera.hh
+++ b/include/ignition/rendering/Camera.hh
@@ -44,7 +44,7 @@ namespace ignition
       public: typedef std::function<void(const void*, unsigned int,
           unsigned int, unsigned int, const std::string&)> NewFrameListener;
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Camera() { }
 
       /// \brief Get the image width in pixels

--- a/include/ignition/rendering/CompositeVisual.hh
+++ b/include/ignition/rendering/CompositeVisual.hh
@@ -32,7 +32,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE CompositeVisual :
       public virtual Visual
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~CompositeVisual() { }
     };
     }

--- a/include/ignition/rendering/Geometry.hh
+++ b/include/ignition/rendering/Geometry.hh
@@ -34,7 +34,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE Geometry :
       public virtual Object
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Geometry() { }
 
       /// \brief Determine if this Geometry is attached to a Visual

--- a/include/ignition/rendering/Image.hh
+++ b/include/ignition/rendering/Image.hh
@@ -48,7 +48,7 @@ namespace ignition
       public: Image(unsigned int _width, unsigned int _height,
                   PixelFormat _format);
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: ~Image();
 
       /// \brief Get image width in pixels

--- a/include/ignition/rendering/Light.hh
+++ b/include/ignition/rendering/Light.hh
@@ -32,7 +32,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE Light :
       public virtual Node
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Light() { }
 
       /// \brief Get the diffuse color
@@ -136,7 +136,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE PointLight :
       public virtual Light
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~PointLight() { }
     };
 
@@ -145,7 +145,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE SpotLight :
       public virtual Light
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~SpotLight() { }
 
       /// \brief Get direction of the light

--- a/include/ignition/rendering/Material.hh
+++ b/include/ignition/rendering/Material.hh
@@ -47,7 +47,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE Material :
       public virtual Object
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Material() { }
 
       /// \brief Determine if lighting affects this material

--- a/include/ignition/rendering/Mesh.hh
+++ b/include/ignition/rendering/Mesh.hh
@@ -126,7 +126,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE SubMesh :
       public virtual Object
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~SubMesh() { }
 
       /// \brief Get the currently assigned material

--- a/include/ignition/rendering/Node.hh
+++ b/include/ignition/rendering/Node.hh
@@ -37,7 +37,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE Node :
       public virtual Object
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Node() { }
 
       /// \brief Determine if this Node is attached to another Node.

--- a/include/ignition/rendering/OrbitViewController.hh
+++ b/include/ignition/rendering/OrbitViewController.hh
@@ -42,13 +42,13 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE OrbitViewController
         : public virtual ViewController
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: OrbitViewController();
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: explicit OrbitViewController(const CameraPtr &_camera);
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~OrbitViewController();
 
       /// \brief Set the camera that will be controlled by this view controller.

--- a/include/ignition/rendering/RenderEngine.hh
+++ b/include/ignition/rendering/RenderEngine.hh
@@ -35,7 +35,7 @@ namespace ignition
     /// creating, storing, and destroying scenes.
     class IGNITION_RENDERING_VISIBLE RenderEngine
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~RenderEngine() { }
 
       /// \brief Load any necessary resources to set up render-engine. This

--- a/include/ignition/rendering/RenderEngineManager.hh
+++ b/include/ignition/rendering/RenderEngineManager.hh
@@ -49,7 +49,7 @@ namespace ignition
       /// \brief Constructor
       public: RenderEngineManager();
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: ~RenderEngineManager();
 
       /// \brief Get the number of available render-engines

--- a/include/ignition/rendering/RenderTarget.hh
+++ b/include/ignition/rendering/RenderTarget.hh
@@ -103,7 +103,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE RenderTexture :
       public virtual RenderTarget
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~RenderTexture() { }
 
       /// \brief Returns the OpenGL texture Id. A valid Id is returned only
@@ -119,7 +119,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE RenderWindow :
       public virtual RenderTarget
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~RenderWindow() { }
 
       /// \brief Get the window handle that the render window is attached to.

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -47,7 +47,7 @@ namespace ignition
     /// factory for all scene objects.
     class IGNITION_RENDERING_VISIBLE Scene
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Scene() { }
 
       /// \brief Load scene-specific resources

--- a/include/ignition/rendering/Storage.hh
+++ b/include/ignition/rendering/Storage.hh
@@ -56,7 +56,7 @@ namespace ignition
       /// \brief Shared pointer to const T
       typedef std::shared_ptr<const T> ConstTPtr;
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Map() { }
 
       /// \brief Get the number of elements in this map
@@ -121,7 +121,7 @@ namespace ignition
       /// \brief Shared pointer to const T
       typedef std::shared_ptr<const T> ConstTPtr;
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Store() { }
 
       /// \brief Get number of elements in this store
@@ -243,7 +243,7 @@ namespace ignition
       /// \brief Shared pointer to const TStore
       typedef std::shared_ptr<const TStore> ConstTStorePtr;
 
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~CompositeStore() { }
 
       /// \brief Get number of Stores

--- a/include/ignition/rendering/ViewController.hh
+++ b/include/ignition/rendering/ViewController.hh
@@ -34,7 +34,7 @@ namespace ignition
     /// \brief A camera view controller
     class IGNITION_RENDERING_VISIBLE ViewController
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~ViewController() { }
 
       /// \brief Set the camera that will be controlled by this view controller.

--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -37,7 +37,7 @@ namespace ignition
     class IGNITION_RENDERING_VISIBLE Visual :
       public virtual Node
     {
-      /// \brief Deconstructor
+      /// \brief Destructor
       public: virtual ~Visual() { }
 
       /// \brief Get the number of geometries attached to this visual


### PR DESCRIPTION
A simple fix in the documentation

Signed-off-by: ahcorde <ahcorde@gmail.com>