### PR TITLE
Fix overriding ogre2 transparency blend mode

### DIFF
--- a/include/ignition/rendering/base/BaseMaterial.hh
+++ b/include/ignition/rendering/base/BaseMaterial.hh
@@ -873,9 +873,10 @@ namespace ignition
       this->SetSpecular(_material->Specular());
       this->SetEmissive(_material->Emissive());
       this->SetShininess(_material->Shininess());
-      this->SetTransparency(_material->Transparency());
       this->SetAlphaFromTexture(_material->TextureAlphaEnabled(),
           _material->AlphaThreshold(), _material->TwoSidedEnabled());
+      // override transparency / blend setting after setting alpha from texture
+      this->SetTransparency(_material->Transparency());
       // override depth check / depth write after setting transparency
       this->SetDepthCheckEnabled(_material->DepthCheckEnabled());
       this->SetDepthWriteEnabled(_material->DepthWriteEnabled());

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -157,17 +157,16 @@ void Ogre2Material::SetAlphaFromTexture(bool _enabled,
     double _alpha, bool _twoSided)
 {
   BaseMaterial::SetAlphaFromTexture(_enabled, _alpha, _twoSided);
-  Ogre::HlmsBlendblock block;
   if (_enabled)
   {
     this->ogreDatablock->setAlphaTest(Ogre::CMPF_GREATER_EQUAL);
+    Ogre::HlmsBlendblock block;
     block.setBlendType(Ogre::SBT_TRANSPARENT_ALPHA);
     this->ogreDatablock->setBlendblock(block);
   }
   else
   {
     this->ogreDatablock->setAlphaTest(Ogre::CMPF_ALWAYS_PASS);
-    this->ogreDatablock->setBlendblock(block);
   }
   this->ogreDatablock->setAlphaTestThreshold(_alpha);
   this->ogreDatablock->setTwoSidedLighting(_twoSided);


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/496

## Summary

Fixes issue with ign-gazebo's TransformControl tool being occluded by models.

The ogre2 transparency blend mode setting was being override when copying a material due to the order of the calls.

-> `SetTransparency` -> sets blend mode
-> `SetAlphaFromTexture`- > overrides the blend mode set in the previous call if arg is `false`

The PR reverses the order to make sure we keep the blend mode if visual is semi-transparent

Also made sure that if `SetAlphaFromTexture(false)` is called any time afterwards, we don't change the existing blend mode.

![transform_control_blendmode](https://user-images.githubusercontent.com/4000684/110197239-13f6b580-7dff-11eb-9800-3e2f8c710adc.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

