### PR TITLE
Fix converting Pbs to Unlit material conversion

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -585,16 +585,23 @@ Ogre::HlmsUnlitDatablock *Ogre2Material::UnlitDatablock()
 void Ogre2Material::FillUnlitDatablock(Ogre::HlmsUnlitDatablock *_datablock)
     const
 {
-  auto tex = this->ogreDatablock->getTexture(Ogre::PBSM_DIFFUSE);
-  if (tex)
-    _datablock->setTexture(0, 0, tex);
+  if (!this->textureName.empty())
+  {
+    std::string baseName = common::basename(this->textureName);
+    Ogre::HlmsTextureManager *hlmsTextureManager =
+        this->ogreHlmsPbs->getHlmsManager()->getTextureManager();
+    Ogre::HlmsTextureManager::TextureLocation texLocation =
+        hlmsTextureManager->createOrRetrieveTexture(baseName,
+        this->ogreDatablock->suggestMapTypeBasedOnTextureType(
+        Ogre::PBSM_DIFFUSE));
+    _datablock->setTexture(0, texLocation.xIdx, texLocation.texture);
+  }
+
   auto samplerblock = this->ogreDatablock->getSamplerblock(Ogre::PBSM_DIFFUSE);
   if (samplerblock)
     _datablock->setSamplerblock(0, *samplerblock);
-  _datablock->setMacroblock(
-      this->ogreDatablock->getMacroblock());
-  _datablock->setBlendblock(
-      this->ogreDatablock->getBlendblock());
+  _datablock->setMacroblock(this->ogreDatablock->getMacroblock());
+  _datablock->setBlendblock(this->ogreDatablock->getBlendblock());
 
   _datablock->setUseColour(true);
   Ogre::Vector3 c = this->ogreDatablock->getDiffuse();

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -348,7 +348,7 @@ void Ogre2ThermalCameraMaterialSwitcher::preRenderTargetUpdate(
         Ogre::AxisAlignedBox box = Ogre::AxisAlignedBox(aabb.getMinimum(),
             aabb.getMaximum());
 
-        // we will be converting rgb values to tempearture values in shaders
+        // we will be converting rgb values to temperature values in shaders
         // but we want to make sure the object rgb values are not affected by
         // lighting, so disable lighting
         // Also check if objects are within camera view


### PR DESCRIPTION
Thermal camera uses unlit material for background objects. When visualizing thermal camera output in a more complex environment, I noticed that the textures are not correct copied over from Pbs to Unlit datablock. The changes here make sure we set the correct texture file to the unlit material.


Signed-off-by: Ian Chen <ichen@osrfoundation.org>