### PR TITLE
Handle non-positive object temperatures

### DIFF
--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -266,6 +266,7 @@ void Ogre2ThermalCameraMaterialSwitcher::preRenderTargetUpdate(
       if (tempAny.index() != 0 && !std::holds_alternative<std::string>(tempAny))
       {
         float temp = -1.0;
+        bool foundTemp = true;
         try
         {
           temp = std::get<float>(tempAny);
@@ -286,30 +287,36 @@ void Ogre2ThermalCameraMaterialSwitcher::preRenderTargetUpdate(
             {
               ignerr << "Error casting user data: " << e.what() << "\n";
               temp = -1.0;
+              foundTemp = false;
             }
           }
         }
 
-        // only accept positive temperature (in kelvin)
-        if (temp >= 0.0)
+        // if a non-positive temperature was given, clamp it to 0
+        if (foundTemp && temp < 0.0)
         {
-          for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
-          {
-            Ogre::SubItem *subItem = item->getSubItem(i);
+          temp = 0.0;
+          ignwarn << "Unable to set negatve temperature for: "
+              << ogreVisual->Name() << ". Value cannot be lower than absolute "
+              << "zero. Clamping temperature to 0 degrees Kelvin."
+              << std::endl;
+        }
+        for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
+        {
+          Ogre::SubItem *subItem = item->getSubItem(i);
 
-            // normalize temperature value
-            float color = (temp / this->resolution) / ((1 << bitDepth) - 1.0);
+          // normalize temperature value
+          float color = (temp / this->resolution) / ((1 << bitDepth) - 1.0);
 
-            // set g, b, a to 0. This will be used by shaders to determine
-            // if particular fragment is a heat source or not
-            // see media/materials/programs/thermal_camera_fs.glsl
-            subItem->setCustomParameter(this->customParamIdx,
-                Ogre::Vector4(color, 0, 0, 0.0));
-            Ogre::HlmsDatablock *datablock = subItem->getDatablock();
-            this->datablockMap[subItem] = datablock;
+          // set g, b, a to 0. This will be used by shaders to determine
+          // if particular fragment is a heat source or not
+          // see media/materials/programs/thermal_camera_fs.glsl
+          subItem->setCustomParameter(this->customParamIdx,
+              Ogre::Vector4(color, 0, 0, 0.0));
+          Ogre::HlmsDatablock *datablock = subItem->getDatablock();
+          this->datablockMap[subItem] = datablock;
 
-            subItem->setMaterial(this->heatSourceMaterial);
-          }
+          subItem->setMaterial(this->heatSourceMaterial);
         }
       }
       // get heat signature and the corresponding min/max temperature values

--- a/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/thermal_camera_fs.glsl
@@ -71,29 +71,26 @@ void main()
   bool isHeatSource = (rgba.g == 0.0 && rgba.b == 0.0 && rgba.a == 0.0);
   float heat = rgba.r;
 
-  if (heat > 0.0)
+  if (isHeatSource)
   {
-    if (isHeatSource)
-    {
-      // heat is normalized so convert back to work in kelvin
-      // for 16 bit camera and 0.01 resolution:
-      //     ((1 << bitDepth) - 1) * resolution = 655.35
-      temp = heat * bitMaxValue * resolution;
+    // heat is normalized so convert back to work in kelvin
+    // for 16 bit camera and 0.01 resolution:
+    //     ((1 << bitDepth) - 1) * resolution = 655.35
+    temp = heat * bitMaxValue * resolution;
 
-      // set temperature variation for heat source
-      heatRange = heatSourceTempRange;
-    }
-    else
-    {
-      // other non-heat source objects are assigned ambient temperature
-      temp = ambient;
-    }
+    // set temperature variation for heat source
+    heatRange = heatSourceTempRange;
+  }
+  else
+  {
+    // other non-heat source objects are assigned ambient temperature
+    temp = ambient;
   }
 
   // add temperature variation, either as a function of color or depth
   if (rgbToTemp == 1)
   {
-    if (heat > 0.0 && !isHeatSource)
+    if (!isHeatSource)
     {
       // convert to grayscale: darker = warmer
       // (https://docs.opencv.org/3.4/de/d25/imgproc_color_conversions.html)


### PR DESCRIPTION
Related to https://github.com/ignitionrobotics/ign-gazebo/pull/621. This handles temperatures that are <= 0 kelvin for the thermal camea.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example world and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
