### PR TITLE
Relax Gaussian noise test tolerance to fix flaky test

### DIFF
--- a/src/GaussianNoisePass_TEST.cc
+++ b/src/GaussianNoisePass_TEST.cc
@@ -85,8 +85,9 @@ void GaussianNoisePassTest::GaussianNoise(const std::string &_renderEngine)
   double biasStdDev = 0.007;
   noisePass->SetBiasStdDev(biasStdDev);
   // expect bias to be within 3-sigma
-  EXPECT_LE(std::fabs(noisePass->Bias()), biasMean + biasStdDev*3);
-  EXPECT_GE(std::fabs(noisePass->Bias()), biasMean - biasStdDev*3);
+  // Note, tol relaxed to 4-sigma to fix flaky test
+  EXPECT_LE(std::fabs(noisePass->Bias()), biasMean + biasStdDev*4);
+  EXPECT_GE(std::fabs(noisePass->Bias()), biasMean - biasStdDev*4);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

The GaussianNoisePass unit test occasionally fails because the value generated is outside of the 3-sigma. I've relaxed the tol check to be 4-sigma which is something we also did in the integration test, [see here](https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering5/test/integration/render_pass.cc#L313)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
