### PR TITLE
Prevent texture spam

### DIFF
--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -281,7 +281,7 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
       // see `https://ogrecave.github.io/ogre/api/1.11/_animation.html` under,
       // `Vertex buffer arrangements`.
       currOffset = 0;
-      if (subMesh.TexCoordCount() > 0)
+      if (subMesh.TexCoordCountBySet(0) > 0)
       {
         vertexDecl->addElement(1, currOffset, Ogre::VET_FLOAT2,
             Ogre::VES_TEXTURE_COORDINATES, 0);
@@ -297,7 +297,7 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
                  Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY,
                  false);
 
-      if (subMesh.TexCoordCount() > 0)
+      if (subMesh.TexCoordCountBySet(0) > 0)
       {
         texBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
             vertexDecl->getVertexSize(1),
@@ -310,7 +310,7 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
       vertices = static_cast<float *>(vBuf->lock(
                       Ogre::HardwareBuffer::HBL_DISCARD));
 
-      if (subMesh.TexCoordCount() > 0)
+      if (subMesh.TexCoordCountBySet(0) > 0)
       {
         vertexData->vertexBufferBinding->setBinding(1, texBuf);
         texMappings = static_cast<float *>(texBuf->lock(
@@ -378,10 +378,10 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
           *vertices++ = subMesh.Normal(j).Z();
         }
 
-        if (subMesh.TexCoordCount() > 0)
+        if (subMesh.TexCoordCountBySet(0) > 0)
         {
-          *texMappings++ = subMesh.TexCoord(j).X();
-          *texMappings++ = subMesh.TexCoord(j).Y();
+          *texMappings++ = subMesh.TexCoordBySet(j, 0).X();
+          *texMappings++ = subMesh.TexCoordBySet(j, 0).Y();
         }
       }
 

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -333,7 +333,7 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
       // TODO(anyone): specular colors
 
       // two dimensional texture coordinates
-      if (subMesh.TexCoordCount() > 0)
+      if (subMesh.TexCoordCountBySet(0) > 0)
       {
         vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
             Ogre::VES_TEXTURE_COORDINATES, 0);
@@ -382,10 +382,10 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
           *vertices++ = subMesh.Normal(j).Z();
         }
 
-        if (subMesh.TexCoordCount() > 0)
+        if (subMesh.TexCoordCountBySet(0) > 0)
         {
-          *vertices++ = subMesh.TexCoord(j).X();
-          *vertices++ = subMesh.TexCoord(j).Y();
+          *vertices++ = subMesh.TexCoordBySet(j, 0).X();
+          *vertices++ = subMesh.TexCoordBySet(j, 0).Y();
         }
       }
 


### PR DESCRIPTION
# 🎉 New feature

## Summary

Certain meshes can produce significant amount of output, such as:

```
[GUI] [Wrn] [SubMesh.cc:478] Multiple texture coordinate sets exist in submesh: WoodBeamRound. Checking first set with index: 0
[GUI] [Wrn] [SubMesh.cc:302] Multiple texture coordinate sets exist in submesh: CeilingRocky. Checking first set with index: 0
```

## Test it

If you have subt installed, run:
```
ign launch -v 4 cloudsim_sim.ign circuit:=tunnel worldName:=niosh_sr_config_a levels:=false
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
