### PR TITLE
Visualize wireframes

### DIFF
--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -110,6 +110,14 @@ namespace ignition
       /// material will be returned.
       public: virtual MaterialPtr Material() = 0;
 
+      /// \brief Enable or disable wireframe
+      /// \param[in] _show True to enable wireframe
+      public: virtual void SetWireframe(bool _show) = 0;
+
+      /// \brief Get whether wireframe is enabled for this visual.
+      /// \return True if wireframe is enabled for this visual.
+      public: virtual bool Wireframe() const = 0;
+
       /// \brief Specify if this visual is visible
       /// \param[in] _visible True if this visual should be made visible
       public: virtual void SetVisible(bool _visible) = 0;

--- a/include/ignition/rendering/base/BaseVisual.hh
+++ b/include/ignition/rendering/base/BaseVisual.hh
@@ -80,6 +80,12 @@ namespace ignition
       public: virtual MaterialPtr Material() override;
 
       // Documentation inherited.
+      public: virtual void SetWireframe(bool _show) override;
+
+      // Documentation inherited.
+      public: virtual bool Wireframe() const override;
+
+      // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
       // Documentation inherited.
@@ -136,6 +142,9 @@ namespace ignition
 
       /// \brief The bounding box of the visual
       protected: ignition::math::AxisAlignedBox boundingBox;
+
+      /// \brief True if wireframe mode is enabled else false
+      protected: bool wireframe = false;
     };
 
     //////////////////////////////////////////////////
@@ -347,6 +356,22 @@ namespace ignition
         GeometryPtr geometry = this->GeometryByIndex(i);
         geometry->PreRender();
       }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    bool BaseVisual<T>::Wireframe() const
