### PR TITLE
Silence noisy sky error

### DIFF
--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1212,11 +1212,14 @@ ParticleEmitterPtr BaseScene::CreateParticleEmitter(unsigned int _id,
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetSkyEnabled(bool)  // NOLINT(readability/casting)
+void BaseScene::SetSkyEnabled(bool _enabled)  // NOLINT(readability/casting)
 {
   // no op, let derived class implement this.
-  ignerr << "Sky not supported by: "
-         << this->Engine()->Name() << std::endl;
+  if (_enabled)
+  {
+    ignerr << "Sky not supported by: "
+           << this->Engine()->Name() << std::endl;
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This was brought up during the tutorial party. This warning is always printed when using `ogre1`, even when the user is not trying to enable the sky. This change makes it so the error is only printed for users trying to enable sky.

Keeping this as draft until the stable release, it's not a critical bugfix.

CC @ammaar8

## Checklist
- [x] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] ~~Updated documentation (as needed)~~
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
