### PR TITLE
Fixed OBJ textures

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -395,6 +395,9 @@ Ogre::HlmsPbsDatablock *Ogre2Material::Datablock() const
 void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
   Ogre::PbsTextureTypes _type)
 {
+  // FIXME(anyone) need to keep baseName = _texture for all meshes. Refer to
+  // https://github.com/ignitionrobotics/ign-rendering/issues/139
+  // for more details
   std::string baseName = _texture;
   if (common::isFile(_texture))
   {
@@ -413,7 +416,7 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
     }
   }
 
-  // check if the model is a OBJ file
+  // temp workaround check if the model is a OBJ file
   {
     size_t idx = _texture.rfind("meshes");
     if (idx != std::string::npos)

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -396,21 +396,8 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
   Ogre::PbsTextureTypes _type)
 {
   std::string baseName = _texture;
-  bool isObj = false;
   if (common::isFile(_texture))
   {
-    // check if the model is a OBJ file
-    {
-      size_t idx = _texture.rfind("meshes");
-      if (idx != std::string::npos)
-      {
-        std::string objFile =
-            common::joinPaths(_texture.substr(0, idx), "meshes", "model.obj");
-        if (common::isFile(objFile))
-          isObj = true;
-      }
-    }
-
     baseName = common::basename(_texture);
     size_t idx = _texture.rfind(baseName);
     if (idx != std::string::npos)
@@ -423,6 +410,18 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
         Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
             dirPath, "FileSystem", "General");
       }
+    }
+  }
+
+  // check if the model is a OBJ file
+  {
+    size_t idx = _texture.rfind("meshes");
+    if (idx != std::string::npos)
+    {
+      std::string objFile =
+        common::joinPaths(_texture.substr(0, idx), "meshes", "model.obj");
+      if (common::isFile(objFile))
+        baseName = _texture;
     }
   }
 
@@ -439,9 +438,6 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
 
   this->ogreDatablock->setTexture(_type, texLocation.xIdx, texLocation.texture,
       &samplerBlockRef);
-
-  if (isObj)
-    hlmsTextureManager->destroyTexture(baseName);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -396,8 +396,22 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
   Ogre::PbsTextureTypes _type)
 {
   std::string baseName = _texture;
+  bool isObj = false;
   if (common::isFile(_texture))
   {
+
+    // check if the model is a OBJ file
+    {
+      size_t idx = _texture.rfind("meshes");
+      if (idx != std::string::npos)
+      {
+        std::string objFile =
+            common::joinPaths(_texture.substr(0, idx), "meshes", "model.obj");
+        if (common::isFile(objFile))
+          isObj = true;
+      }
+    }
+
     baseName = common::basename(_texture);
     size_t idx = _texture.rfind(baseName);
     if (idx != std::string::npos)
@@ -426,6 +440,9 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
 
   this->ogreDatablock->setTexture(_type, texLocation.xIdx, texLocation.texture,
       &samplerBlockRef);
+
+  if (isObj)
+    hlmsTextureManager->destroyTexture(baseName);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -399,7 +399,6 @@ void Ogre2Material::SetTextureMapImpl(const std::string &_texture,
   bool isObj = false;
   if (common::isFile(_texture))
   {
-
     // check if the model is a OBJ file
     {
       size_t idx = _texture.rfind("meshes");


### PR DESCRIPTION
# Bug Fix

Resolves issue https://github.com/ignitionrobotics/ign-rendering/issues/139 for OBJ files only

## Summary
The Ogre 2 plugin uses a texture's filename to uniquely identify each texture, so any textures named `texture.png` are treated the same, even if they're in different directories. The new change checks to see if the mesh has an OBJ file (`model.obj`), if it does it sets `baseName` to be the full path (instead of `texture.png`).

For example, load this world on `ign-gazebo`:

<details><summary>world.sdf</summary>
<p>

```
<?xml version="1.0" ?>
<sdf version="1.6">
  <world name="shapes">
    <plugin
      filename="ignition-gazebo-physics-system"
      name="ignition::gazebo::systems::Physics">
    </plugin>
    <plugin
      filename="ignition-gazebo-scene-broadcaster-system"
      name="ignition::gazebo::systems::SceneBroadcaster">
    </plugin>

    <gui fullscreen="0">

      <!-- 3D scene -->
      <plugin filename="GzScene3D" name="3D View">
        <ignition-gui>
          <title>3D View</title>
          <property type="bool" key="showTitleBar">false</property>
          <property type="string" key="state">docked</property>
        </ignition-gui>

        <engine>ogre2</engine>
        <scene>scene</scene>
        <ambient_light>1.0 1.0 1.0</ambient_light>
        <background_color>0.8 0.8 0.8</background_color>
        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
      </plugin>
    </gui>

    <light type="directional" name="sun">
      <cast_shadows>true</cast_shadows>
      <pose>0 0 10 0 0 0</pose>
      <diffuse>0.8 0.8 0.8 1</diffuse>
      <specular>0.2 0.2 0.2 1</specular>
      <attenuation>
        <range>1000</range>
        <constant>0.9</constant>
        <linear>0.01</linear>
        <quadratic>0.001</quadratic>
      </attenuation>
      <direction>-0.5 0.1 -0.9</direction>
    </light>

    <model name="ground_plane">
      <static>true</static>
      <link name="link">
        <collision name="collision">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
            </plane>
          </geometry>
        </collision>
        <visual name="visual">
          <geometry>
            <plane>
              <normal>0 0 1</normal>
              <size>100 100</size>
            </plane>
          </geometry>
          <material>
            <ambient>0.8 0.8 0.8 1</ambient>
            <diffuse>0.8 0.8 0.8 1</diffuse>
            <specular>0.8 0.8 0.8 1</specular>
          </material>
        </visual>
      </link>
    </model>

<include>
<uri>
https://fuel.ignitionrobotics.org/1.0/GoogleResearch/models/adizero_F50_TRX_FG_LEA
</uri>
</include>
<include>
<pose>0 0.5 0 0 0 0</pose>
<uri>
https://fuel.ignitionrobotics.org/1.0/GoogleResearch/models/adistar_boost_m
</uri>
</include>
  </world>
</sdf>
```

</p>
</details>

![2021-02-09T12:48:21 639635366](https://user-images.githubusercontent.com/8602001/107426460-194d3280-6ad5-11eb-82fa-e98a8f85a2ed.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**