### PR TITLE
Scale light intensity by PI for Ogre2

### DIFF
--- a/ogre2/src/Ogre2Light.cc
+++ b/ogre2/src/Ogre2Light.cc
@@ -126,13 +126,13 @@ void Ogre2Light::SetAttenuationRange(double _range)
 //////////////////////////////////////////////////
 double Ogre2Light::Intensity() const
 {
-  return this->ogreLight->getPowerScale();
+  return this->ogreLight->getPowerScale() / IGN_PI;
 }
 
 //////////////////////////////////////////////////
 void Ogre2Light::SetIntensity(double _intensity)
 {
-  this->ogreLight->setPowerScale(_intensity);
+  this->ogreLight->setPowerScale(_intensity * IGN_PI);
 }
 
 //////////////////////////////////////////////////

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -76,7 +76,7 @@ void LightTest::Light(const std::string &_renderEngine)
 
   // intensity
   light->SetIntensity(1.25);
-  EXPECT_DOUBLE_EQ(1.25, light->Intensity());
+  EXPECT_NEAR(1.25, light->Intensity(), 1e-6);
 
   // attenuation
   // Checking near because Ogre stores it as float


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The light intensity has to be scaled by PI before applying it as the  power scale for Ogre2 lights. Without this change, the default sun light brightness is different between ign-gazebo4 and ign-gazebo5

![image](https://user-images.githubusercontent.com/206116/112684887-b96ed900-8e41-11eb-8a43-400ac134e34a.png)
Left: ign-gazebo4, Right: ign-gazebo5

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
