### PR TITLE
Visualize wireframes

### DIFF
--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -110,6 +110,14 @@ namespace ignition
       /// material will be returned.
       public: virtual MaterialPtr Material() = 0;
 
+      /// \brief Enable or disable wireframe
+      /// \param[in] _show True to enable wireframe
+      public: virtual void SetWireframe(bool _show) = 0;
+
+      /// \brief Get whether wireframe is enabled for this visual.
+      /// \return True if wireframe is enabled for this visual.
+      public: virtual bool Wireframe() const = 0;
+
       /// \brief Specify if this visual is visible
       /// \param[in] _visible True if this visual should be made visible
       public: virtual void SetVisible(bool _visible) = 0;

--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -122,10 +122,6 @@ namespace ignition
       /// \param[in] _visible True if this visual should be made visible
       public: virtual void SetVisible(bool _visible) = 0;
 
-      /// \brief Set the visibility of this visual
-      /// \param[in] _visibility Value of the visiblity
-      public: virtual void SetTransparency(double _transp) = 0;
-
       /// \brief Set visibility flags
       /// \param[in] _flags Visibility flags
       public: virtual void SetVisibilityFlags(uint32_t _flags) = 0;

--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -122,6 +122,10 @@ namespace ignition
       /// \param[in] _visible True if this visual should be made visible
       public: virtual void SetVisible(bool _visible) = 0;
 
+      /// \brief Set the visibility of this visual
+      /// \param[in] _visibility Value of the visiblity
+      public: virtual void SetTransparency(double _transp) = 0;
+
       /// \brief Set visibility flags
       /// \param[in] _flags Visibility flags
       public: virtual void SetVisibilityFlags(uint32_t _flags) = 0;

--- a/include/ignition/rendering/base/BaseVisual.hh
+++ b/include/ignition/rendering/base/BaseVisual.hh
@@ -88,9 +88,6 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
-      // Documentation inherited
-      public: virtual void SetTransparency(double _transp) override;
-
       // Documentation inherited.
       public: virtual void SetVisibilityFlags(uint32_t _flags) override;
 
@@ -367,7 +364,7 @@ namespace ignition
     {
       return this->wireframe;
     }
-    
+
     //////////////////////////////////////////////////
     template <class T>
     void BaseVisual<T>::SetWireframe(bool _show)
@@ -382,15 +379,6 @@ namespace ignition
     void BaseVisual<T>::SetVisible(bool _visible)
     {
       ignerr << "SetVisible(" << _visible << ") not supported for "
-             << "render engine: " << this->Scene()->Engine()->Name()
-             << std::endl;
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseVisual<T>::SetTransparency(double _transp)
-    {
-      ignerr << "SetTransparency(" << _transp << ") not supported for "
              << "render engine: " << this->Scene()->Engine()->Name()
              << std::endl;
     }

--- a/include/ignition/rendering/base/BaseVisual.hh
+++ b/include/ignition/rendering/base/BaseVisual.hh
@@ -88,6 +88,9 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
+      // Documentation inherited
+      public: virtual void SetTransparency(double _transp) override;
+
       // Documentation inherited.
       public: virtual void SetVisibilityFlags(uint32_t _flags) override;
 
@@ -142,6 +145,9 @@ namespace ignition
 
       /// \brief The bounding box of the visual
       protected: ignition::math::AxisAlignedBox boundingBox;
+
+      /// \brief True if wireframe mode is enabled
+      protected: bool wireframe;
     };
 
     //////////////////////////////////////////////////
