### PR TITLE
Fix gazebo_scene_viewer for macOS and ensure exits cleanly

### DIFF
--- a/examples/gazebo_scene_viewer/CMakeLists.txt
+++ b/examples/gazebo_scene_viewer/CMakeLists.txt
@@ -17,7 +17,11 @@ if (NOT APPLE)
   find_package(GLEW REQUIRED)
   include_directories(SYSTEM ${GLEW_INCLUDE_DIRS})
   link_directories(${GLEW_LIBRARY_DIRS})
+  set(STD_CXX_FS_LIBRARIES "stdc++fs")
 endif()
+
+find_package(bullet REQUIRED)
+link_directories(${BULLET_LIBRARY_DIRS})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
@@ -33,7 +37,8 @@ target_link_libraries(gazebo_scene_viewer
   ${GLEW_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${IGNITION-RENDERING_LIBRARIES}
-  stdc++fs
+  ${STD_CXX_FS_LIBRARIES}
+  ${BULLET_LIBRARIES}
 )
 
 add_executable(gazebo_scene_viewer2_demo
@@ -48,5 +53,6 @@ target_link_libraries(gazebo_scene_viewer2_demo
   ${GLEW_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${IGNITION-RENDERING_LIBRARIES}
-  stdc++fs
+  ${STD_CXX_FS_LIBRARIES}
+  ${BULLET_LIBRARIES}
 )

--- a/examples/gazebo_scene_viewer/CMakeLists.txt
+++ b/examples/gazebo_scene_viewer/CMakeLists.txt
@@ -20,9 +20,6 @@ if (NOT APPLE)
   set(STD_CXX_FS_LIBRARIES "stdc++fs")
 endif()
 
-find_package(bullet REQUIRED)
-link_directories(${BULLET_LIBRARY_DIRS})
-
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 add_executable(gazebo_scene_viewer
@@ -38,7 +35,6 @@ target_link_libraries(gazebo_scene_viewer
   ${GAZEBO_LIBRARIES}
   ${IGNITION-RENDERING_LIBRARIES}
   ${STD_CXX_FS_LIBRARIES}
-  ${BULLET_LIBRARIES}
 )
 
 add_executable(gazebo_scene_viewer2_demo
@@ -54,5 +50,4 @@ target_link_libraries(gazebo_scene_viewer2_demo
   ${GAZEBO_LIBRARIES}
   ${IGNITION-RENDERING_LIBRARIES}
   ${STD_CXX_FS_LIBRARIES}
-  ${BULLET_LIBRARIES}
 )

--- a/examples/gazebo_scene_viewer/GazeboDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboDemo.cc
@@ -92,17 +92,17 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string ogre_engine("ogre");
+  std::string ogreEngine("ogre");
   if (_argc > 1)
   {
-    ogre_engine = _argv[1];
+    ogreEngine = _argv[1];
   }
 
   Connect();
   std::vector<CameraPtr> cameras;
   std::vector<std::string> engineNames;
 
-  engineNames.push_back(ogre_engine);
+  engineNames.push_back(ogreEngine);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/gazebo_scene_viewer/GazeboDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboDemo.cc
@@ -14,6 +14,16 @@
  * limitations under the License.
  *
  */
+
+#if defined(__APPLE__)
+  #include <OpenGL/gl.h>
+  #include <GLUT/glut.h>
+#elif not defined(_WIN32)
+  #include <GL/glew.h>
+  #include <GL/gl.h>
+  #include <GL/glut.h>
+#endif
+
 #include <iostream>
 #include <gazebo/common/Console.hh>
 #include <gazebo/transport/TransportIface.hh>
@@ -76,13 +86,23 @@ CameraPtr CreateCamera(const std::string &_engine)
   return camera;
 }
 
-int main(int, char**)
+int main(int _argc, char** _argv)
 {
+  glutInit(&_argc, _argv);
+
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogre_engine("ogre");
+  if (_argc > 1)
+  {
+    ogre_engine = _argv[1];
+  }
+
   Connect();
   std::vector<CameraPtr> cameras;
   std::vector<std::string> engineNames;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogre_engine);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
@@ -14,6 +14,16 @@
  * limitations under the License.
  *
  */
+
+#if defined(__APPLE__)
+  #include <OpenGL/gl.h>
+  #include <GLUT/glut.h>
+#elif not defined(_WIN32)
+  #include <GL/glew.h>
+  #include <GL/gl.h>
+  #include <GL/glut.h>
+#endif
+
 #include <iostream>
 #include <ignition/common/Console.hh>
 #include <gazebo/transport/TransportIface.hh>
@@ -76,13 +86,23 @@ CameraPtr CreateCamera(const std::string &_engine)
   return camera;
 }
 
-int main(int, char**)
+int main(int _argc, char** _argv)
 {
+  glutInit(&_argc, _argv);
+
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogre_engine("ogre");
+  if (_argc > 1)
+  {
+    ogre_engine = _argv[1];
+  }
+
   Connect();
   std::vector<CameraPtr> cameras;
   std::vector<std::string> engineNames;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogre_engine);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
@@ -92,17 +92,17 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string ogre_engine("ogre");
+  std::string ogreEngine("ogre");
   if (_argc > 1)
   {
-    ogre_engine = _argv[1];
+    ogreEngine = _argv[1];
   }
 
   Connect();
   std::vector<CameraPtr> cameras;
   std::vector<std::string> engineNames;
 
-  engineNames.push_back(ogre_engine);
+  engineNames.push_back(ogreEngine);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/gazebo_scene_viewer/SceneManager.cc
+++ b/examples/gazebo_scene_viewer/SceneManager.cc
@@ -461,7 +461,10 @@ void SceneManagerPrivate::OnLightUpdate(::ConstLightPtr &_lightMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnLightUpdate(_lightMsg);
   this->newSceneManager->OnLightUpdate(_lightMsg);
@@ -473,7 +476,10 @@ void SceneManagerPrivate::OnModelUpdate(::ConstModelPtr &_modelMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnModelUpdate(_modelMsg);
   this->newSceneManager->OnModelUpdate(_modelMsg);
@@ -485,7 +491,10 @@ void SceneManagerPrivate::OnJointUpdate(::ConstJointPtr &_jointMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnJointUpdate(_jointMsg);
   this->newSceneManager->OnJointUpdate(_jointMsg);
@@ -497,7 +506,10 @@ void SceneManagerPrivate::OnVisualUpdate(::ConstVisualPtr &_visualMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnVisualUpdate(_visualMsg);
   this->newSceneManager->OnVisualUpdate(_visualMsg);
@@ -509,7 +521,10 @@ void SceneManagerPrivate::OnSensorUpdate(::ConstSensorPtr &_sensorMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnSensorUpdate(_sensorMsg);
   this->newSceneManager->OnSensorUpdate(_sensorMsg);
@@ -521,7 +536,10 @@ void SceneManagerPrivate::OnPoseUpdate(::ConstPosesStampedPtr &_posesMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->poseMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnPoseUpdate(_posesMsg);
   this->newSceneManager->OnPoseUpdate(_posesMsg);
@@ -533,7 +551,10 @@ void SceneManagerPrivate::OnRemovalUpdate(const std::string &_name)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->poseMutex);
 
-  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr)
+  {
+    return;
+  }
 
   this->currentSceneManager->OnRemovalUpdate(_name);
   this->newSceneManager->OnRemovalUpdate(_name);

--- a/examples/gazebo_scene_viewer/SceneManager.cc
+++ b/examples/gazebo_scene_viewer/SceneManager.cc
@@ -40,6 +40,7 @@ SceneManager::SceneManager() :
 //////////////////////////////////////////////////
 SceneManager::~SceneManager()
 {
+  this->Fini();
   delete this->pimpl;
 }
 
@@ -157,8 +158,8 @@ SceneManagerPrivate::SceneManagerPrivate() :
 //////////////////////////////////////////////////
 SceneManagerPrivate::~SceneManagerPrivate()
 {
-  delete currentSceneManager;
-  delete newSceneManager;
+    newSceneManager.reset();
+    currentSceneManager.reset();
 }
 
 //////////////////////////////////////////////////
@@ -224,7 +225,11 @@ void SceneManagerPrivate::Init()
 //////////////////////////////////////////////////
 void SceneManagerPrivate::Fini()
 {
-  // TODO(anyone): disconnect
+  // block all message receival during cleanup
+  std::lock_guard<std::mutex> generalLock(this->generalMutex);
+  std::lock_guard<std::mutex> poseLock(this->poseMutex);
+
+  this->transportNode->Fini();
 }
 
 //////////////////////////////////////////////////
@@ -456,6 +461,8 @@ void SceneManagerPrivate::OnLightUpdate(::ConstLightPtr &_lightMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+
   this->currentSceneManager->OnLightUpdate(_lightMsg);
   this->newSceneManager->OnLightUpdate(_lightMsg);
 }
@@ -465,6 +472,8 @@ void SceneManagerPrivate::OnModelUpdate(::ConstModelPtr &_modelMsg)
 {
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
+
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
 
   this->currentSceneManager->OnModelUpdate(_modelMsg);
   this->newSceneManager->OnModelUpdate(_modelMsg);
@@ -476,6 +485,8 @@ void SceneManagerPrivate::OnJointUpdate(::ConstJointPtr &_jointMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+
   this->currentSceneManager->OnJointUpdate(_jointMsg);
   this->newSceneManager->OnJointUpdate(_jointMsg);
 }
@@ -485,6 +496,8 @@ void SceneManagerPrivate::OnVisualUpdate(::ConstVisualPtr &_visualMsg)
 {
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
+
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
 
   this->currentSceneManager->OnVisualUpdate(_visualMsg);
   this->newSceneManager->OnVisualUpdate(_visualMsg);
@@ -496,6 +509,8 @@ void SceneManagerPrivate::OnSensorUpdate(::ConstSensorPtr &_sensorMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->generalMutex);
 
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+
   this->currentSceneManager->OnSensorUpdate(_sensorMsg);
   this->newSceneManager->OnSensorUpdate(_sensorMsg);
 }
@@ -506,6 +521,8 @@ void SceneManagerPrivate::OnPoseUpdate(::ConstPosesStampedPtr &_posesMsg)
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->poseMutex);
 
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
+
   this->currentSceneManager->OnPoseUpdate(_posesMsg);
   this->newSceneManager->OnPoseUpdate(_posesMsg);
 }
@@ -515,6 +532,8 @@ void SceneManagerPrivate::OnRemovalUpdate(const std::string &_name)
 {
   // wait for update unlock before adding message
   std::lock_guard<std::mutex> lock(this->poseMutex);
+
+  if (this->currentSceneManager == nullptr || this->newSceneManager == nullptr) return;
 
   this->currentSceneManager->OnRemovalUpdate(_name);
   this->newSceneManager->OnRemovalUpdate(_name);

--- a/examples/gazebo_scene_viewer/SceneManagerPrivate.hh
+++ b/examples/gazebo_scene_viewer/SceneManagerPrivate.hh
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <ignition/common/Time.hh>
 
@@ -110,9 +111,9 @@ namespace ignition
 
       private: void DemoteCurrentScenes();
 
-      private: CurrentSceneManager *currentSceneManager;
+      private: std::unique_ptr<CurrentSceneManager> currentSceneManager;
 
-      private: NewSceneManager *newSceneManager;
+      private: std::unique_ptr<NewSceneManager> newSceneManager;
 
       private: gazebo::transport::NodePtr transportNode;
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This is similar to PR #256. The example `gazebo_scene_viewer` does not display a window on macOS. The example will build and run, the console will display the usage, however the GLUT window does not open. There was also a non-macOS specific issue where the window would segfault on exit when triggered by an ESC keypress in the window.

## Configuration

- OS: macOS Catalina 10.15.7
- Machine: Mac Pro (2019)
- Config: ignition-rendering4

## Detail

The macOS changes involve setting up and managing the correct OpenGL context. The segfault issue was caused by two things: the first was a potential nullptr dereference in the subscriber callbacks, this is now checked and in any case should not be hit provided the transport is cleaned up before the scene mangers go out of scope. The second issue was the gazebo transport node not being stopped and finalised before exit(0) was executed. This would cause either a segfault or a hang as the application window would go out of scope while a cleanup thread was running resulting in a pthread mutex lock exception. 

1. Add OpenGL context settings for macOS to the CameraWindow.
2. Move glutInit to main in GazeboDemo and GazeboWorldDemo
3. Update CMakeLists.txt to exclude libstdc++fs for macOS and add find_package for bullet.
4. Expose command line option to set either ogre or ogre2 as an engine.
5. Ensure gazebo::transport is stopped and cleaned up prior to exit.
6. Use std::unique_ptr to manage current and new scene manager lifetimes.
7. Disconnect pub/sub from transport on SceneManager Fini.
8. Add checks in pub/sub callbacks to ensure scene manager pointers are valid.

## Tests

Both examples are working correctly in macOS for ogre (ogre2 not tested). The image below is for `gazebo_scene_viewer2_demo`

![gazebo_scene_viewer2_demo_1](https://user-images.githubusercontent.com/24916364/109162226-e01cef80-776f-11eb-8f43-5a6f89883993.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

