### PR TITLE
👩‍🌾 Find rendering engines quietly, it's ok if they're not present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 # Find OGRE
 list(APPEND ign_ogre_components "RTShaderSystem" "Terrain" "Overlay")
 
-ign_find_package(IgnOGRE VERSION 1.8.0
+ign_find_package(IgnOGRE VERSION 1.8.0 QUIET
   COMPONENTS ${ign_ogre_components}
   REQUIRED_BY ogre
   PRIVATE_FOR ogre)
@@ -78,7 +78,7 @@ endif()
 
 #--------------------------------------
 # Find OGRE2
-ign_find_package(IgnOGRE2 VERSION 2.1.0
+ign_find_package(IgnOGRE2 VERSION 2.1.0 QUIET
     COMPONENTS HlmsPbs HlmsUnlit Overlay
     REQUIRED_BY ogre2
     PRIVATE_FOR ogre2)
@@ -101,7 +101,7 @@ if(NOT MSVC)
 
   #--------------------------------------
   # Find OptiX
-  ign_find_package(OptiX VERSION 3.8.0
+  ign_find_package(OptiX VERSION 3.8.0 QUIET
       REQUIRED_BY optix
       PRIVATE_FOR optix)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #281

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Requires https://github.com/ignitionrobotics/ign-cmake/pull/164

All rendering engines are optional to Ignition Rendering, so I think that we shouldn't throw warnings when they can't be found.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

https://github.com/osrf/buildfarmer/issues/181
