### PR TITLE
Added command line argument for examples to pick version of Ogre

### DIFF
--- a/examples/actor_animation/Main.cc
+++ b/examples/actor_animation/Main.cc
@@ -181,17 +181,17 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string engine("ogre");
+  std::string ogreEngineName("ogre");
   if (_argc > 1)
   {
-    engine = _argv[1];
+    ogreEngineName = _argv[1];
   }
 
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back(engine);
+  engineNames.push_back(ogreEngineName);
 
   std::vector<VisualPtr> visuals;
   ic::SkeletonPtr skel = nullptr;

--- a/examples/camera_tracking/Main.cc
+++ b/examples/camera_tracking/Main.cc
@@ -118,12 +118,20 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
   std::vector<NodePtr> nodes;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/custom_scene_viewer/ManualSceneDemo.cc
+++ b/examples/custom_scene_viewer/ManualSceneDemo.cc
@@ -185,10 +185,10 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string ogreEngine("ogre");
+  std::string ogreEngineName("ogre");
   if (_argc > 1)
   {
-    ogreEngine = _argv[1];
+    ogreEngineName = _argv[1];
   }
 
   common::Console::SetVerbosity(4);
@@ -208,7 +208,7 @@ int main(int _argc, char** _argv)
   sceneDemo->AddScene(SceneBuilderPtr(new ShadowSceneBuilder(4)));
   sceneDemo->AddScene(SceneBuilderPtr(new ShadowSceneBuilder(5)));
 //! [add scenes]
-  sceneDemo->AddCamera(ogreEngine);
+  sceneDemo->AddCamera(ogreEngineName);
   sceneDemo->AddCamera("optix");
   sceneDemo->Run();
   return 0;

--- a/examples/gazebo_scene_viewer/GazeboDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboDemo.cc
@@ -92,17 +92,17 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string ogreEngine("ogre");
+  std::string ogreEngineName("ogre");
   if (_argc > 1)
   {
-    ogreEngine = _argv[1];
+    ogreEngineName = _argv[1];
   }
 
   Connect();
   std::vector<CameraPtr> cameras;
   std::vector<std::string> engineNames;
 
-  engineNames.push_back(ogreEngine);
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
@@ -92,17 +92,17 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string ogreEngine("ogre");
+  std::string ogreEngineName("ogre");
   if (_argc > 1)
   {
-    ogreEngine = _argv[1];
+    ogreEngineName = _argv[1];
   }
 
   Connect();
   std::vector<CameraPtr> cameras;
   std::vector<std::string> engineNames;
 
-  engineNames.push_back(ogreEngine);
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/lidar_visual/Main.cc
+++ b/examples/lidar_visual/Main.cc
@@ -264,10 +264,10 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string engine("ogre");
+  std::string ogreEngineName("ogre");
   if (_argc > 1)
   {
-    engine = _argv[1];
+    ogreEngineName = _argv[1];
   }
 
   common::Console::SetVerbosity(4);
@@ -276,7 +276,7 @@ int main(int _argc, char** _argv)
   std::vector<LidarVisualPtr> nodes;
   std::vector<GpuRaysPtr> sensors;
 
-  engineNames.push_back(engine);
+  engineNames.push_back(ogreEngineName);
 
   for (auto engineName : engineNames)
   {

--- a/examples/mesh_viewer/Main.cc
+++ b/examples/mesh_viewer/Main.cc
@@ -123,11 +123,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/mouse_picking/Main.cc
+++ b/examples/mouse_picking/Main.cc
@@ -126,11 +126,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/particles_demo/Main.cc
+++ b/examples/particles_demo/Main.cc
@@ -159,11 +159,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre2");
+  engineNames.push_back(ogreEngineName);
 
   for (auto engineName : engineNames)
   {

--- a/examples/render_pass/Main.cc
+++ b/examples/render_pass/Main.cc
@@ -176,11 +176,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -177,17 +177,17 @@ int main(int _argc, char** _argv)
 
   // Expose engine name to command line because we can't instantiate both
   // ogre and ogre2 at the same time
-  std::string engine("ogre");
+  std::string ogreEngineName("ogre");
   if (_argc > 1)
   {
-    engine = _argv[1];
+    ogreEngineName = _argv[1];
   }
 
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back(engine);
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/thermal_camera/Main.cc
+++ b/examples/thermal_camera/Main.cc
@@ -129,11 +129,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre2");
+  engineNames.push_back(ogreEngineName);
 
   for (auto engineName : engineNames)
   {

--- a/examples/transform_control/Main.cc
+++ b/examples/transform_control/Main.cc
@@ -112,11 +112,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
 
   for (auto engineName : engineNames)

--- a/examples/view_control/Main.cc
+++ b/examples/view_control/Main.cc
@@ -158,11 +158,19 @@ int main(int _argc, char** _argv)
 {
   glutInit(&_argc, _argv);
 
+  // Expose engine name to command line because we can't instantiate both
+  // ogre and ogre2 at the same time
+  std::string ogreEngineName("ogre");
+  if (_argc > 1)
+  {
+    ogreEngineName = _argv[1];
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre");
+  engineNames.push_back(ogreEngineName);
   engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {


### PR DESCRIPTION
Updated the following examples to use a command line argument to determine which version of Ogre to use (Ogre1 vs. Ogre2):

- actor_animation
- camera_tracking
- custom_scene_viewer
- gazebo_scene_viewer
- lidar_visual
- mesh_viewer
- mouse_picking
- particles_demo
- render_pass
- simple_demo
- thermal_camera
- transform_control
- view_control