### PR TITLE
More verbose messages when failing to load render engine

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -471,42 +471,64 @@ bool RenderEngineManagerPrivate::LoadEnginePlugin(
     return false;
   }
 
-  std::string pluginName = *pluginNames.begin();
-  if (pluginName.empty())
+  auto engineNames = pluginLoader.PluginsImplementing<
+      ignition::rendering::RenderEnginePlugin>();
+
+  if (engineNames.empty())
   {
-    ignerr << "Failed to load plugin [" << _filename <<
-              "] : couldn't load library on path [" << pathToLib <<
-              "]." << std::endl;
+    std::stringstream error;
+    error << "Found no render engine plugins in ["
+          << _filename << "], available interfaces are:"
+          << std::endl;
+    for (auto pluginName : pluginNames)
+    {
+      error << "- " << pluginName << std::endl;
+    }
+    ignerr << error.str();
     return false;
   }
 
-  auto commonPlugin = this->pluginLoader.Instantiate(pluginName);
-  if (!commonPlugin)
+  auto engineName = *engineNames.begin();
+  if (engineNames.size() > 1)
   {
-    ignerr << "Failed to load plugin [" << _filename <<
-              "] : couldn't instantiate plugin on path [" << pathToLib <<
-              "]." << std::endl;
-    return false;
+    std::stringstream warn;
+    warn << "Found multiple render engine plugins in ["
+          << _filename << "]:"
+          << std::endl;
+    for (auto pluginName : engineNames)
+    {
+      warn << "- " << pluginName << std::endl;
+    }
+    warn << "Loading [" << engineName << "]." << std::endl;
+    ignwarn << warn.str();
   }
 
-  auto plugin =
-      commonPlugin->QueryInterface<ignition::rendering::RenderEnginePlugin>();
+  auto plugin = pluginLoader.Instantiate(engineName);
   if (!plugin)
   {
-    ignerr << "Failed to load plugin [" << _filename <<
-              "] : couldn't get interface [" << pluginName <<
-              "]." << std::endl;
+    ignerr << "Failed to instantiate plugin [" << engineName << "]"
+           << std::endl;
+    return false;
+  }
+
+  auto renderPlugin =
+      plugin->QueryInterface<ignition::rendering::RenderEnginePlugin>();
+
+  if (!renderPlugin)
+  {
+    ignerr << "Failed to query interface from [" << engineName << "]"
+           << std::endl;
     return false;
   }
 
   // This triggers the engine to be instantiated
   {
     std::lock_guard<std::recursive_mutex> lock(this->enginesMutex);
-    this->engines[_filename] = plugin->Engine();
+    this->engines[_filename] = renderPlugin->Engine();
   }
 
   // store engine plugin data so plugin can be unloaded later
-  this->enginePlugins[_filename] = pluginName;
+  this->enginePlugins[_filename] = engineName;
 
   return true;
 }


### PR DESCRIPTION
I'm working on this as part of https://github.com/ignitionrobotics/ign-sensors/issues/18, but the current state of this PR applies even outside that context.

## Summary

This is making error messages more verbose when loading a render engine:

* If no render engine interface was found, but other interfaces were, print the names of the other interfaces.
* If multiple render engines were found, warn the user that there were others, and keep choosing a random one (note that `pluginNames` is an `unordered_set`, so getting `begin` is "random").

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] ~~Added example world and/or tutorial~~
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
