### PR TITLE
Fix DepthGaussianNoise test

### DIFF
--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -310,8 +310,8 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
 
     float maxVal = ignition::math::INF_D;
 
-    // values should be well within 4-sigma
-    float noiseTol = 4.0*noiseStdDev;
+    // values should be well within 3-sigma
+    float noiseTol = 3.0*noiseStdDev;
     unsigned int colorNoiseTol = static_cast<unsigned int>(255.0*noiseTol);
 
     // Verify Point Cloud XYZ values
@@ -339,8 +339,9 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
       float mz = pointCloudData[pcMid + 2];
       float midLeftZ = pointCloudData[pcMid + 2 - pointCloudChannelCount];
       float midRightZ = pointCloudData[pcMid + 2 + pointCloudChannelCount];
-      EXPECT_NEAR(mz, midLeftZ, noiseTol);
-      EXPECT_NEAR(mz, midRightZ, noiseTol);
+      // 2 noisy values should be within 2 * 3 sigma
+      EXPECT_NEAR(mz, midLeftZ, 2*noiseTol);
+      EXPECT_NEAR(mz, midRightZ, 2*noiseTol);
 
       // Verify Point Cloud RGB values
       // The mid point should be blue

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -310,8 +310,8 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
 
     float maxVal = ignition::math::INF_D;
 
-    // values should be well within 3-sigma
-    float noiseTol = 3.0*noiseStdDev;
+    // values should be well within 4-sigma
+    float noiseTol = 4.0*noiseStdDev;
     unsigned int colorNoiseTol = static_cast<unsigned int>(255.0*noiseTol);
 
     // Verify Point Cloud XYZ values
@@ -339,7 +339,7 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
       float mz = pointCloudData[pcMid + 2];
       float midLeftZ = pointCloudData[pcMid + 2 - pointCloudChannelCount];
       float midRightZ = pointCloudData[pcMid + 2 + pointCloudChannelCount];
-      // 2 noisy values should be within 2 * 3 sigma
+      // 2 noisy values should be within 2 * 4 sigma
       EXPECT_NEAR(mz, midLeftZ, 2*noiseTol);
       EXPECT_NEAR(mz, midRightZ, 2*noiseTol);
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes one of the test Gaussian noise test failures mentioned in #175

## Summary
While the difference between data with noise and data without noise should be within 3 sigma, the difference between 2 noisy values should be within 2 * 3 sigma, i.e. full span of the Gaussian noise distribution

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
