### PR TITLE
Add support for 8 bit thermal camera image format

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 ### Ignition Rendering 4.X
 
+### Ignition Rendering 4.x.x (202x-xx-xx)
+
+1. Add support for 8 bit thermal camera image format
+    * [Pull Request #235](https://github.com/ignitionrobotics/ign-rendering/pull/235)
+
 ### Ignition Rendering 4.3.1 (2021-02-03)
 
 1. Fix converting Pbs to Unlit material conversion (#230)

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -79,7 +79,8 @@ class Ogre2ThermalCameraMaterialSwitcher : public Ogre::RenderTargetListener
   /// \param[in] _format Inage format
   public: void SetFormat(PixelFormat _format);
 
-  /// \brieft Set linear resolution
+  /// \brief Set temperature linear resolution
+  /// \param[in] _resolution Temperature linear resolution
   public: void SetLinearResolution(double _resolution);
 
   /// \brief Callback when a render target is about to be rendered
@@ -133,7 +134,7 @@ class Ogre2ThermalCameraMaterialSwitcher : public Ogre::RenderTargetListener
   /// \brief thermal camera image format
   private: PixelFormat format = PF_L16;
 
-  /// \brief thermal camera image format
+  /// \brief thermal camera image bit depth
   private: int bitDepth = 16u;
 };
 }

--- a/ogre2/src/media/materials/programs/heat_signature_fs.glsl
+++ b/ogre2/src/media/materials/programs/heat_signature_fs.glsl
@@ -35,12 +35,16 @@ out vec4 fragColor;
 uniform float minTemp = 0.0;
 uniform float maxTemp = 100.0;
 
+uniform int bitDepth;
+uniform float resolution;
+
 // map a temperature from the [0, 655.35] range to the [minTemp, maxTemp]
-// range (655.35 is the largest Kelvin value allowed)
+// range (655.35 is the largest Kelvin value allowed for 16 bit with
+// 10mK resolution)
 float mapNormalized(float num)
 {
   float mappedKelvin = ((maxTemp - minTemp) * num) + minTemp;
-  return mappedKelvin / 655.35;
+  return mappedKelvin / (((1 << bitDepth) - 1.0) * resolution);
 }
 
 void main()

--- a/ogre2/src/media/materials/programs/heat_signature_fs.glsl
+++ b/ogre2/src/media/materials/programs/heat_signature_fs.glsl
@@ -38,9 +38,8 @@ uniform float maxTemp = 100.0;
 uniform int bitDepth;
 uniform float resolution;
 
