### PR TITLE
Fix depth alpha

### DIFF
--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -283,7 +283,7 @@ void DepthCameraTest::DepthCameraBoxes(
       // We observed the values can be either 255 or 0 but graphics card
       // drivers are free to fill it with any value they want.
       // This should be fixed in ogre 2.2 in ign-rendering6 which forbids
-      // forbids the use of RGB format.
+      // the use of RGB format.
       // see https://github.com/ignitionrobotics/ign-rendering/issues/315
       EXPECT_TRUE(255u == ma || 0u == ma);
       EXPECT_TRUE(255u == la || 0u == la);

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -255,7 +255,6 @@ void DepthCameraTest::DepthCameraBoxes(
       EXPECT_EQ(0u, mr);
       EXPECT_EQ(0u, mg);
       EXPECT_GT(mb, 0u);
-      EXPECT_EQ(255u, ma);
 
       // Far left and right points should be red (background color)
       float lc = pointCloudData[pcLeft + 3];
@@ -268,7 +267,6 @@ void DepthCameraTest::DepthCameraBoxes(
       EXPECT_EQ(255u, lr);
       EXPECT_EQ(0u, lg);
       EXPECT_EQ(0u, lb);
-      EXPECT_EQ(255u, la);
 
       float rc = pointCloudData[pcRight + 3];
       uint32_t *rrgba = reinterpret_cast<uint32_t *>(&rc);
@@ -280,7 +278,16 @@ void DepthCameraTest::DepthCameraBoxes(
       EXPECT_EQ(255u, rr);
       EXPECT_EQ(0u, rg);
       EXPECT_EQ(0u, rb);
-      EXPECT_EQ(255u, ra);
+
+      // Note: internal texture format used is RGB with no alpha channel
+      // We observed the values can be either 255 or 0 but graphics card
+      // drivers are free to fill it with any value they want.
+      // This should be fixed in ogre 2.2 in ign-rendering6 which forbids
+      // forbids the use of RGB format.
+      // see https://github.com/ignitionrobotics/ign-rendering/issues/315
+      EXPECT_TRUE(255u == ma || 0u == ma);
+      EXPECT_TRUE(255u == la || 0u == la);
+      EXPECT_TRUE(255u == ra || 0u == ra);
     }
 
     // Check that for a box really close it returns it is not seen

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -354,7 +354,6 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
       EXPECT_NEAR(0u, mr, colorNoiseTol);
       EXPECT_NEAR(0u, mg, colorNoiseTol);
       EXPECT_GT(mb, 0u);
-      EXPECT_EQ(255u, ma);
 
       // Far left and right points should be red (background color)
       float lc = pointCloudData[pcLeft + 3];
@@ -367,7 +366,6 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
       EXPECT_NEAR(255u, lr, colorNoiseTol);
       EXPECT_NEAR(0u, lg, colorNoiseTol);
       EXPECT_NEAR(0u, lb, colorNoiseTol);
-      EXPECT_EQ(255u, la);
 
       float rc = pointCloudData[pcRight + 3];
       uint32_t *rrgba = reinterpret_cast<uint32_t *>(&rc);
@@ -379,7 +377,16 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
       EXPECT_NEAR(255u, rr, colorNoiseTol);
       EXPECT_NEAR(0u, rg, colorNoiseTol);
       EXPECT_NEAR(0u, rb, colorNoiseTol);
-      EXPECT_EQ(255u, ra);
+
+      // Note: internal texture format used is RGB with no alpha channel
+      // We observed the values can be either 255 or 0 but graphics card
+      // drivers are free to fill it with any value they want.
+      // This should be fixed in ogre 2.2 in ign-rendering6 which forbids
+      // forbids the use of RGB format.
+      // see https://github.com/ignitionrobotics/ign-rendering/issues/315
+      EXPECT_TRUE(255u == ma || 0u == ma);
+      EXPECT_TRUE(255u == la || 0u == la);
+      EXPECT_TRUE(255u == ra || 0u == ra);
     }
 
     // Clean up

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -382,7 +382,7 @@ void RenderPassTest::DepthGaussianNoise(const std::string &_renderEngine)
       // We observed the values can be either 255 or 0 but graphics card
       // drivers are free to fill it with any value they want.
       // This should be fixed in ogre 2.2 in ign-rendering6 which forbids
-      // forbids the use of RGB format.
+      // the use of RGB format.
       // see https://github.com/ignitionrobotics/ign-rendering/issues/315
       EXPECT_TRUE(255u == ma || 0u == ma);
       EXPECT_TRUE(255u == la || 0u == la);

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -406,11 +406,7 @@ TEST_P(RenderPassTest, GaussianNoise)
 }
 
 /////////////////////////////////////////////////
-#ifdef __APPLE__
-TEST_P(RenderPassTest, DISABLED_DepthGaussianNoise)
-#else
 TEST_P(RenderPassTest, DepthGaussianNoise)
-#endif
 {
   DepthGaussianNoise(GetParam());
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #315 

## Summary

Fixes tests that check the alpha value of pixels returned by the Depth Camera. As explained in #315, the internal texture format does not have an alpha channel so the graphics card driver is free to fill any value it wants. I've updated the test to check for either `255` or `0` which we have seen on the CI machines and also on a computer with AMD card with mesa driver. I'm also open to just removing this check in the test.

I also re-enabled the test on macOS :crossed_fingers: 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
