### PR TITLE
Get current status of MacOS tests on edifice

### DIFF
--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -200,7 +200,8 @@ void ThermalCameraTest::ThermalCameraBoxes(
       for (unsigned int j = 0; j < thermalCamera->ImageWidth(); ++j)
       {
         float temp = thermalData[step + j] * linearResolution;
-        EXPECT_NEAR(boxTemp, temp, boxTempRange);
+        EXPECT_NEAR(boxTemp, temp, boxTempRange)
+          << "i is " << i << " j is " << j;
       }
     }
 
@@ -217,7 +218,8 @@ void ThermalCameraTest::ThermalCameraBoxes(
       for (unsigned int j = 0; j < thermalCamera->ImageWidth(); ++j)
       {
         float temp = thermalData[step + j] * linearResolution;
-        EXPECT_NEAR(ambientTemp, temp, ambientTempRange);
+        EXPECT_NEAR(ambientTemp, temp, ambientTempRange)
+          << "i is " << i << " j is " << j;
       }
     }
 


### PR DESCRIPTION
<!-- Please remove the appropriate section.
For example, if this is a new feature, remove the "Bug Report" section -->

# Bug Report

I'm trying to see the results of MacOS CI using the current state of `main` in order to see if a new failure spotted in https://github.com/ignitionrobotics/ign-rendering/pull/246#issuecomment-777937844 is being cause by the forward port or not.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
