### PR TITLE
Fix heap overflow when reading

### DIFF
--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -192,9 +192,12 @@ void Ogre2SelectionBuffer::CreateRTTBuffer()
   const_cast<Ogre::CompositorPassSceneDef *>(scenePass)->mVisibilityMask =
       IGN_VISIBILITY_SELECTABLE;
 
-  // buffer to store render texture data
-  size_t bufferSize = Ogre::PixelUtil::getMemorySize(width, height, 1, format);
+  // buffer to store render texture data. Ensure it's at least 4 bytes
+  size_t bufferSize = std::max<size_t>(
+      Ogre::PixelUtil::getMemorySize(width, height, 1, format),
+      4u);
   this->dataPtr->buffer = new uint8_t[bufferSize];
+  memset(this->dataPtr->buffer, 0, 4u);
   this->dataPtr->pixelBox = new Ogre::PixelBox(width,
       height, 1, format, this->dataPtr->buffer);
 }


### PR DESCRIPTION
PF_RGB is 3 bytes. But later on Ogre2SelectionBuffer::OnSelectionClick
will try to read 4 bytes from it.

Fixed by ensuring it's always at least 4 bytes and zero-initializing
those 4 bytes.

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

## Summary

This is too simple of a fix and self explanatory. We were allocating 3 bytes of data and then reading 4 bytes in `Ogre2SelectionBuffer::OnSelectionClick`.

It may be possible to backport to older versions.

Detected by ASAN, just add to ign-rendering/ogre2/src/CMakeLists.txt:

```
set( CMAKE_C_FLAGS_DEBUG
	"${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address" )
set( CMAKE_CXX_FLAGS_DEBUG
	"${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address" )
set( CMAKE_LINKER_FLAGS_DEBUG
	"${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address" )
```

## Checklist
- [x] Signed all commits for DCO
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

