### PR TITLE
👩‍🌾 Make GitHub actions tests that are flaky due to display more verbose

### DIFF
--- a/.github/ci/after_make.sh
+++ b/.github/ci/after_make.sh
@@ -4,7 +4,7 @@ set -x
 
 make install
 
-Xvfb :1 -screen 0 1280x1024x24 &
+Xvfb :1 -ac -noreset -core -screen 0 1280x1024x24 &
 export DISPLAY=:1.0
 export RENDER_ENGINE_VALUES=ogre2
 export MESA_GL_VERSION_OVERRIDE=3.3

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -735,7 +735,7 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
       window = this->ogreRoot->createRenderWindow(
           stream.str(), _width, _height, false, &params);
     }
-    catch(std::exception _e)
+    catch(const std::exception &_e)
     {
       ignerr << " Unable to create the rendering window: " << _e.what()
              << std::endl;

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -670,7 +670,12 @@ void Ogre2RenderEngine::CreateResources()
 void Ogre2RenderEngine::CreateRenderWindow()
 {
   // create dummy window
-  this->CreateRenderWindow(std::to_string(this->dummyWindowId), 1, 1, 1, 0);
+  auto res = this->CreateRenderWindow(std::to_string(this->dummyWindowId),
+      1, 1, 1, 0);
+  if (res.empty())
+  {
+    ignerr << "Failed to create dummy render window." << std::endl;
+  }
 }
 
 //////////////////////////////////////////////////
@@ -730,16 +735,18 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
       window = this->ogreRoot->createRenderWindow(
           stream.str(), _width, _height, false, &params);
     }
-    catch(...)
+    catch(std::exception _e)
     {
-      ignerr << " Unable to create the rendering window\n";
+      ignerr << " Unable to create the rendering window: " << _e.what()
+             << std::endl;
       window = nullptr;
     }
   }
 
   if (attempts >= 10)
   {
-    ignerr << "Unable to create the rendering window\n" << std::endl;
+    ignerr << "Unable to create the rendering window after [" << attempts
+           << "] attempts." << std::endl;
     return std::string();
   }
 

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -242,12 +242,13 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
 
     if (x <= 100)
     {
-      EXPECT_EQ(nullptr, vis);
+      EXPECT_EQ(nullptr, vis)
+          << "Found [" << vis->Name() << "] at X [" << x << "]";
     }
     else if (x > 100 && x <= 300)
     {
       // Don't end test here on failure, this condition is flaky
-      EXPECT_NE(nullptr, vis) << x;
+      EXPECT_NE(nullptr, vis) << "X: " << x;
       if (vis)
       {
         EXPECT_EQ("sphere", vis->Name());
@@ -255,12 +256,13 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
     }
     else if (x > 300 && x <= 400)
     {
-      EXPECT_EQ(nullptr, vis);
+      EXPECT_EQ(nullptr, vis)
+          << "Found [" << vis->Name() << "] at X [" << x << "]";
     }
     else if (x > 400 && x <= 700)
     {
       // Don't end test here on failure, this condition is flaky
-      EXPECT_NE(nullptr, vis) << x;
+      EXPECT_NE(nullptr, vis) << "X: " << x;
       if (vis)
       {
         EXPECT_EQ("box", vis->Name());


### PR DESCRIPTION
# 🦟 Bug exploration

## Summary

Our tests on `ign-rendering` and `ign-gui` occasionally fail on GitHub actions because they can't open the display, see more info on https://github.com/ignitionrobotics/ign-gui/issues/58.

This is an attempt of making the display tests more robust (with the new arguments passed to `Xvfb`) and failures more verbose (with the updated error messages on `Ogre2RenderEngine`).

Unfortunately, the failure is so rare that I haven't been able to get a failure message with this branch yet. It should come with time, unless the changes to the `Xvfb` invocation really fix it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

---

https://github.com/osrf/buildfarmer/issues/161