+    {
+      return this->wireframe;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseVisual<T>::SetWireframe(bool _show)
+    {
+      ignerr << "SetWireframe(" << _show << ") not supported for "
+             << "render engine: " << this->Scene()->Engine()->Name()
+             << std::endl;
     }
 
     //////////////////////////////////////////////////

--- a/ogre/include/ignition/rendering/ogre/OgreVisual.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreVisual.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_OGRE_OGREVISUAL_HH_
 #define IGNITION_RENDERING_OGRE_OGREVISUAL_HH_
 
+#include <memory>
 #include <vector>
 
 #include "ignition/rendering/base/BaseVisual.hh"
@@ -29,12 +30,21 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
+    // forward declaration
+    class OgreVisualPrivate;
+
     class IGNITION_RENDERING_OGRE_VISIBLE OgreVisual :
       public BaseVisual<OgreNode>
     {
       protected: OgreVisual();
 
       public: virtual ~OgreVisual();
+
+      // Documentation inherited.
+      public: virtual void SetWireframe(bool _show) override;
+
+      // Documentation inherited.
+      public: virtual bool Wireframe() const override;
 
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
@@ -82,6 +92,9 @@ namespace ignition
       protected: OgreGeometryStorePtr geometries;
 
       private: OgreVisualPtr SharedThis();
+
+      /// \brief Pointer to private data class
+      private: std::unique_ptr<OgreVisualPrivate> dataPtr;
 
       private: friend class OgreScene;
     };

--- a/ogre/src/OgreVisual.cc
+++ b/ogre/src/OgreVisual.cc
@@ -26,14 +26,77 @@
 using namespace ignition;
 using namespace rendering;
 
+/// \brief Private data for the Ogre2Visual class
+class ignition::rendering::OgreVisualPrivate
+{
+  /// \brief True if wireframe mode is enabled
+  public: bool wireframe;
+};
+
 //////////////////////////////////////////////////
 OgreVisual::OgreVisual()
+  : dataPtr(new OgreVisualPrivate)
 {
+  this->dataPtr->wireframe = false;
 }
 
 //////////////////////////////////////////////////
 OgreVisual::~OgreVisual()
 {
+}
+
+//////////////////////////////////////////////////
+void OgreVisual::SetWireframe(bool _show)
+{
+  if (this->dataPtr->wireframe == _show)
+    return;
+
+  this->dataPtr->wireframe = _show;
+  for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
+      i++)
+  {
+    Ogre::Entity *entity = nullptr;
+    Ogre::MovableObject *obj = this->ogreNode->getAttachedObject(i);
+
+    entity = dynamic_cast<Ogre::Entity *>(obj);
+
+    if (!entity)
+      continue;
+
+    for (unsigned int j = 0; j < entity->getNumSubEntities(); j++)
+    {
+      Ogre::SubEntity *subEntity = entity->getSubEntity(j);
+      Ogre::MaterialPtr entityMaterial = subEntity->getMaterial();
+      if (entityMaterial.isNull())
+        continue;
+
+      unsigned int techniqueCount, passCount;
+      Ogre::Technique *technique;
+      Ogre::Pass *pass;
+
+      for (techniqueCount = 0;
+           techniqueCount < entityMaterial->getNumTechniques();
+           ++techniqueCount)
+      {
+        technique = entityMaterial->getTechnique(techniqueCount);
+
+        for (passCount = 0; passCount < technique->getNumPasses(); passCount++)
+        {
+          pass = technique->getPass(passCount);
+          if (_show)
+            pass->setPolygonMode(Ogre::PM_WIREFRAME);
+          else
+            pass->setPolygonMode(Ogre::PM_SOLID);
+        }
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+bool OgreVisual::Wireframe() const
+{
+  return this->dataPtr->wireframe;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Visual.hh
@@ -43,6 +43,12 @@ namespace ignition
       /// \brief Destructor
       public: virtual ~Ogre2Visual();
 
+      // Documentation inherited
+      public: virtual void SetWireframe(bool _show) override;
+
+      // Documentation inherited
+      public: virtual bool Wireframe() const override;
+
       // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 

--- a/ogre2/src/Ogre2Visual.cc
+++ b/ogre2/src/Ogre2Visual.cc
@@ -26,23 +26,74 @@
 #include "ignition/rendering/ogre2/Ogre2WireBox.hh"
 #include "ignition/rendering/Utils.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreItem.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 using namespace ignition;
 using namespace rendering;
 
 /// \brief Private data for the Ogre2Visual class
 class ignition::rendering::Ogre2VisualPrivate
 {
+  /// \brief True if wireframe mode is enabled
+  public: bool wireframe;
 };
 
 //////////////////////////////////////////////////
 Ogre2Visual::Ogre2Visual()
   : dataPtr(new Ogre2VisualPrivate)
 {
+  this->dataPtr->wireframe = false;
 }
 
 //////////////////////////////////////////////////
 Ogre2Visual::~Ogre2Visual()
 {
+}
+
+//////////////////////////////////////////////////
+void Ogre2Visual::SetWireframe(bool _show)
+{
+  if (this->dataPtr->wireframe == _show)
+    return;
+
+  this->dataPtr->wireframe = _show;
+  for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
+      i++)
+  {
+    Ogre::Item *item = nullptr;
+    Ogre::MovableObject *obj = this->ogreNode->getAttachedObject(i);
+
+    item = dynamic_cast<Ogre::Item *>(obj);
+
+    if (!item)
+      continue;
+
+    for (unsigned int j = 0; j < item->getNumSubItems(); j++)
+    {
+      Ogre::SubItem *subItem = item->getSubItem(j);
+      auto datablock = subItem->getDatablock();
+      auto macroblock = *(datablock->getMacroblock());
+
+      if (_show)
+        macroblock.mPolygonMode = Ogre::PM_WIREFRAME;
+      else
+        macroblock.mPolygonMode = Ogre::PM_SOLID;
+
+      datablock->setMacroblock(macroblock);
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+bool Ogre2Visual::Wireframe() const
+{
+  return this->dataPtr->wireframe;
 }
 
 //////////////////////////////////////////////////

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -55,6 +55,9 @@ class VisualTest : public testing::Test,
 
   /// \brief Test getting setting bounding boxes
   public: void BoundingBox(const std::string &_renderEngine);
+
+  /// \brief Test changing to wireframe
+  public: void Wireframe(const std::string &_renderEngine);
 };
 
 /////////////////////////////////////////////////
@@ -546,6 +549,34 @@ void VisualTest::BoundingBox(const std::string &_renderEngine)
 TEST_P(VisualTest, BoundingBox)
 {
   BoundingBox(GetParam());
+}
+
+/////////////////////////////////////////////////
+void VisualTest::Wireframe(const std::string &_renderEngine)
+{
+  RenderEngine *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ScenePtr scene = engine->CreateScene("scene6");
+
+  // create visual
+  VisualPtr visual = scene->CreateVisual();
+  ASSERT_NE(nullptr, visual);
+
+  // set wireframe
+  visual->SetWireframe(true);
+  EXPECT_EQ(true, visual->Wireframe());
+}
+
+/////////////////////////////////////////////////
+TEST_P(VisualTest, Wireframe)
+{
+  Wireframe(GetParam());
 }
 
 


### PR DESCRIPTION
Signed-off-by: Atharva Pusalkar <atharvapusalkar18@gmail.com>

# 🎉 New feature

## Summary
Adds wireframe mode to visuals in OGRE 1 and 2. This PR targets Ignition Fortress since the changes break the ABI.

OGRE 2
![wireframe_ign_f](https://user-images.githubusercontent.com/39728574/116821979-0610a700-ab9a-11eb-9829-9a24f50ed73d.gif)

OGRE 1
![wireframe_ign_f_ogre](https://user-images.githubusercontent.com/39728574/116821984-0d37b500-ab9a-11eb-899a-e9d1b84555b5.gif)

## Test it
Test it with [wireframes](https://github.com/atharva-18/ign-gazebo/tree/wireframes).

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**