### PR TITLE
Fix custom shaders uniforms ign-rendering package version number

### DIFF
--- a/examples/custom_shaders_uniforms/CMakeLists.txt
+++ b/examples/custom_shaders_uniforms/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(SYSTEM
   ${PROJECT_BINARY_DIR}
 )
 
-find_package(ignition-rendering4)
+find_package(ignition-rendering5)
 
 set(TARGET_THIRD_PARTY_DEPENDS "")
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Fixed package version number that was missed when the changes were forward ported from `ign-rendering4`. 

We'll need to change it to `ign-rendering6` when forward porting to `main` 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

