### PR TITLE
Fix crash on shutdown

### DIFF
--- a/ogre2/src/Ogre2Node.cc
+++ b/ogre2/src/Ogre2Node.cc
@@ -164,6 +164,9 @@ bool Ogre2Node::AttachChild(NodePtr _child)
 //////////////////////////////////////////////////
 bool Ogre2Node::DetachChild(NodePtr _child)
 {
+  if (nullptr == this->ogreNode)
+    return false;
+
   Ogre2NodePtr derived = std::dynamic_pointer_cast<Ogre2Node>(_child);
 
   if (!derived)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Ignition Gazebo has been crashing on shutdown whenever there are models in an `ogre2` world.

This is a quick fix for the crash just so this is fixed by the release, but I haven't spent time looking into whether this is happening on Dome or tracking down when the problem started.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
