### PR TITLE
Add API for particle emitter scatter ratio

### DIFF
--- a/include/ignition/rendering/ParticleEmitter.hh
+++ b/include/ignition/rendering/ParticleEmitter.hh
@@ -245,6 +245,17 @@ namespace ignition
       /// \param[in] _image The color image name.
       /// \sa ColorRangeImage
       public: virtual void SetColorRangeImage(const std::string &_image) = 0;
+
+      /// \brief Get the particle scatter ratio.
+      /// \return The particle scatter ratio.
+      /// \sa SetParticleScatterRatio
+      public: virtual float ParticleScatterRatio() const = 0;
+
+      /// \brief Set the particle scatter ratio.
+      /// \param[in] _ratio The scatter ratio. The particle emitter's scatter
+      /// ratio will only be set to _ratio if _ratio > 0.
+      /// \sa ParticleScatterRatio
+      public: virtual void SetParticleScatterRatio(float _ratio) = 0;
     };
     }
   }

--- a/include/ignition/rendering/base/BaseParticleEmitter.hh
+++ b/include/ignition/rendering/base/BaseParticleEmitter.hh
@@ -137,6 +137,12 @@ namespace ignition
       public: virtual void SetColorRangeImage(
                   const std::string &_image) override;
 
+      // Documentation inherited.
+      public: virtual float ParticleScatterRatio() const override;
+
+      // Documentation inherited.
+      public: virtual void SetParticleScatterRatio(float _ratio) override;
+
       /// \brief Emitter type.
       protected: EmitterType type = EM_POINT;
 
@@ -181,6 +187,15 @@ namespace ignition
 
       /// \brief The color image.
       protected: std::string colorRangeImage = "";
+
+      /// \brief The particle scatter ratio. This is used to determine the ratio
+      /// of particles that will be detected by sensors. Increasing the ratio
+      /// increases the scatter of the particles, which means there is a higher
+      /// chance of particles reflecting and interfering with depth sensing,
+      /// making the emitter appear more dense. Decreasing the ratio decreases
+      /// the scatter of the particles, making it appear less dense. This value
+      /// should be > 0.
+      protected: float particleScatterRatio = 0.65f;
 
       /// \brief Only the scene can create a particle emitter
       private: friend class BaseScene;
@@ -404,6 +419,21 @@ namespace ignition
     void BaseParticleEmitter<T>::SetColorRangeImage(const std::string &_image)
     {
       this->colorRangeImage = _image;
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    float BaseParticleEmitter<T>::ParticleScatterRatio() const
+    {
+      return this->particleScatterRatio;
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseParticleEmitter<T>::SetParticleScatterRatio(float _ratio)
+    {
+      if (_ratio > 0.0f)
+        this->particleScatterRatio = _ratio;
     }
     }
   }

--- a/ogre2/src/Ogre2ParticleNoiseListener.cc
+++ b/ogre2/src/Ogre2ParticleNoiseListener.cc
@@ -21,6 +21,7 @@
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
+#include "ignition/rendering/ogre2/Ogre2ParticleEmitter.hh"
 
 #include "Ogre2ParticleNoiseListener.hh"
 
@@ -88,6 +89,7 @@ void Ogre2ParticleNoiseListener::preRenderTargetUpdate(
 
       // get particle scatter ratio value from particle emitter user data
       // and pass that to the shaders
+      float scatterRatio = 0.65f;
       Ogre::Any userAny = ps->getUserObjectBindings().getUserAny();
       if (!userAny.isEmpty() && userAny.getType() == typeid(unsigned int))
       {
@@ -101,48 +103,12 @@ void Ogre2ParticleNoiseListener::preRenderTargetUpdate(
         {
           ignerr << "Ogre Error:" << e.getFullDescription() << "\n";
         }
-        Ogre2VisualPtr ogreVisual =
-            std::dynamic_pointer_cast<Ogre2Visual>(result);
-        if (ogreVisual)
-        {
-          const std::string particleScatterRatioKey = "particle_scatter_ratio";
-          Variant particleScatterRatioAny =
-              ogreVisual->UserData(particleScatterRatioKey);
-          if (particleScatterRatioAny.index() != std::variant_npos)
-          {
-            float ratio = -1.0;
-            try
-            {
-              ratio = std::get<float>(particleScatterRatioAny);
-            }
-            catch(...)
-            {
-              try
-              {
-                ratio = std::get<double>(particleScatterRatioAny);
-              }
-              catch(...)
-              {
-                try
-                {
-                  ratio = std::get<int>(particleScatterRatioAny);
-                }
-                catch(std::bad_variant_access &e)
-                {
-                  ignerr << "Error casting user data: " << e.what() << "\n";
-                  ratio = -1.0;
-                }
-              }
-            }
-            if (ratio > 0)
-            {
-              this->particleScatterRatio = ratio;
-            }
-          }
-        }
+        Ogre2ParticleEmitterPtr emitterPtr =
+          std::dynamic_pointer_cast<Ogre2ParticleEmitter>(result);
+        if (emitterPtr)
+          scatterRatio = emitterPtr->ParticleScatterRatio();
       }
-      psParams->setNamedConstant("particleScatterRatio",
-          static_cast<float>(this->particleScatterRatio));
+      psParams->setNamedConstant("particleScatterRatio", scatterRatio);
 
       return;
     }

--- a/ogre2/src/Ogre2ParticleNoiseListener.hh
+++ b/ogre2/src/Ogre2ParticleNoiseListener.hh
@@ -49,15 +49,6 @@ namespace ignition
       /// \brief Pointer to ogre matieral with shaders for applying particle
       /// scattering effect to sensors
       private: Ogre::MaterialPtr ogreMaterial;
-
-      /// \brief Particle scatter ratio. This is used to determine the ratio of
-      /// particles that will be detected by sensors. Increasing the ratio
-      /// increases the scatter of the particles, which means there is a higher
-      /// chance of particles reflecting and interfering with depth sensing,
-      /// making the emitter appear more dense. Decreasing the ratio decreases
-      /// the scatter of the particles, making it appear less dense. This value
-      /// should be > 0.
-      private: float particleScatterRatio = 0.65f;
     };
     }
   }