@@ -357,9 +363,34 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
+    bool BaseVisual<T>::Wireframe() const
+    {
+      return this->wireframe;
+    }
+    
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseVisual<T>::SetWireframe(bool _show)
+    {
+      ignerr << "SetWireframe(" << _show << ") not supported for "
+             << "render engine: " << this->Scene()->Engine()->Name()
+             << std::endl;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
     void BaseVisual<T>::SetVisible(bool _visible)
     {
       ignerr << "SetVisible(" << _visible << ") not supported for "
+             << "render engine: " << this->Scene()->Engine()->Name()
+             << std::endl;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseVisual<T>::SetTransparency(double _transp)
+    {
+      ignerr << "SetTransparency(" << _transp << ") not supported for "
              << "render engine: " << this->Scene()->Engine()->Name()
              << std::endl;
     }

--- a/include/ignition/rendering/base/BaseVisual.hh
+++ b/include/ignition/rendering/base/BaseVisual.hh
@@ -80,6 +80,12 @@ namespace ignition
       public: virtual MaterialPtr Material() override;
 
       // Documentation inherited.
+      public: virtual void SetWireframe(bool _show) override;
+
+      // Documentation inherited.
+      public: virtual bool Wireframe() const override;
+
+      // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
       // Documentation inherited.

--- a/ogre/include/ignition/rendering/ogre/OgreVisual.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreVisual.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_OGRE_OGREVISUAL_HH_
 #define IGNITION_RENDERING_OGRE_OGREVISUAL_HH_
 
+#include <memory>
 #include <vector>
 
 #include "ignition/rendering/base/BaseVisual.hh"
@@ -29,12 +30,21 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
+    // forward declaration
+    class OgreVisualPrivate;
+
     class IGNITION_RENDERING_OGRE_VISIBLE OgreVisual :
       public BaseVisual<OgreNode>
     {
       protected: OgreVisual();
 
       public: virtual ~OgreVisual();
+
+      // Documentation inherited.
+      public: virtual void SetWireframe(bool _show) override;
+
+      // Documentation inherited.
+      public: virtual bool Wireframe() const override;
 
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
@@ -82,6 +92,9 @@ namespace ignition
       protected: OgreGeometryStorePtr geometries;
 
       private: OgreVisualPtr SharedThis();
+
+      /// \brief Pointer to private data class
+      private: std::unique_ptr<OgreVisualPrivate> dataPtr;
 
       private: friend class OgreScene;
     };

--- a/ogre/include/ignition/rendering/ogre/OgreVisual.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreVisual.hh
@@ -49,6 +49,9 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
+      // Documentation inherited
+      public: virtual void SetTransparency(double _transp) override;
+
       // Documentation inherited.
       public: virtual void SetVisibilityFlags(uint32_t _flags) override;
 

--- a/ogre/include/ignition/rendering/ogre/OgreVisual.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreVisual.hh
@@ -49,9 +49,6 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
-      // Documentation inherited
-      public: virtual void SetTransparency(double _transp) override;
-
       // Documentation inherited.
       public: virtual void SetVisibilityFlags(uint32_t _flags) override;
 

--- a/ogre/src/OgreVisual.cc
+++ b/ogre/src/OgreVisual.cc
@@ -26,14 +26,77 @@
 using namespace ignition;
 using namespace rendering;
 
+/// \brief Private data for the Ogre2Visual class
+class ignition::rendering::OgreVisualPrivate
+{
+  /// \brief True if wireframe mode is enabled
+  public: bool wireframe;
+};
+
 //////////////////////////////////////////////////
 OgreVisual::OgreVisual()
+  : dataPtr(new OgreVisualPrivate)
 {
 }
 
 //////////////////////////////////////////////////
 OgreVisual::~OgreVisual()
 {
+}
+
+//////////////////////////////////////////////////
+void OgreVisual::SetWireframe(bool _show)
+{
+  if (this->dataPtr->wireframe == _show)
+    return;
+
+  this->dataPtr->wireframe = _show;
+  for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
+      i++)
+  {
+    Ogre::Entity *entity = nullptr;
+    Ogre::MovableObject *obj = this->ogreNode->getAttachedObject(i);
+
+    entity = dynamic_cast<Ogre::Entity*>(obj);
+
+    if (!entity)
+      continue;
+
+    // For each ogre::entity
+    for (unsigned int j = 0; j < entity->getNumSubEntities(); j++)
+    {
+      Ogre::SubEntity *subEntity = entity->getSubEntity(j);
+      Ogre::MaterialPtr entityMaterial = subEntity->getMaterial();
+      if (entityMaterial.isNull())
+        continue;
+
+      unsigned int techniqueCount, passCount;
+      Ogre::Technique *technique;
+      Ogre::Pass *pass;
+
+      for (techniqueCount = 0;
+           techniqueCount < entityMaterial->getNumTechniques();
+           ++techniqueCount)
+      {
+        technique = entityMaterial->getTechnique(techniqueCount);
+
+        for (passCount = 0; passCount < technique->getNumPasses(); passCount++)
+        {
+          pass = technique->getPass(passCount);
+          if (_show)
+            pass->setPolygonMode(Ogre::PM_WIREFRAME);
+          else
+            pass->setPolygonMode(Ogre::PM_SOLID);
+        }
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+bool OgreVisual::Wireframe() const
+{
+  return this->dataPtr->wireframe;
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreVisual.cc
+++ b/ogre/src/OgreVisual.cc
@@ -37,6 +37,7 @@ class ignition::rendering::OgreVisualPrivate
 OgreVisual::OgreVisual()
   : dataPtr(new OgreVisualPrivate)
 {
+  this->dataPtr->wireframe = false;
 }
 
 //////////////////////////////////////////////////
@@ -102,76 +103,6 @@ bool OgreVisual::Wireframe() const
 void OgreVisual::SetVisible(bool _visible)
 {
   this->ogreNode->setVisible(_visible);
-}
-
-//////////////////////////////////////////////////
-void OgreVisual::SetTransparency(double _transp)
-{
-  for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
-      i++)
-  {
-    Ogre::Entity *entity = nullptr;
-    Ogre::MovableObject *obj = this->ogreNode->getAttachedObject(i);
-
-    entity = dynamic_cast<Ogre::Entity*>(obj);
-
-    ignwarn << "Fetched entity..." << std::endl;
-
-    if (!entity)
-      continue;
-
-    ignwarn << "Num entities: " << entity->getNumSubEntities() << std::endl;
-
-    // For each ogre::entity
-    for (unsigned int j = 0; j < entity->getNumSubEntities(); j++)
-    {
-      Ogre::SubEntity *subEntity = entity->getSubEntity(j);
-      Ogre::MaterialPtr entityMaterial = subEntity->getMaterial();
-      if (entityMaterial.isNull())
-        continue;
-
-      unsigned int techniqueCount, passCount;
-      Ogre::Technique *technique;
-      Ogre::Pass *pass;
-      Ogre::ColourValue dc;
-
-      ignwarn << "Num techniques: " << entityMaterial->getNumTechniques() << std::endl;
-
-      for (techniqueCount = 0;
-           techniqueCount < entityMaterial->getNumTechniques();
-           ++techniqueCount)
-      {
-        technique = entityMaterial->getTechnique(techniqueCount);
-
-        ignwarn << "Num passes: " << technique->getNumPasses() << std::endl;
-        for (passCount = 0; passCount < technique->getNumPasses(); passCount++)
-        {
-          pass = technique->getPass(passCount);
-          pass->setDepthWriteEnabled(false);
-          pass->setSceneBlending(Ogre::SBT_TRANSPARENT_ALPHA);
-        
-          dc = pass->getDiffuse();
-          dc.a = (1.0f - 0.5f);
-          pass->setDiffuse(dc);
-          // this->dataPtr->diffuse = Conversions::Convert(dc);
-
-          for (unsigned int unitStateCount = 0; unitStateCount <
-              pass->getNumTextureUnitStates(); ++unitStateCount)
-          {
-            auto textureUnitState = pass->getTextureUnitState(unitStateCount);
-
-            if (textureUnitState->getColourBlendMode().operation ==
-                Ogre::LBX_SOURCE1)
-            {
-              textureUnitState->setAlphaOperation(
-                  Ogre::LBX_SOURCE1, Ogre::LBS_MANUAL, Ogre::LBS_CURRENT,
-                  1.0 - 0.5);
-            }
-          }
-        }
-      }
-    }
-  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
@@ -43,6 +43,12 @@ namespace ignition
       /// \brief Destructor
       public: virtual ~Ogre2Visual();
 
+      // Documentation inherited
+      public: virtual void SetWireframe(bool _show) override;
+
+      // Documentation inherited
+      public: virtual bool Wireframe() const override;
+
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
@@ -52,6 +52,9 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
+      // Documentation inherited
+      public: virtual void SetTransparency(double _transp) override;
+
       // Documentation inherited.
       public: virtual void SetVisibilityFlags(uint32_t _flags) override;
 

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
@@ -52,9 +52,6 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
-      // Documentation inherited
-      public: virtual void SetTransparency(double _transp) override;
-
       // Documentation inherited.
       public: virtual void SetVisibilityFlags(uint32_t _flags) override;
 

--- a/ogre2/src/Ogre2Visual.cc
+++ b/ogre2/src/Ogre2Visual.cc
@@ -65,7 +65,6 @@ void Ogre2Visual::SetWireframe(bool _show)
     if (!entity)
       continue;
 
-    // For each ogre::entity
     for (unsigned int j = 0; j < entity->getNumSubEntities(); j++)
     {
       Ogre::v1::SubEntity *subEntity = entity->getSubEntity(j);
@@ -110,6 +109,12 @@ bool Ogre2Visual::Wireframe() const
 void Ogre2Visual::SetVisible(bool _visible)
 {
   this->ogreNode->setVisible(_visible);
+}
+
+//////////////////////////////////////////////////
+void Ogre2Visual::SetTransparency(double _transp)
+{
+  
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Visual.cc
+++ b/ogre2/src/Ogre2Visual.cc
@@ -40,6 +40,7 @@ class ignition::rendering::Ogre2VisualPrivate
 Ogre2Visual::Ogre2Visual()
   : dataPtr(new Ogre2VisualPrivate)
 {
+  this->dataPtr->wireframe = false;
 }
 
 //////////////////////////////////////////////////
@@ -57,43 +58,26 @@ void Ogre2Visual::SetWireframe(bool _show)
   for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
       i++)
   {
-    Ogre::v1::Entity *entity = nullptr;
+    Ogre::Item *item = nullptr;
     Ogre::MovableObject *obj = this->ogreNode->getAttachedObject(i);
 
-    entity = dynamic_cast<Ogre::v1::Entity*>(obj);
+    item = dynamic_cast<Ogre::Item*>(obj);
 
-    if (!entity)
+    if (!item)
       continue;
 
-    for (unsigned int j = 0; j < entity->getNumSubEntities(); j++)
+    for (unsigned int j = 0; j < item->getNumSubItems(); j++)
     {
-      Ogre::v1::SubEntity *subEntity = entity->getSubEntity(j);
-      Ogre::MaterialPtr entityMaterial = subEntity->getMaterial();
-      if (entityMaterial.isNull())
-        continue;
+      Ogre::SubItem *subItem = item->getSubItem(j);
+      auto datablock = subItem->getDatablock();
+      auto macroblock = *(datablock->getMacroblock());
 
-      unsigned int techniqueCount, passCount;
-      Ogre::Technique *technique;
-      Ogre::Pass *pass;
+      if (_show)
+        macroblock.mPolygonMode = Ogre::PM_WIREFRAME;
+      else
+        macroblock.mPolygonMode = Ogre::PM_SOLID;
 
-      for (techniqueCount = 0;
-           techniqueCount < entityMaterial->getNumTechniques();
-           ++techniqueCount)
-      {
-        technique = entityMaterial->getTechnique(techniqueCount);
-
-        for (passCount = 0; passCount < technique->getNumPasses(); passCount++)
-        {
-          pass = technique->getPass(passCount);
-          auto macroblock = *(pass->getMacroblock());
-          if (_show)
-            macroblock.mPolygonMode = Ogre::PM_WIREFRAME;
-          else
-            macroblock.mPolygonMode = Ogre::PM_SOLID;
-
-          pass->setMacroblock(macroblock);
-        }
-      }
+      datablock->setMacroblock(macroblock);
     }
   }
 }
@@ -109,12 +93,6 @@ bool Ogre2Visual::Wireframe() const
 void Ogre2Visual::SetVisible(bool _visible)
 {
   this->ogreNode->setVisible(_visible);
-}
-
-//////////////////////////////////////////////////
-void Ogre2Visual::SetTransparency(double _transp)
-{
-  
 }
 
 //////////////////////////////////////////////////

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -55,6 +55,9 @@ class VisualTest : public testing::Test,
 
   /// \brief Test getting setting bounding boxes
   public: void BoundingBox(const std::string &_renderEngine);
+
+  /// \brief Test changing to wireframe
+  public: void Wireframe(const std::string &_renderEngine);
 };
 
 /////////////////////////////////////////////////
@@ -546,6 +549,34 @@ void VisualTest::BoundingBox(const std::string &_renderEngine)
 TEST_P(VisualTest, BoundingBox)
 {
   BoundingBox(GetParam());
+}
+
+/////////////////////////////////////////////////
+void VisualTest::Wireframe(const std::string &_renderEngine)
+{
+  RenderEngine *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ScenePtr scene = engine->CreateScene("scene6");
+
+  // create visual
+  VisualPtr visual = scene->CreateVisual();
+  ASSERT_NE(nullptr, visual);
+
+  // set wireframe
+  visual->SetWireframe(true);
+  EXPECT_EQ(true, visual->Wireframe());
+}
+
+/////////////////////////////////////////////////
+TEST_P(VisualTest, Wireframe)
+{
+  Wireframe(GetParam());
 }
 
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds wireframe mode to visuals in OGRE 1 and 2.

OGRE 2
![wireframe](https://user-images.githubusercontent.com/39728574/116659202-d8b3d580-a9ae-11eb-9286-68bd357c5937.gif)
OGRE 1
![wireframe_ogre](https://user-images.githubusercontent.com/39728574/116659557-698ab100-a9af-11eb-925e-727c48627bdb.gif)

## Test it
Test it with [visualize_wireframes](https://github.com/atharva-18/ign-gazebo/tree/visualize_wireframes).

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
