### PR TITLE
Fix ogre2 render pass high GPU usage

### DIFF
--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -255,10 +255,10 @@ void Ogre2RenderTarget::UpdateRenderPassChain(
           ogre2RenderPass->OgreCompositorNodeDefinitionName());
 
       // check if we need to create all nodes or just update the connections.
-      // if node does not exist then it means it has not been added to the
-      // chain yet, in which case, we need to recreate the nodes and
-      // connections
-      if (!node)
+      // if node does not exist then it means it either has not been added to
+      // the chain yet or it was removed because it was disabled.
+      // In both cases, we need to recreate the nodes and connections
+      if (!node && ogre2RenderPass->IsEnabled())
       {
         _recreateNodes = true;
       }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #341 

## Summary

When a render pass is added but not enabled, it was found that ogre2 compositor nodes are being unnecessarily recreated every frame, see this comment: https://github.com/ignitionrobotics/ign-rendering/pull/313#issuecomment-861073829

I've updated the check to take into account the enabled state of the render pass so that we only recreate the nodes if the ogre compositor node is not found but render pass is enabled.

To test: 
1. build and run `ogre2_demo`
2. GPU usage should be lower after the fix. I use `nividia-smi` to check this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