--- a/src/ParticleEmitter_TEST.cc
+++ b/src/ParticleEmitter_TEST.cc
@@ -91,11 +91,7 @@ void ParticleEmitterTest::CheckBasicAPI()
   math::Color    expectedColorEnd        = ignition::math::Color::White;
   double         expectedScaleRate       = 1;
   std::string    expectedColorRangeImage = "";
-  // Particle scatter ratio is stored in user data
-  // TODO(anyone) Add API to set scatter ratio
-  // (this requires adding a virtual function in the base class,
-  // which breaks ABI, so this should be done in an unreleased version)
-  Variant        emptyVariant;
+  float          particleScatterRatio    = 0.65f;
 
   // Check default expectations.
   EXPECT_EQ(expectedEmitterType,      particleEmitter->Type());
@@ -112,7 +108,8 @@ void ParticleEmitterTest::CheckBasicAPI()
   EXPECT_EQ(expectedColorEnd,         particleEmitter->ColorEnd());
   EXPECT_DOUBLE_EQ(expectedScaleRate, particleEmitter->ScaleRate());
   EXPECT_EQ(expectedColorRangeImage,  particleEmitter->ColorRangeImage());
-  EXPECT_EQ(emptyVariant,  particleEmitter->UserData("particle_scatter_ratio"));
+  EXPECT_FLOAT_EQ(particleScatterRatio,
+      particleEmitter->ParticleScatterRatio());
 
   // Modify values.
   expectedEmitterType     = EmitterType::EM_BOX;
@@ -129,10 +126,7 @@ void ParticleEmitterTest::CheckBasicAPI()
   expectedColorEnd        = ignition::math::Color::Blue;
   expectedScaleRate       = 10;
   expectedColorRangeImage = common::joinPaths(TEST_MEDIA_PATH, "texture.png");
-  // Particle scatter ratio is stored in user data
-  // TODO(anyone) Add API to set scatter ratio
-  // (see note above in the other todo about how this breaks ABI)
-  double expectedScatterRatio  = 0.24;
+  float expectedScatterRatio  = 0.24f;
 
   // Modify attributes.
   particleEmitter->SetType(expectedEmitterType);
@@ -147,7 +141,7 @@ void ParticleEmitterTest::CheckBasicAPI()
   particleEmitter->SetColorRange(expectedColorStart, expectedColorEnd);
   particleEmitter->SetScaleRate(expectedScaleRate);
   particleEmitter->SetColorRangeImage(expectedColorRangeImage);
-  particleEmitter->SetUserData("particle_scatter_ratio", expectedScatterRatio);
+  particleEmitter->SetParticleScatterRatio(expectedScatterRatio);
 
   // Check getters.
   EXPECT_EQ(expectedEmitterType,      particleEmitter->Type());
@@ -164,8 +158,8 @@ void ParticleEmitterTest::CheckBasicAPI()
   EXPECT_EQ(expectedColorEnd,         particleEmitter->ColorEnd());
   EXPECT_DOUBLE_EQ(expectedScaleRate, particleEmitter->ScaleRate());
   EXPECT_EQ(expectedColorRangeImage,  particleEmitter->ColorRangeImage());
-  Variant v = particleEmitter->UserData("particle_scatter_ratio");
-  EXPECT_DOUBLE_EQ(expectedScatterRatio,  std::get<double>(v));
+  EXPECT_FLOAT_EQ(expectedScatterRatio,
+      particleEmitter->ParticleScatterRatio());
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -685,7 +685,7 @@ void DepthCameraTest::DepthCameraParticles(
     // reduce particle scatter ratio - this creates a "less dense" particle
     // emitter so we should have larger depth values on avg since fewers
     // depth readings are occluded by particles
-    emitter->SetUserData("particle_scatter_ratio", 0.1);
+    emitter->SetParticleScatterRatio(0.1f);
 
     g_depthCounter = 0u;
     g_pointCloudCounter = 0u;

--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -642,7 +642,7 @@ void GpuRaysTest::RaysParticles(const std::string &_renderEngine)
   // reduce particle scatter ratio - this creates a "less dense" particle
   // emitter so we should have larger range values on avg since fewer
   // rays are occluded by particles
-  emitter->SetUserData("particle_scatter_ratio", 0.1);
+  emitter->SetParticleScatterRatio(0.1f);
 
   unsigned int particleHitLowScatterCount = 0u;
   unsigned int particleMissLowScatterCount = 0u;


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

Addresses a missing API that was mentioned [here](https://github.com/ignitionrobotics/ign-rendering/pull/264#discussion_r596898756). This breaks ABI, so this is targeting Edifice before release.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**