### PR TITLE
Fix size of light visual

### DIFF
--- a/include/ignition/rendering/base/BaseLightVisual.hh
+++ b/include/ignition/rendering/base/BaseLightVisual.hh
@@ -220,8 +220,8 @@ namespace ignition
       {
         double angles[2];
         double range = 0.2;
-        angles[0] = range * tan(outerAngle);
-        angles[1] = range * tan(innerAngle);
+        angles[0] = range * tan(outerAngle / 2);
+        angles[1] = range * tan(innerAngle / 2);
 
         unsigned int i = 0;
         positions.emplace_back(ignition::math::Vector3d(0, 0, 0));


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Light visual is displayed wrong - it shows a cone corresponding to a light with double the angle than it should represent.

This bug was fixed in Gazebo-classic https://github.com/osrf/gazebo/pull/2947

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