-// map a temperature from the [0, 655.35] range to the [minTemp, maxTemp]
-// range (655.35 is the largest Kelvin value allowed for 16 bit with
-// 10mK resolution)
+// map a temperature from the [min, max] range to the user defined
+// [minTemp, maxTemp] range
 float mapNormalized(float num)
 {
   float mappedKelvin = ((maxTemp - minTemp) * num) + minTemp;

--- a/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
@@ -38,6 +38,7 @@ uniform float resolution;
 uniform float heatSourceTempRange;
 uniform float ambient;
 uniform int rgbToTemp;
+uniform int bitDepth;
 
 float getDepth(vec2 uv)
 {
@@ -51,6 +52,7 @@ void main()
   // temperature defaults to ambient
   float temp = ambient;
   float heatRange = range;
+  int bitMaxValue = (1 << bitDepth) - 1;
 
   // dNorm value is between [0, 1]. It is used to for varying temperature
   // value of a fragment.
@@ -74,7 +76,9 @@ void main()
     if (isHeatSource)
     {
       // heat is normalized so convert back to work in kelvin
-      temp = heat * 655.35;
+      // for 16 bit camera and 0.01 resolution:
+      //     ((1 << bitDepth) - 1)* resolution = 655.35
+      temp = heat * bitMaxValue * resolution;
 
       // set temperature variation for heat source
       heatRange = heatSourceTempRange;
@@ -115,7 +119,8 @@ void main()
   // apply resolution factor
   temp /= resolution;
   // normalize
-  temp /= 65535.0;
+  float denorm = float(bitMaxValue);
+  temp /= denorm;
 
   fragColor = vec4(temp, 0, 0, 1.0);
 }

--- a/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
@@ -77,7 +77,7 @@ void main()
     {
       // heat is normalized so convert back to work in kelvin
       // for 16 bit camera and 0.01 resolution:
-      //     ((1 << bitDepth) - 1)* resolution = 655.35
+      //     ((1 << bitDepth) - 1) * resolution = 655.35
       temp = heat * bitMaxValue * resolution;
 
       // set temperature variation for heat source

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -316,6 +316,10 @@ void ThermalCameraTest::ThermalCameraBoxes8Bit(
     double farDist = 10.0;
     double nearDist = 0.15;
     double hfov = 1.05;
+    // set min max values based on thermal camera spec
+    // using the Vividia HTi HT-301 camera as example:
+    // https://hti-instrument.com/products/ht-301-mobile-phone-thermal-imager
+    // The range is ~= -20 to 400 degree Celsius
     double minTemp = 253.0;
     double maxTemp = 673.0;
     // Create thermal camera

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -40,7 +40,7 @@ void OnNewThermalFrame(uint16_t *_scanDest, const uint16_t *_scan,
                   unsigned int _channels,
                   const std::string &_format)
 {
-  // EXPECT_EQ("L16", _format);
+  EXPECT_TRUE(_format == "L16" || _format == "L8");
   EXPECT_EQ(50u, _width);
   EXPECT_EQ(50u, _height);
   EXPECT_EQ(1u, _channels);
@@ -400,8 +400,6 @@ void ThermalCameraTest::ThermalCameraBoxes8Bit(
         ambientTempRange);
     EXPECT_FLOAT_EQ(thermalData[right], thermalData[left]);
     EXPECT_NEAR(boxTemp, thermalData[mid] * linearResolution, boxTempRange);
-
-    std::cerr << " mid " << thermalData[mid] << std::endl;
 
     // move box in front of near clip plane and verify the thermal
     // image returns all box temperature values

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -23,10 +23,11 @@
 
 #include "test_config.h"  // NOLINT(build/include)
 
-#include "ignition/rendering/ThermalCamera.hh"
+#include "ignition/rendering/PixelFormat.hh"
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/RenderingIface.hh"
 #include "ignition/rendering/Scene.hh"
+#include "ignition/rendering/ThermalCamera.hh"
 
 #define DEPTH_TOL 1e-4
 #define DOUBLE_TOL 1e-6
@@ -39,7 +40,7 @@ void OnNewThermalFrame(uint16_t *_scanDest, const uint16_t *_scan,
                   unsigned int _channels,
                   const std::string &_format)
 {
-  EXPECT_EQ("L16", _format);
+  // EXPECT_EQ("L16", _format);
   EXPECT_EQ(50u, _width);
   EXPECT_EQ(50u, _height);
   EXPECT_EQ(1u, _channels);
@@ -58,6 +59,9 @@ class ThermalCameraTest: public testing::Test,
   // (if _useHeatSignature is true, applying a heat signature is tested)
   public: void ThermalCameraBoxes(const std::string &_renderEngine,
               const bool _useHeatSignature);
+
+  // Test 8 bit thermal camera output
+  public: void ThermalCameraBoxes8Bit(const std::string &_renderEngine);
 
   // Path to test textures
   public: const std::string TEST_MEDIA_PATH =
@@ -256,6 +260,193 @@ void ThermalCameraTest::ThermalCameraBoxes(
   ignition::rendering::unloadEngine(engine->Name());
 }
 
+//////////////////////////////////////////////////
+void ThermalCameraTest::ThermalCameraBoxes8Bit(
+    const std::string &_renderEngine)
+{
+  int imgWidth = 50;
+  int imgHeight = 50;
+  double aspectRatio = imgWidth/imgHeight;
+
+  double unitBoxSize = 1.0;
+  ignition::math::Vector3d boxPosition(1.8, 0.0, 0.0);
+
+  // Only ogre2 supports 8 bit image format
+  if (_renderEngine.compare("ogre2") != 0)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' doesn't support 8 bit thermal cameras" << std::endl;
+    return;
+  }
+
+  // Setup ign-rendering with an empty scene
+  auto *engine = ignition::rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ignition::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  // red background
+  scene->SetBackgroundColor(1.0, 0.0, 0.0);
+
+  // Create an scene with a box in it
+  scene->SetAmbientLight(1.0, 1.0, 1.0);
+  ignition::rendering::VisualPtr root = scene->RootVisual();
+
+  // create box visual
+  ignition::rendering::VisualPtr box = scene->CreateVisual();
+  box->AddGeometry(scene->CreateBox());
+  box->SetOrigin(0.0, 0.0, 0.0);
+  box->SetLocalPosition(boxPosition);
+  box->SetLocalRotation(0, 0, 0);
+  box->SetLocalScale(unitBoxSize, unitBoxSize, unitBoxSize);
+
+  // set box temperature
+  float boxTemp = 310.0;
+  box->SetUserData("temperature", boxTemp);
+
+  root->AddChild(box);
+  {
+    // range is hardcoded in shaders
+    float boxTempRange = 3.0;
+    double farDist = 10.0;
+    double nearDist = 0.15;
+    double hfov = 1.05;
+    double minTemp = 253.0;
+    double maxTemp = 673.0;
+    // Create thermal camera
+    auto thermalCamera = scene->CreateThermalCamera("ThermalCamera");
+    ASSERT_NE(thermalCamera, nullptr);
+
+    ignition::math::Pose3d testPose(ignition::math::Vector3d(0, 0, 0),
+        ignition::math::Quaterniond::Identity);
+    thermalCamera->SetLocalPose(testPose);
+
+    // Configure thermal camera
+    thermalCamera->SetImageWidth(imgWidth);
+    EXPECT_EQ(thermalCamera->ImageWidth(),
+      static_cast<unsigned int>(imgWidth));
+    thermalCamera->SetImageHeight(imgHeight);
+    EXPECT_EQ(thermalCamera->ImageHeight(),
+      static_cast<unsigned int>(imgHeight));
+    thermalCamera->SetFarClipPlane(farDist);
+    EXPECT_NEAR(thermalCamera->FarClipPlane(), farDist, DOUBLE_TOL);
+    thermalCamera->SetNearClipPlane(nearDist);
+    EXPECT_NEAR(thermalCamera->NearClipPlane(), nearDist, DOUBLE_TOL);
+    thermalCamera->SetAspectRatio(aspectRatio);
+    EXPECT_NEAR(thermalCamera->AspectRatio(), aspectRatio, DOUBLE_TOL);
+    thermalCamera->SetHFOV(hfov);
+    EXPECT_NEAR(thermalCamera->HFOV().Radian(), hfov, DOUBLE_TOL);
+
+    // set bit depth
+    thermalCamera->SetImageFormat(ignition::rendering::PF_L8);
+    EXPECT_EQ(ignition::rendering::PF_L8, thermalCamera->ImageFormat());
+
+    // set min max temp
+    thermalCamera->SetMinTemperature(minTemp);
+    EXPECT_DOUBLE_EQ(minTemp, thermalCamera->MinTemperature());
+    thermalCamera->SetMaxTemperature(maxTemp);
+    EXPECT_DOUBLE_EQ(maxTemp, thermalCamera->MaxTemperature());
+
+    // thermal-specific params
+    // set room temperature: 294 ~ 298 Kelvin
+    float ambientTemp = 296.0f;
+    float ambientTempRange = 4.0f;
+
+    // 8 bit format so higher number here (lower resolution)
+    // +- 3 degrees
+    float linearResolution = 3.0f;
+    thermalCamera->SetAmbientTemperature(ambientTemp);
+    EXPECT_FLOAT_EQ(ambientTemp, thermalCamera->AmbientTemperature());
+    thermalCamera->SetAmbientTemperatureRange(ambientTempRange);
+    EXPECT_FLOAT_EQ(ambientTempRange, thermalCamera->AmbientTemperatureRange());
+    thermalCamera->SetLinearResolution(linearResolution);
+    EXPECT_FLOAT_EQ(linearResolution, thermalCamera->LinearResolution());
+    thermalCamera->SetHeatSourceTemperatureRange(boxTempRange);
+    EXPECT_FLOAT_EQ(boxTempRange, thermalCamera->HeatSourceTemperatureRange());
+    scene->RootVisual()->AddChild(thermalCamera);
+
+    // Set a callback on the camera sensor to get a thermal camera frame
+    // todo(anyone) change this to uint8_t when thermal cameras supports a
+    // ConnectNewThermalFrame event that provides this format
+    uint16_t *thermalData = new uint16_t[imgHeight * imgWidth];
+    ignition::common::ConnectionPtr connection =
+      thermalCamera->ConnectNewThermalFrame(
+          std::bind(&::OnNewThermalFrame, thermalData,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    EXPECT_NE(nullptr, connection);
+
+    // Update once to create image
+    thermalCamera->Update();
+
+    // thermal image indices
+    int midWidth = static_cast<int>(thermalCamera->ImageWidth() * 0.5);
+    int midHeight = static_cast<int>(thermalCamera->ImageHeight() * 0.5);
+    int mid = midHeight * thermalCamera->ImageWidth() + midWidth -1;
+    int left = midHeight * thermalCamera->ImageWidth();
+    int right = (midHeight+1) * thermalCamera->ImageWidth() - 1;
+
+    // verify temperature
+    // Box should be in the middle of image and return box temp
+    // Left and right side of the image frame should be ambient temp
+    EXPECT_NEAR(ambientTemp, thermalData[left] * linearResolution,
+        ambientTempRange);
+    EXPECT_NEAR(ambientTemp, thermalData[right] * linearResolution,
+        ambientTempRange);
+    EXPECT_FLOAT_EQ(thermalData[right], thermalData[left]);
+    EXPECT_NEAR(boxTemp, thermalData[mid] * linearResolution, boxTempRange);
+
+    std::cerr << " mid " << thermalData[mid] << std::endl;
+
+    // move box in front of near clip plane and verify the thermal
+    // image returns all box temperature values
+    ignition::math::Vector3d boxPositionNear(
+        unitBoxSize * 0.5 + nearDist * 0.5, 0.0, 0.0);
+    box->SetLocalPosition(boxPositionNear);
+    thermalCamera->Update();
+
+    for (unsigned int i = 0; i < thermalCamera->ImageHeight(); ++i)
+    {
+      unsigned int step = i * thermalCamera->ImageWidth();
+      for (unsigned int j = 0; j < thermalCamera->ImageWidth(); ++j)
+      {
+        float temp = thermalData[step + j] * linearResolution;
+        EXPECT_NEAR(boxTemp, temp, boxTempRange);
+      }
+    }
+
+    // move box beyond far clip plane and verify the thermal
+    // image returns all ambient temperature values
+    ignition::math::Vector3d boxPositionFar(
+        unitBoxSize * 0.5 + farDist * 1.5, 0.0, 0.0);
+    box->SetLocalPosition(boxPositionFar);
+    thermalCamera->Update();
+
+    for (unsigned int i = 0; i < thermalCamera->ImageHeight(); ++i)
+    {
+      unsigned int step = i * thermalCamera->ImageWidth();
+      for (unsigned int j = 0; j < thermalCamera->ImageWidth(); ++j)
+      {
+        float temp = thermalData[step + j] * linearResolution;
+        EXPECT_NEAR(ambientTemp, temp, ambientTempRange);
+      }
+    }
+
+    // Clean up
+    connection.reset();
+    delete [] thermalData;
+  }
+
+  engine->DestroyScene(scene);
+  ignition::rendering::unloadEngine(engine->Name());
+}
+
+
 TEST_P(ThermalCameraTest, ThermalCameraBoxesUniformTemp)
 {
   ThermalCameraBoxes(GetParam(), false);
@@ -264,6 +455,11 @@ TEST_P(ThermalCameraTest, ThermalCameraBoxesUniformTemp)
 TEST_P(ThermalCameraTest, ThermalCameraBoxesHeatSignature)
 {
   ThermalCameraBoxes(GetParam(), true);
+}
+
+TEST_P(ThermalCameraTest, ThermalCameraBoxesUniformTemp8Bit)
+{
+  ThermalCameraBoxes8Bit(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(ThermalCamera, ThermalCameraTest,

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -266,7 +266,7 @@ void ThermalCameraTest::ThermalCameraBoxes8Bit(
 {
   int imgWidth = 50;
   int imgHeight = 50;
-  double aspectRatio = imgWidth/imgHeight;
+  double aspectRatio = imgWidth / imgHeight;
 
   double unitBoxSize = 1.0;
   ignition::math::Vector3d boxPosition(1.8, 0.0, 0.0);
@@ -312,7 +312,7 @@ void ThermalCameraTest::ThermalCameraBoxes8Bit(
   root->AddChild(box);
   {
     // range is hardcoded in shaders
-    float boxTempRange = 3.0;
+    float boxTempRange = 3.0f;
     double farDist = 10.0;
     double nearDist = 0.15;
     double hfov = 1.05;


### PR DESCRIPTION

## Summary

The existing thermal camera implementation produces image output in 16 bit format and that's being hard coded in various places including the shaders. This PR makes the implementation slightly more generic to support generating 8 bit data.

There are a few workarounds that had to be done so that this change does not break ABI. For example, the new thermal image event's function callback is hard coded to `uint16_t` and that can not be changed so unfortunately I had to workaround this by packing 8 bit data into 16 bit array. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge**

---


