### PR TITLE
Fix new [] / delete mismatch

### DIFF
--- a/src/Image.cc
+++ b/src/Image.cc
@@ -20,6 +20,16 @@ using namespace ignition;
 using namespace rendering;
 
 //////////////////////////////////////////////////
+template <class T>
+struct ArrayDeleter
+{
+  void operator () (T const * p)
+  {
+    delete [] p;
+  }
+};
+
+//////////////////////////////////////////////////
 Image::Image(unsigned int _width, unsigned int _height,
   PixelFormat _format) :
   width(_width),
@@ -27,7 +37,7 @@ Image::Image(unsigned int _width, unsigned int _height,
 {
   this->format = PixelUtil::Sanitize(_format);
   unsigned int size = this->MemorySize();
-  this->data = DataPtr(new unsigned char[size]);
+  this->data = DataPtr(new unsigned char[size], ArrayDeleter<unsigned char>());
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Using a custom deallocator to avoid breaking ABI

Alternatively C++17 supports the following syntax, which was not used:

`typedef std::shared_ptr<unsigned char[]> DataPtr;`

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

## Summary

Another self-explanatory bugfix. Pointers allocated with new [] must be deallocated with delete []; not with "delete"

I thought I could not avoid breaking ABI but turns out it was easy. Thus there is no ABI breakage in this fix.

It may be possibly to backport this fix to older versions

Found by Valgrind. Also detected by ASAN. To use ASAN, just add to ign-rendering/ogre2/src/CMakeLists.txt:

```
set( CMAKE_C_FLAGS_DEBUG
	"${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address" )
set( CMAKE_CXX_FLAGS_DEBUG
	"${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address" )
set( CMAKE_LINKER_FLAGS_DEBUG
	"${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address" )
```


## Checklist
- [x] Signed all commits for DCO
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
