### PR TITLE
Fixed transform control example

### DIFF
--- a/include/ignition/rendering/Utils.hh
+++ b/include/ignition/rendering/Utils.hh
@@ -37,7 +37,6 @@ namespace ignition
     /// \brief Get the screen scaling factor.
     /// \param[out] _xScale The X screen scaling factor.
     /// \param[out] _yScale The Y screen scaling factor.
-    /// \return The screen scaling factor.
     IGNITION_RENDERING_VISIBLE
     void screenScalingFactor(float &_xScale, float &_yScale);
     }

--- a/include/ignition/rendering/Utils.hh
+++ b/include/ignition/rendering/Utils.hh
@@ -34,6 +34,12 @@ namespace ignition
     /// \return The screen scaling factor.
     IGNITION_RENDERING_VISIBLE
     float screenScalingFactor();
+    /// \brief Get the screen scaling factor.
+    /// \param[out] _xScale The X screen scaling factor.
+    /// \param[out] _yScale The Y screen scaling factor.
+    /// \return The screen scaling factor.
+    IGNITION_RENDERING_VISIBLE
+    void screenScalingFactor(float &_xScale, float &_yScale);
     }
   }
 }

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -216,10 +216,11 @@ VisualPtr OgreCamera::VisualAt(const ignition::math::Vector2i
     }
   }
 
-  float ratio = screenScalingFactor();
+  float xScale, YScale;
+  screenScalingFactor(xScale, YScale);
   ignition::math::Vector2i mousePos(
-      static_cast<int>(std::rint(ratio * _mousePos.X())),
-      static_cast<int>(std::rint(ratio * _mousePos.Y())));
+      static_cast<int>(std::rint(xScale * _mousePos.X())),
+      static_cast<int>(std::rint(YScale * _mousePos.Y())));
 
   Ogre::Entity *entity = this->selectionBuffer->OnSelectionClick(
       mousePos.X(), mousePos.Y());

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -216,11 +216,11 @@ VisualPtr OgreCamera::VisualAt(const ignition::math::Vector2i
     }
   }
 
-  float xScale, YScale;
-  screenScalingFactor(xScale, YScale);
+  float xScale, yScale;
+  screenScalingFactor(xScale, yScale);
   ignition::math::Vector2i mousePos(
       static_cast<int>(std::rint(xScale * _mousePos.X())),
-      static_cast<int>(std::rint(YScale * _mousePos.Y())));
+      static_cast<int>(std::rint(yScale * _mousePos.Y())));
 
   Ogre::Entity *entity = this->selectionBuffer->OnSelectionClick(
       mousePos.X(), mousePos.Y());

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -201,10 +201,11 @@ VisualPtr Ogre2Camera::VisualAt(const ignition::math::Vector2i &_mousePos)
     }
   }
 
-  float ratio = screenScalingFactor();
+  float xScale, YScale;
+  screenScalingFactor(xScale, YScale);
   ignition::math::Vector2i mousePos(
-      static_cast<int>(std::rint(ratio * _mousePos.X())),
-      static_cast<int>(std::rint(ratio * _mousePos.Y())));
+      static_cast<int>(std::rint(xScale * _mousePos.X())),
+      static_cast<int>(std::rint(YScale * _mousePos.Y())));
 
   Ogre::Item *ogreItem = this->selectionBuffer->OnSelectionClick(
       mousePos.X(), mousePos.Y());

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -201,11 +201,11 @@ VisualPtr Ogre2Camera::VisualAt(const ignition::math::Vector2i &_mousePos)
     }
   }
 
-  float xScale, YScale;
-  screenScalingFactor(xScale, YScale);
+  float xScale, yScale;
+  screenScalingFactor(xScale, yScale);
   ignition::math::Vector2i mousePos(
       static_cast<int>(std::rint(xScale * _mousePos.X())),
-      static_cast<int>(std::rint(YScale * _mousePos.Y())));
+      static_cast<int>(std::rint(yScale * _mousePos.Y())));
 
   Ogre::Item *ogreItem = this->selectionBuffer->OnSelectionClick(
       mousePos.X(), mousePos.Y());


### PR DESCRIPTION
I found an issue in the rendering examples, in particular in the `transform_control` example. When I try to click in the arrows or in one of the other Gizmo visuals is not getting the visual. I need to click in other part of the screen. See the gif below.

![transform_bad](https://user-images.githubusercontent.com/1933907/106288053-d757fd00-6247-11eb-9ffa-11e7e37a45b3.gif)

With this fix I'm able to get the right visual:

![transform_ok](https://user-images.githubusercontent.com/1933907/106288270-1d14c580-6248-11eb-82cd-fb2d6627b486.gif)

This is also happening in ign-gazebo.

Signed-off-by: ahcorde <ahcorde@gmail.com>