### PR TITLE
Fix capsule selection

### DIFF
--- a/ogre2/src/Ogre2Capsule.cc
+++ b/ogre2/src/Ogre2Capsule.cc
@@ -92,9 +92,9 @@ void Ogre2Capsule::Destroy()
 void Ogre2Capsule::Update()
 {
   common::MeshManager *meshMgr = common::MeshManager::Instance();
-  std::string capsuleMeshName = this->Name() + "_capsule_mesh"
-    + "_" + std::to_string(this->radius)
-    + "_" + std::to_string(this->length);
+  std::string capsuleMeshName = "capsule_mesh";
+  capsuleMeshName += "_" + std::to_string(this->radius)
+      + "_" + std::to_string(this->length);
 
   // Create new mesh if needed
   if (!meshMgr->HasMesh(capsuleMeshName))


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes #283 

## Summary

The mesh that is created by these lines is more like templates so we should not be giving it a unique name. We then create an instance of the mesh (Ogre::item) and assign it a unique name. However that's not the actual cause of the problem though. It seems like there is an issue that after the mesh with the original name (prefixed by Name(), e.g. `scene::Capsule(65523)`) is converted to an item, ogre is not able to find it on mouse click. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
