### PR TITLE
Fix race condition when rendering the UI (#304)

### DIFF
--- a/include/ignition/rendering/Camera.hh
+++ b/include/ignition/rendering/Camera.hh
@@ -279,8 +279,13 @@ namespace ignition
       /// \brief Get the OpenGL texture id associated with the render texture
       /// used by this camera. A valid id is returned only if the underlying
       /// render engine is OpenGL based.
-      /// \return Texture Id of type GLuint.
+      /// \return Texture Id of type GLuint. Returned value is
+      /// valid until the next SwapFromThread() call
       public: virtual unsigned int RenderTextureGLId() const = 0;
+
+      /// \brief Informs this Camera we're done updating from worker thread
+      /// and for this iteration of the loop
+      public: virtual void SwapFromThread() = 0;
 
       /// \brief Add a render pass to the camera
       /// \param[in] _pass New render pass to add

--- a/include/ignition/rendering/RenderTarget.hh
+++ b/include/ignition/rendering/RenderTarget.hh
@@ -93,6 +93,10 @@ namespace ignition
       /// \return Render pass at the specified index
       public: virtual RenderPassPtr RenderPassByIndex(unsigned int _index)
           const = 0;
+
+      /// \brief Informs this RenderTarget we're done updating from worker
+      /// thread and for this iteration of the loop
+      public: virtual void SwapFromThread() = 0;
     };
 
     /* \class RenderTexture RenderTexture.hh \

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -165,6 +165,9 @@ namespace ignition
       public: virtual unsigned int RenderTextureGLId() const override;
 
       // Documentation inherited.
+      public: virtual void SwapFromThread() override;
+
+      // Documentation inherited.
       public: virtual void AddRenderPass(const RenderPassPtr &_pass) override;
 
       // Documentation inherited.
@@ -706,6 +709,14 @@ namespace ignition
       ignerr << "RenderTextureGLId is not supported by current render"
           << " engine" << std::endl;
       return 0u;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseCamera<T>::SwapFromThread()
+    {
+      ignerr << "SwapFromThread is not supported by current render"
+          << " engine" << std::endl;
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseRenderTarget.hh
+++ b/include/ignition/rendering/base/BaseRenderTarget.hh
@@ -79,6 +79,9 @@ namespace ignition
 
       protected: virtual void RebuildImpl() = 0;
 
+      // Documentation inherited.
+      public: virtual void SwapFromThread() override;
+
       protected: PixelFormat format = PF_UNKNOWN;
 
       protected: bool targetDirty = true;
@@ -174,6 +177,12 @@ namespace ignition
         this->RebuildImpl();
         this->targetDirty = false;
       }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseRenderTarget<T>::SwapFromThread()
+    {
     }
 
     //////////////////////////////////////////////////

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
@@ -106,6 +106,9 @@ namespace ignition
       public: virtual unsigned int RenderTextureGLId() const override;
 
       // Documentation inherited.
+      public: virtual void SwapFromThread() override;
+
+      // Documentation inherited.
       public: virtual void Destroy() override;
 
       public: Ogre::Camera *OgreCamera() const;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
@@ -191,6 +191,9 @@ namespace ignition
       /// into a render target or render texture.
       protected: Ogre::CompositorWorkspace *ogreCompositorWorkspace = nullptr;
 
+      /// \brief See Ogre2RenderTexture::ogreTexture
+      protected: Ogre::CompositorWorkspace *ogreCompositorWorkspaceInDisplay = nullptr;
+
       /// \brief Ogre's compositor workspace definition name
       protected: std::string ogreCompositorWorkspaceDefName;
 
@@ -246,6 +249,9 @@ namespace ignition
       public: virtual unsigned int GLId() const override;
 
       // Documentation inherited.
+      public: virtual void SwapFromThread() override;
+
+      // Documentation inherited.
       public: virtual Ogre::RenderTarget *RenderTarget() const override;
 
       // Documentation inherited.
@@ -258,7 +264,11 @@ namespace ignition
       protected: virtual void BuildTarget();
 
       /// \brief Pointer to the internal ogre render texture object
+      /// This value may get swapped with ogreTextureInDisplay
+      /// after calling SwapFromThread
       protected: Ogre::Texture *ogreTexture = nullptr;
+
+      protected: Ogre::Texture *ogreTextureInDisplay = nullptr;
 
       /// \brief Make scene our friend so it can create a ogre2 render texture
       private: friend class Ogre2Scene;

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -208,6 +208,12 @@ unsigned int Ogre2Camera::RenderTextureGLId() const
 }
 
 //////////////////////////////////////////////////
+void Ogre2Camera::SwapFromThread()
+{
+  this->renderTexture->SwapFromThread();
+}
+
+//////////////////////////////////////////////////
 void Ogre2Camera::SetSelectionBuffer()
 {
   this->selectionBuffer = new Ogre2SelectionBuffer(this->name, this->scene);


### PR DESCRIPTION
## Summary

This fix also depends on on a fix in ign-gazebo so that it now can call
SwapFromThread, otherwise the race condition will still happen.

At the current moment, the implementation is very wasteful creating many
more RenderTargets than needed (because 2 workspaces are created).
This issue will be fixed in the next commit

Affects ignitionrobotics/ign-rendering#304

# 🦟 Bug fix

Fixes #304 

## Checklist
- [x] Signed all commits for DCO
