### PR TITLE
Update spot light visual size

### DIFF
--- a/include/ignition/rendering/base/BaseLightVisual.hh
+++ b/include/ignition/rendering/base/BaseLightVisual.hh
@@ -220,8 +220,8 @@ namespace ignition
       {
         double angles[2];
         double range = 0.2;
-        angles[0] = range * tan(outerAngle);
-        angles[1] = range * tan(innerAngle);
+        angles[0] = range * tan(outerAngle / 2.0);
+        angles[1] = range * tan(innerAngle / 2.0);
 
         unsigned int i = 0;
         positions.emplace_back(ignition::math::Vector3d(0, 0, 0));


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Port spot light visual size fix from https://github.com/osrf/gazebo/pull/2947 by @peci1



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**


