### PR TITLE
Improve build times by reducing included headers

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Capsule.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Capsule.hh
@@ -23,7 +23,6 @@
 
 #include "ignition/rendering/base/BaseCapsule.hh"
 #include "ignition/rendering/ogre2/Ogre2Geometry.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace Ogre
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Conversions.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Conversions.hh
@@ -24,8 +24,19 @@
 
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/PixelFormat.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Export.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+
+#include <OgreColourValue.h>
+#include <OgreVector3.h>
+#include <OgrePixelFormat.h>
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
@@ -28,7 +28,6 @@
 #include <string>
 
 #include "ignition/rendering/base/BaseDepthCamera.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
 #include "ignition/common/Event.hh"

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DynamicRenderable.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DynamicRenderable.hh
@@ -22,9 +22,21 @@
 #include <vector>
 
 #include "ignition/rendering/ogre2/Export.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "ignition/rendering/Marker.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreHlmsPso.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
+namespace Ogre
+{
+  class MovableObject;
+}
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2GaussianNoisePass.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2GaussianNoisePass.hh
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include "ignition/rendering/base/BaseGaussianNoisePass.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderPass.hh"
 #include "ignition/rendering/ogre2/Export.hh"
 

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2GpuRays.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2GpuRays.hh
@@ -24,7 +24,6 @@
 #include "ignition/rendering/RenderTypes.hh"
 #include "ignition/rendering/base/BaseGpuRays.hh"
 #include "ignition/rendering/ogre2/Export.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTarget.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Grid.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Grid.hh
@@ -21,7 +21,6 @@
 #include <memory>
 #include "ignition/rendering/base/BaseGrid.hh"
 #include "ignition/rendering/ogre2/Ogre2Geometry.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace Ogre
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2LidarVisual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2LidarVisual.hh
@@ -23,7 +23,6 @@
 #include "ignition/rendering/base/BaseLidarVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Light.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Light.hh
@@ -21,7 +21,14 @@
 
 #include "ignition/rendering/base/BaseLight.hh"
 #include "ignition/rendering/ogre2/Ogre2Node.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreLight.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 namespace Ogre
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2LightVisual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2LightVisual.hh
@@ -21,7 +21,6 @@
 
 #include "ignition/rendering/base/BaseLightVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace Ogre
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Marker.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Marker.hh
@@ -21,7 +21,6 @@
 #include <memory>
 #include "ignition/rendering/base/BaseMarker.hh"
 #include "ignition/rendering/ogre2/Ogre2Geometry.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
@@ -22,7 +22,21 @@
 
 #include "ignition/rendering/base/BaseMaterial.hh"
 #include "ignition/rendering/ogre2/Ogre2Object.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <Hlms/Pbs/OgreHlmsPbsPrerequisites.h>
+#include <OgreMaterial.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
+namespace Ogre
+{
+  class HlmsPbsDatablock;
+  class HlmsUnlitDatablock;
+}  // namespace Ogre
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
@@ -24,8 +24,16 @@
 #include <ignition/math/Color.hh>
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/ogre2/Export.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreMaterial.h>
+#include <OgreRenderTargetListener.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RayQuery.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RayQuery.hh
@@ -20,7 +20,6 @@
 #include <memory>
 
 #include "ignition/rendering/base/BaseRayQuery.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Object.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderPass.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderPass.hh
@@ -22,7 +22,6 @@
 
 #include "ignition/rendering/base/BaseRenderPass.hh"
 #include "ignition/rendering/ogre2/Export.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Object.hh"
 
 namespace ignition

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
@@ -24,9 +24,16 @@
 
 #include "ignition/rendering/base/BaseRenderTypes.hh"
 #include "ignition/rendering/base/BaseRenderTarget.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Object.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTargetMaterial.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <Compositor/OgreCompositorShadowNode.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 namespace Ogre
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTargetMaterial.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTargetMaterial.hh
@@ -20,8 +20,22 @@
 #include <vector>
 
 #include "ignition/rendering/config.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Export.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreRenderTargetListener.h>
