### PR TITLE
Helper function to get a scene

### DIFF
--- a/include/ignition/rendering/RenderingIface.hh
+++ b/include/ignition/rendering/RenderingIface.hh
@@ -24,6 +24,7 @@
 
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Export.hh"
+#include "ignition/rendering/RenderTypes.hh"
 
 namespace ignition
 {
@@ -131,6 +132,17 @@ namespace ignition
     /// \param[in] _paths The list of the plugin paths
     IGNITION_RENDERING_VISIBLE
     void setPluginPaths(const std::list<std::string> &_paths);
+
+    /// \brief Most applications will only have one rendering engine loaded
+    /// at a time, and only one scene within that. This helper function gets
+    /// the first scene that can be found in the first loaded rendering engine.
+    ///
+    /// It's not recommended to call this function when there's more than one
+    /// engine or scene.
+    ///
+    /// \return Pointer to a scene that was found, null if no scene is loaded.
+    IGNITION_RENDERING_VISIBLE
+    ScenePtr sceneFromFirstRenderEngine();
     }
   }
 }

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -648,9 +648,6 @@ std::string OgreRenderEngine::CreateRenderWindow(const std::string &_handle,
   // Hide window if dimensions are less than or equal to one.
   params["border"] = "none";
 
-  std::ostringstream stream;
-  stream << "OgreWindow(0)" << "_" << _handle;
-
   // Needed for retina displays
   params["contentScalingFactor"] = std::to_string(_ratio);
 
@@ -660,9 +657,12 @@ std::string OgreRenderEngine::CreateRenderWindow(const std::string &_handle,
     params["currentGLContext"] = "true";
   }
 
+  std::ostringstream stream;
   int attempts = 0;
-  while (window == nullptr && (attempts++) < 10)
+  while (window == nullptr && attempts < 10)
   {
+    stream.str("");
+    stream << "OgreWindow(" << attempts << ")" << "_" << _handle;
     try
     {
       window = this->ogreRoot->createRenderWindow(
@@ -674,6 +674,7 @@ std::string OgreRenderEngine::CreateRenderWindow(const std::string &_handle,
              << "]. Exception [" << _e.what() << "]" << std::endl;
       window = nullptr;
     }
+    attempts++;
   }
 
   if (attempts >= 10)

--- a/src/RenderingIface_TEST.cc
+++ b/src/RenderingIface_TEST.cc
@@ -19,6 +19,8 @@
 
 #include "test_config.h"  // NOLINT(build/include)
 
+#include <ignition/common/Console.hh>
+
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/RenderingIface.hh"
@@ -46,7 +48,10 @@ unsigned int defaultEnginesForTest()
 /////////////////////////////////////////////////
 TEST(RenderingIfaceTest, GetEngine)
 {
+  common::Console::SetVerbosity(4);
+
   unsigned int count = defaultEnginesForTest();
+  EXPECT_GT(count, 0u);
 
   EXPECT_EQ(count, engineCount());
 
@@ -55,6 +60,7 @@ TEST(RenderingIfaceTest, GetEngine)
   EXPECT_FALSE(isEngineLoaded("ogre2"));
   EXPECT_FALSE(isEngineLoaded("optix"));
   EXPECT_FALSE(isEngineLoaded("no_such_engine"));
+  EXPECT_EQ(nullptr, sceneFromFirstRenderEngine());
 
   // check get engine
   for (unsigned int i = 0; i < count; ++i)
@@ -73,6 +79,16 @@ TEST(RenderingIfaceTest, GetEngine)
       ++i;
 #endif
 
+#ifndef _WIN32
+    // Windows CI fails with
+    // Ogre::RenderingAPIException::RenderingAPIException: OpenGL 1.5 is not
+    // supported in GLRenderSystem::initialiseContext
+    auto scene = eng->CreateScene("scene");
+    EXPECT_NE(nullptr, scene);
+
+    EXPECT_EQ(scene, sceneFromFirstRenderEngine());
+#endif
+
     ASSERT_EQ(1u, loadedEngines().size());
     EXPECT_EQ(eng->Name(), loadedEngines()[0]);
 
@@ -81,6 +97,7 @@ TEST(RenderingIfaceTest, GetEngine)
   }
 
   EXPECT_TRUE(loadedEngines().empty());
+  EXPECT_EQ(nullptr, sceneFromFirstRenderEngine());
 
   // non-existent engine
   EXPECT_EQ(nullptr, engine("no_such_engine"));
@@ -90,6 +107,8 @@ TEST(RenderingIfaceTest, GetEngine)
 /////////////////////////////////////////////////
 TEST(RenderingIfaceTest, RegisterEngine)
 {
+  common::Console::SetVerbosity(4);
+
   unsigned int count = defaultEnginesForTest();
 
   if (count == 0)


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Most applications will only have one rendering engine loaded at a time, and only one scene within that. This helper function gets the first scene that can be found in any rendering engine.

This pattern is being repeated on several `ign-gui` and `ign-gazebo` plugins, so it would be nice to reduce duplication. For example:

* [Screenshot](https://github.com/ignitionrobotics/ign-gui/blob/ffbdb26ce519f85b273d57527a11470dae3838e1/src/plugins/screenshot/Screenshot.cc#L184-L229)
* [Grid3D](https://github.com/ignitionrobotics/ign-gazebo/blob/f795b657683f629133e7de056771959786a150fd/src/gui/plugins/grid_config/GridConfig.cc#L152-L187)
* [VisualizeLidar](https://github.com/ignitionrobotics/ign-gazebo/blob/a41cf80049c07977079d0b215398dc4225b63038/src/gui/plugins/visualize_lidar/VisualizeLidar.cc#L151-L186)
* etc

This PR could target `ign-rendering3`, I'm targeting `main` because I have other PRs that will depend on it. Once this has been reviewed I can rebase and target 3.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Take a look at the added tests.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