+#include <OgreMaterialManager.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Silence deriving from Ogre::RenderTargetListener dll-linkage warnings
+  #pragma warning(disable:4275)
+#endif
 
 namespace ignition
 {
@@ -97,5 +111,9 @@ namespace ignition
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 #endif

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
@@ -29,7 +29,6 @@
 
 #include "ignition/rendering/base/BaseThermalCamera.hh"
 #include "ignition/rendering/ogre2/Export.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
 #include "ignition/common/Event.hh"

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2WireBox.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2WireBox.hh
@@ -21,7 +21,6 @@
 #include <memory>
 #include "ignition/rendering/base/BaseWireBox.hh"
 #include "ignition/rendering/ogre2/Ogre2Geometry.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace Ogre
 {

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -17,12 +17,20 @@
 
 #include "ignition/rendering/ogre2/Ogre2Camera.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
-// #include "ignition/rendering/ogre2/Ogre2Material.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTarget.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2SelectionBuffer.hh"
 #include "ignition/rendering/Utils.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreCamera.h>
+#include <OgreItem.h>
+#include <OgreSceneManager.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 /// \brief Private data for the Ogre2Camera class
 class ignition::rendering::Ogre2CameraPrivate

--- a/ogre2/src/Ogre2Conversions.cc
+++ b/ogre2/src/Ogre2Conversions.cc
@@ -16,6 +16,14 @@
  */
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreMatrix4.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 using namespace ignition;
 using namespace rendering;
 

--- a/ogre2/src/Ogre2DynamicRenderable.cc
+++ b/ogre2/src/Ogre2DynamicRenderable.cc
@@ -32,6 +32,18 @@
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreItem.h>
+#include <OgreMesh2.h>
+#include <OgreMeshManager2.h>
+#include <OgreSceneManager.h>
+#include <OgreSubMesh2.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 /// \brief Private implementation
 class ignition::rendering::Ogre2DynamicRenderablePrivate
 {
@@ -131,8 +143,8 @@ void Ogre2DynamicRenderable::DestroyBuffer()
   if (this->dataPtr->vbuffer)
     delete [] this->dataPtr->vbuffer;
 
-  Ogre::Root *root = Ogre2RenderEngine::Instance()->OgreRoot();
-  Ogre::RenderSystem *renderSystem = root->getRenderSystem();
+  Ogre::RenderSystem *renderSystem =
+      this->dataPtr->sceneManager->getDestinationRenderSystem();
   Ogre::VaoManager *vaoManager = renderSystem->getVaoManager();
 
   if (!vaoManager)
@@ -187,8 +199,8 @@ void Ogre2DynamicRenderable::UpdateBuffer()
   if (!this->dataPtr->dirty)
     return;
 
-  Ogre::Root *root = Ogre2RenderEngine::Instance()->OgreRoot();
-  Ogre::RenderSystem *renderSystem = root->getRenderSystem();
+  Ogre::RenderSystem *renderSystem =
+      this->dataPtr->sceneManager->getDestinationRenderSystem();
 
   Ogre::VaoManager *vaoManager = renderSystem->getVaoManager();
   if (!vaoManager)

--- a/ogre2/src/Ogre2GaussianNoisePass.cc
+++ b/ogre2/src/Ogre2GaussianNoisePass.cc
@@ -19,9 +19,24 @@
 #include <ignition/common/Console.hh>
 
 #include "ignition/rendering/RenderPassSystem.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2GaussianNoisePass.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <Compositor/OgreCompositorManager2.h>
+#include <Compositor/OgreCompositorNodeDef.h>
+#include <Compositor/Pass/PassQuad/OgreCompositorPassQuadDef.h>
+#include <OgreMaterial.h>
+#include <OgreMaterialManager.h>
+#include <OgrePass.h>
+#include <OgreRoot.h>
+#include <OgreTechnique.h>
+#include <OgreVector3.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 /// \brief Private data for the Ogre2GaussianNoisePass class
 class ignition::rendering::Ogre2GaussianNoisePassPrivate

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -26,7 +26,6 @@
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2ParticleEmitter.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTarget.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
@@ -35,6 +34,26 @@
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
 
 #include "Ogre2ParticleNoiseListener.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <Compositor/OgreCompositorManager2.h>
+#include <Compositor/OgreCompositorWorkspace.h>
+#include <Compositor/Pass/PassClear/OgreCompositorPassClearDef.h>
+#include <Compositor/Pass/PassQuad/OgreCompositorPassQuadDef.h>
+#include <Compositor/Pass/PassScene/OgreCompositorPassSceneDef.h>
+#include <OgreDepthBuffer.h>
+#include <OgreHardwarePixelBuffer.h>
+#include <OgreItem.h>
+#include <OgreRenderTexture.h>
+#include <OgreRoot.h>
+#include <OgreSceneManager.h>
+#include <OgreTechnique.h>
+#include <OgreTextureManager.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 namespace ignition
 {

--- a/ogre2/src/Ogre2LidarVisual.cc
+++ b/ogre2/src/Ogre2LidarVisual.cc
@@ -23,6 +23,14 @@
 #include "ignition/rendering/ogre2/Ogre2Marker.hh"
 #include "ignition/rendering/ogre2/Ogre2Geometry.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreSceneNode.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 class ignition::rendering::Ogre2LidarVisualPrivate
 {
   /// \brief Non Hitting DynamicLines Object to display

--- a/ogre2/src/Ogre2Light.cc
+++ b/ogre2/src/Ogre2Light.cc
@@ -20,8 +20,15 @@
 #include "ignition/rendering/ogre2/Ogre2Light.hh"
 
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreSceneManager.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 /// \brief Private data for the Ogre2Light class
 class ignition::rendering::Ogre2LightPrivate

--- a/ogre2/src/Ogre2LightVisual.cc
+++ b/ogre2/src/Ogre2LightVisual.cc
@@ -18,6 +18,14 @@
 #include "ignition/rendering/ogre2/Ogre2Material.hh"
 #include "ignition/rendering/ogre2/Ogre2DynamicRenderable.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreSceneNode.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 using namespace ignition;
 using namespace rendering;
 

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -20,8 +20,12 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif
+#include <Hlms/Pbs/OgreHlmsPbs.h>
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
+#include <Hlms/Unlit/OgreHlmsUnlit.h>
 #include <Hlms/Unlit/OgreHlmsUnlitDatablock.h>
+#include <OgreHlmsManager.h>
+#include <OgreMaterialManager.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -35,6 +39,7 @@
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
+
 
 /// \brief Private data for the Ogre2Material class
 class ignition::rendering::Ogre2MaterialPrivate

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -16,10 +16,21 @@
 */
 
 #include "ignition/common/Console.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/RenderTypes.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreItem.h>
+#include <OgreMaterialManager.h>
+#include <OgrePass.h>
+#include <OgreSceneManager.h>
+#include <OgreTechnique.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 using namespace ignition;
 using namespace rendering;

--- a/ogre2/src/Ogre2Mesh.cc
+++ b/ogre2/src/Ogre2Mesh.cc
@@ -20,7 +20,10 @@
 #ifdef _MSC_VER
 #pragma warning(push, 0)
 #endif
+#include <Animation/OgreSkeletonInstance.h>
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
+#include <OgreItem.h>
+#include <OgreSceneManager.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -29,10 +32,8 @@
 
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2Mesh.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Material.hh"
 #include "ignition/rendering/ogre2/Ogre2Storage.hh"
-
 
 /// brief Private implementation of the Ogre2Mesh class
 class ignition::rendering::Ogre2MeshPrivate

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -28,13 +28,32 @@
 #include <ignition/math/Matrix4.hh>
 
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Mesh.hh"
 #include "ignition/rendering/ogre2/Ogre2MeshFactory.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2Storage.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreHardwareBufferManager.h>
+#include <OgreItem.h>
+#include <OgreKeyFrame.h>
+#include <OgreMesh2.h>
+#include <OgreMeshManager.h>
+#include <OgreMeshManager2.h>
+#include <OgreOldBone.h>
+#include <OgreOldSkeletonManager.h>
+#include <OgreSceneManager.h>
+#include <OgreSkeleton.h>
+#include <OgreSubItem.h>
+#include <OgreSubMesh.h>
+#include <OgreSubMesh2.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 /// \brief Private data for the Ogre2MeshFactory class
 class ignition::rendering::Ogre2MeshFactoryPrivate

--- a/ogre2/src/Ogre2Node.cc
+++ b/ogre2/src/Ogre2Node.cc
@@ -19,9 +19,16 @@
 
 #include "ignition/rendering/ogre2/Ogre2Node.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2Storage.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreSceneManager.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 using namespace ignition;
 using namespace rendering;

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -20,11 +20,22 @@
 #include <ignition/common/MeshManager.hh>
 #include <ignition/common/SubMesh.hh>
 
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Camera.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2RayQuery.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreCamera.h>
+#include <OgreItem.h>
+#include <OgreMesh2.h>
+#include <OgreRay.h>
+#include <OgreSceneManager.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 /// \brief Private data class for Ogre2RayQuery
 class ignition::rendering::Ogre2RayQueryPrivate

--- a/ogre2/src/Ogre2RenderTargetMaterial.cc
+++ b/ogre2/src/Ogre2RenderTargetMaterial.cc
@@ -17,6 +17,15 @@
 
 #include "ignition/rendering/ogre2/Ogre2RenderTargetMaterial.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreRenderTarget.h>
+#include <OgreViewport.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 using namespace ignition::rendering;
 
 

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -27,7 +27,6 @@
 #include "ignition/rendering/ogre2/Ogre2GizmoVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2GpuRays.hh"
 #include "ignition/rendering/ogre2/Ogre2Grid.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2Light.hh"
 #include "ignition/rendering/ogre2/Ogre2LightVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2LidarVisual.hh"
@@ -44,6 +43,17 @@
 #include "ignition/rendering/ogre2/Ogre2ThermalCamera.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
 #include "ignition/rendering/ogre2/Ogre2WireBox.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreRoot.h>
+#include <OgreSceneManager.h>
+#include <Overlay/OgreOverlayManager.h>
+#include <Overlay/OgreOverlaySystem.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 /// \brief Private data for the Ogre2Scene class
 class ignition::rendering::Ogre2ScenePrivate

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -20,12 +20,29 @@
 
 #include "ignition/common/Console.hh"
 #include "ignition/rendering/RenderTypes.hh"
-#include "ignition/rendering/ogre2/Ogre2Includes.hh"
 #include "ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTarget.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2SelectionBuffer.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <Compositor/OgreCompositorManager2.h>
+#include <Compositor/OgreCompositorWorkspace.h>
+#include <Compositor/Pass/PassScene/OgreCompositorPassSceneDef.h>
+#include <OgreCamera.h>
+#include <OgreHardwarePixelBuffer.h>
+#include <OgreItem.h>
+#include <OgreRenderTexture.h>
+#include <OgreRoot.h>
+#include <OgreSceneManager.h>
+#include <OgreTextureManager.h>
+#include <OgreViewport.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 using namespace ignition;
 using namespace rendering;


### PR DESCRIPTION
## Summary

Ogre2Includes.hh is a very convenient header but it includes too many
Ogre headers, which heavily affects build times.

For certain .cc files compilation time was reduced by 1.2 seconds on an
i7 7700 @3.60Ghz

A full build was of ign-rendering5 went from 1m 57s to 1m 46s (I only
touched ogre2, not ogre; a full rebuild of ign-rendering5 includes
both; optix was not included in my config).

This amounts to an 11 second improvement for a full build meaning a 9.4%
reduction (more if we consider ogre1 module is affecting measuring)

The solution is to simply include the Ogre headers that are needed, instead
of relying on Ogre2Includes.hh; and making sure Ogre2Includes.hh is never
included in a *.hh file.

## Checklist
- [x] Signed all commits for DCO

This is a simple header inclusion change; it does not alter runtime functionality.
Note that merging this change into other branches such as the WIP 2.2 might cause a few compiler errors as there are fewer headers included. But those build errors should be trivial fix.