### PR TITLE
Replace renderOneFrame for per-workspace update calls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,89 @@
 
 ### Ignition Rendering 5.X.X (20XX-XX-XX)
 
+### Ignition Rendering 5.1.0 (2021-06-22)
+
+1. add ifdef for apple in integration test
+    * [Pull request #349](https://github.com/ignitionrobotics/ign-rendering/pull/349)
+
+1. Update light map tutorial
+    * [Pull request #346](https://github.com/ignitionrobotics/ign-rendering/pull/346)
+
+1. relax gaussian test tolerance
+    * [Pull request #344](https://github.com/ignitionrobotics/ign-rendering/pull/344)
+
+1. Fix custom shaders uniforms ign version number
+    * [Pull request #343](https://github.com/ignitionrobotics/ign-rendering/pull/343)
+
+1. recreate node only when needed
+    * [Pull request #342](https://github.com/ignitionrobotics/ign-rendering/pull/342)
+
+1. Backport memory fixes found by ASAN
+    * [Pull request #340](https://github.com/ignitionrobotics/ign-rendering/pull/340)
+
+1. Fix FSAA in UI and lower VRAM consumption
+    * [Pull request #313](https://github.com/ignitionrobotics/ign-rendering/pull/313)
+
+1. Fix depth alpha
+    * [Pull request #316](https://github.com/ignitionrobotics/ign-rendering/pull/316)
+
+1. Fix floating point precision bug handling alpha channel (#332)
+    * [Pull request #333](https://github.com/ignitionrobotics/ign-rendering/pull/333)
+
+1. Fix heap overflow when reading
+    * [Pull request #337](https://github.com/ignitionrobotics/ign-rendering/pull/337)
+
+1. Fix new [] / delete mismatch
+    * [Pull request #338](https://github.com/ignitionrobotics/ign-rendering/pull/338)
+
+1. Test re-enabling depth camera integration test on mac
+    * [Pull request #335](https://github.com/ignitionrobotics/ign-rendering/pull/335)
+
+1. Include MoveTo Helper class to ign-rendering
+    * [Pull request #311](https://github.com/ignitionrobotics/ign-rendering/pull/311)
+
+1. Remove `tools/code_check` and update codecov
+    * [Pull request #321](https://github.com/ignitionrobotics/ign-rendering/pull/321)
+
+1. [OGRE 1.x] Uniform buffer shader support
+    * [Pull request #294](https://github.com/ignitionrobotics/ign-rendering/pull/294)
+
+1. Helper function to get a scene
+    * [Pull request #320](https://github.com/ignitionrobotics/ign-rendering/pull/320)
+
+1. fix capsule mouse picking
+    * [Pull request #319](https://github.com/ignitionrobotics/ign-rendering/pull/319)
+
+1. Fix depth alpha
+    * [Pull request #316](https://github.com/ignitionrobotics/ign-rendering/pull/316)
+
+1. Add shadows to Ogre2DepthCamera without crashing
+    * [Pull request #303](https://github.com/ignitionrobotics/ign-rendering/pull/303)
+
+1. Reduce lidar data discretization
+    * [Pull request #296](https://github.com/ignitionrobotics/ign-rendering/pull/296)
+
+1. update light visual size
+    * [Pull request #306](https://github.com/ignitionrobotics/ign-rendering/pull/306)
+
+1. Improve build times by reducing included headers
+    * [Pull request #299](https://github.com/ignitionrobotics/ign-rendering/pull/299)
+
+1. Add light map tutorial
+    * [Pull request #302](https://github.com/ignitionrobotics/ign-rendering/pull/302)
+
+1. Prevent console warnings when multiple texture coordinates are present
+    * [Pull request #301](https://github.com/ignitionrobotics/ign-rendering/pull/301)
+
+1. Fix gazebo scene viewer build
+    * [Pull request #289](https://github.com/ignitionrobotics/ign-rendering/pull/289)
+
+1. Silence noisy sky error
+    * [Pull request #282](https://github.com/ignitionrobotics/ign-rendering/pull/282)
+
+1. Added command line argument to pick version of Ogre
+    * [Pull request #277](https://github.com/ignitionrobotics/ign-rendering/pull/277)
+
 ### Ignition Rendering 5.0.0 (2021-03-30)
 
 1. Add ogre2 skybox support

--- a/Migration.md
+++ b/Migration.md
@@ -21,10 +21,7 @@ release will remove the deprecated code.
       ```
       scene->PreRender();
       for( auto& camera in cameras )
-      {
-          camera->PreRender();
           camera->Render();
-      }
       for( auto& camera in cameras )
           camera->PostRender();
       scene->PostRender();

--- a/Migration.md
+++ b/Migration.md
@@ -21,7 +21,10 @@ release will remove the deprecated code.
       ```
       scene->PreRender();
       for( auto& camera in cameras )
+      {
+          camera->PreRender();
           camera->Render();
+      }
       for( auto& camera in cameras )
           camera->PostRender();
       scene->PostRender();

--- a/include/ignition/rendering/Camera.hh
+++ b/include/ignition/rendering/Camera.hh
@@ -166,8 +166,8 @@ namespace ignition
       /// \brief Renders a new frame and writes the results to the given image.
       /// This is a convenience function for single-camera scenes. It wraps the
       /// pre-render, render, post-render, and get-image calls into a single
-      /// function. This should be used in applications with multiple cameras
-      /// or multiple consumers of a single camera's images.
+      /// function. This should NOT be used in applications with multiple
+      /// cameras or multiple consumers of a single camera's images.
       /// \param[out] _image Output image buffer
       public: virtual void Capture(Image &_image) = 0;
 

--- a/include/ignition/rendering/Camera.hh
+++ b/include/ignition/rendering/Camera.hh
@@ -152,8 +152,8 @@ namespace ignition
       /// \brief Renders a new frame.
       /// This is a convenience function for single-camera scenes. It wraps the
       /// pre-render, render, and post-render into a single
-      /// function. This should be used in applications with multiple cameras
-      /// or multiple consumers of a single camera's images.
+      /// function. This should NOT be used in applications with multiple
+      /// cameras or multiple consumers of a single camera's images.
       public: virtual void Update() = 0;
 
       /// \brief Created an empty image buffer for capturing images. The

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1106,6 +1106,31 @@ namespace ignition
       /// so flushing once per probe may make better sense.
       public: virtual void PostRenderGpuFlush() = 0;
 
+      /// \brief Old projects migrating to newer versions will
+      /// leak memory if they don't call PostRenderGpuFlush
+      ///
+      /// Settings this value to true forces Gazebo to flush commands for
+      /// every camera.
+      ///
+      /// This is much slower but will ease porting, specially
+      /// if it's not easy to adapt your code to call PostRenderGpuFlush
+      /// at regular intervals for some reason
+      ///
+      /// New projects should set this value to false
+      ///
+      /// \remarks Not all rendering engines care about this.
+      /// ogre2 plugin does.
+      ///
+      /// \param[in] _autoFlush True for old projects who can't or don't know
+      /// when to call PostRenderGpuFlush and prefer to penalize rendering
+      /// performance
+      public: virtual void SetLegacyAutoGpuFlush( bool _autoFlush ) = 0;
+
+      /// \brief Gets the value of SetLegacyAutoGpuFlush
+      /// \return True if Gazebo is using the old method.
+      /// Returns always true for plugins that ignore SetLegacyAutoGpuFlush
+      public: virtual bool GetLegacyAutoGpuFlush() const = 0;
+
       /// \brief Remove and destroy all objects from the scene graph. This does
       /// not completely destroy scene resources, so new objects can be created
       /// and added to the scene afterwards.

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1077,6 +1077,35 @@ namespace ignition
       /// changes by traversing scene-graph, calling PreRender on all objects
       public: virtual void PreRender() = 0;
 
+      /// \brief Flushes all buffered frame data and starts 'a new frame'.
+      /// CPUs queue up a bunch of rendering commands and then waits
+      /// for the GPU to finish up.
+      /// If we flush too often, the CPU will often have to wait for the GPU
+      /// doing nothing.
+      /// If we flush too infrequently, RAM consumption will rise due to
+      /// queueing up unsubmitted work.
+      /// Note that work may be submitted earlier if required by a specific
+      /// operation (e.g. reading GPU -> CPU), however RAM may still
+      /// rise if FlushFrame() isn't called
+      /// This function must be called at least once per frame
+      /// This function may be called for any camera, but affects all cameras
+      ///
+      /// \remarks
+      /// This function should be called after updating all cameras / once per
+      /// frame, but it may be called more often if you're updating too many
+      /// cameras and running out of memory
+      ///
+      /// Example:
+      ///
+      /// Cubemap rendering w/ 3 probes and 5 shadowmaps can cause
+      /// a blow up of passes:
+      ///
+      /// (5 shadow maps per face + 1 regular render) x 6 faces x 3 probes =
+      /// 108 render_scene passes.
+      /// 108 is way too much, causing out of memory situations;
+      /// so flushing once per probe may make better sense.
+      public: virtual void PostRenderGpuFlush() = 0;
+
       /// \brief Remove and destroy all objects from the scene graph. This does
       /// not completely destroy scene resources, so new objects can be created
       /// and added to the scene afterwards.

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1133,7 +1133,7 @@ namespace ignition
       ///
       /// ## Upper bound
       ///
-      /// Once Scene::PostFrame is called, a flush is always forced.
+      /// Once Scene::PostRender is called, a flush is always forced.
       ///
       /// If you set a value of e.g. 6, but you have a single camera and call
       /// PostRender, having a value of 1 or 6 won't matter as the result will

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1080,7 +1080,7 @@ namespace ignition
       /// \brief Call this function after you're done updating ALL cameras
       /// \remark Each PreRender must have a correspondent PostRender
       ///
-      /// \see Scene::SetNumCameraPassesPerGpuFlush
+      /// \see Scene::SetCameraPassCountPerGpuFlush
       public: virtual void PostRender() = 0;
 
       /// \brief
@@ -1138,19 +1138,19 @@ namespace ignition
       /// when to call PostRender and prefer to penalize rendering
       /// performance
       /// Value in range [1; 255] for
-      public: virtual void SetNumCameraPassesPerGpuFlush(uint8_t _numPass) = 0;
+      public: virtual void SetCameraPassCountPerGpuFlush(uint8_t _numPass) = 0;
 
-      /// \brief Returns the value set in SetNumCameraPassesPerGpuFlush
+      /// \brief Returns the value set in SetCameraPassCountPerGpuFlush
       /// \return Value in range [0; 255].
       /// ALWAYS returns 0 for plugins that ignore
-      /// SetNumCameraPassesPerGpuFlush
-      public: virtual uint8_t GetNumCameraPassesPerGpuFlush() const = 0;
+      /// SetCameraPassCountPerGpuFlush
+      public: virtual uint8_t GetCameraPassCountPerGpuFlush() const = 0;
 
-      /// \brief Checks if SetNumCameraPassesPerGpuFlush is 0
+      /// \brief Checks if SetCameraPassCountPerGpuFlush is 0
       /// \return True if Gazebo is using the old method (i.e. 0).
       /// ALWAYS returns true for plugins that ignore
-      /// SetNumCameraPassesPerGpuFlush
-      public: virtual bool GetLegacyAutoGpuFlush() const = 0;
+      /// SetCameraPassCountPerGpuFlush
+      public: virtual bool LegacyAutoGpuFlush() const = 0;
 
       /// \brief Remove and destroy all objects from the scene graph. This does
       /// not completely destroy scene resources, so new objects can be created

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1131,6 +1131,17 @@ namespace ignition
       /// force one flush per cubemap face, flushing a total of 3 times
       /// (one per cubemap).
       ///
+      /// ## Upper bound
+      ///
+      /// Once Scene::PostFrame is called, a flush is always forced.
+      ///
+      /// If you set a value of e.g. 6, but you have a single camera and call
+      /// PostRender, having a value of 1 or 6 won't matter as the result will
+      /// be exactly the same (in every term: performance, memory consumption)
+      ///
+      /// A value of 6 is like an upper bound.
+      /// We may queue _up to_ 6 render passes or less; but never more.
+      ///
       /// \remarks Not all rendering engines care about this.
       /// ogre2 plugin does.
       ///

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1090,10 +1090,7 @@ namespace ignition
       /// \code
       ///   scene->PreRender();
       ///   for( auto& camera in cameras )
-      ///   {
-      ///     camera->PreRender();
       ///     camera->Render();
-      ///   }
       ///   for( auto& camera in cameras )
       ///     camera->PostRender();
       ///   scene->PostRender();
@@ -1186,7 +1183,7 @@ namespace ignition
       /// \return Value in range [0; 255].
       /// ALWAYS returns 0 for plugins that ignore
       /// SetCameraPassCountPerGpuFlush
-      public: virtual uint8_t GetCameraPassCountPerGpuFlush() const = 0;
+      public: virtual uint8_t CameraPassCountPerGpuFlush() const = 0;
 
       /// \brief Checks if SetCameraPassCountPerGpuFlush is 0
       /// \return True if Gazebo is using the old method (i.e. 0).

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -409,7 +409,7 @@ namespace ignition
       this->Scene()->PreRender();
       this->Render();
       this->PostRender();
-      if (!this->Scene()->GetLegacyAutoGpuFlush())
+      if (!this->Scene()->LegacyAutoGpuFlush())
         this->Scene()->PostRender();
     }
 

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -409,7 +409,8 @@ namespace ignition
       this->Scene()->PreRender();
       this->Render();
       this->PostRender();
-      this->Scene()->PostRender();
+      if (!this->Scene()->GetLegacyAutoGpuFlush())
+        this->Scene()->PostRender();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -410,7 +410,9 @@ namespace ignition
       this->Render();
       this->PostRender();
       if (!this->Scene()->LegacyAutoGpuFlush())
+      {
         this->Scene()->PostRender();
+      }
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -409,7 +409,7 @@ namespace ignition
       this->Scene()->PreRender();
       this->Render();
       this->PostRender();
-      this->Scene()->PostRenderGpuFlush();
+      this->Scene()->PostRender();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -409,6 +409,7 @@ namespace ignition
       this->Scene()->PreRender();
       this->Render();
       this->PostRender();
+      this->Scene()->PostRenderGpuFlush();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -526,14 +526,14 @@ namespace ignition
       public: virtual void PostRender() override;
 
       // Documentation inherited.
-      public: virtual void SetNumCameraPassesPerGpuFlush(
+      public: virtual void SetCameraPassCountPerGpuFlush(
             uint8_t _numPass) override;
 
       // Documentation inherited.
-      public: virtual uint8_t GetNumCameraPassesPerGpuFlush() const override;
+      public: virtual uint8_t GetCameraPassCountPerGpuFlush() const override;
 
       // Documentation inherited.
-      public: virtual bool GetLegacyAutoGpuFlush() const override;
+      public: virtual bool LegacyAutoGpuFlush() const override;
 
       protected: virtual unsigned int CreateObjectId();
 

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -523,10 +523,14 @@ namespace ignition
       public: virtual void Destroy() override;
 
       // Documentation inherited.
-      public: virtual void PostRenderGpuFlush() override;
+      public: virtual void PostRender() override;
 
       // Documentation inherited.
-      public: virtual void SetLegacyAutoGpuFlush( bool _autoFlush ) override;
+      public: virtual void SetNumCameraPassesPerGpuFlush(
+            uint8_t _numPass) override;
+
+      // Documentation inherited.
+      public: virtual uint8_t GetNumCameraPassesPerGpuFlush() const override;
 
       // Documentation inherited.
       public: virtual bool GetLegacyAutoGpuFlush() const override;

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -522,6 +522,9 @@ namespace ignition
 
       public: virtual void Destroy() override;
 
+      // Documentation inherited.
+      public: virtual void PostRenderGpuFlush() override;
+
       protected: virtual unsigned int CreateObjectId();
 
       protected: virtual std::string CreateObjectName(unsigned int _id,

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -530,7 +530,7 @@ namespace ignition
             uint8_t _numPass) override;
 
       // Documentation inherited.
-      public: virtual uint8_t GetCameraPassCountPerGpuFlush() const override;
+      public: virtual uint8_t CameraPassCountPerGpuFlush() const override;
 
       // Documentation inherited.
       public: virtual bool LegacyAutoGpuFlush() const override;

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -525,6 +525,12 @@ namespace ignition
       // Documentation inherited.
       public: virtual void PostRenderGpuFlush() override;
 
+      // Documentation inherited.
+      public: virtual void SetLegacyAutoGpuFlush( bool _autoFlush ) override;
+
+      // Documentation inherited.
+      public: virtual bool GetLegacyAutoGpuFlush() const override;
+
       protected: virtual unsigned int CreateObjectId();
 
       protected: virtual std::string CreateObjectName(unsigned int _id,

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -110,9 +110,10 @@ namespace ignition
 
       /// \cond PRIVATE
       /// \internal
-      /// \brief When LegacyAutoGpuFlush(), render targets will
-      /// call this function at start to mimic legacy behavior
-      public: void LegacyStartFrame();
+      /// \brief When LegacyAutoGpuFlush(), this function mimics
+      /// legacy behavior.
+      /// When not, it verifies PreRender has been called
+      public: void StartRendering();
 
       /// \internal
       /// \brief Every Render() function calls this function with
@@ -124,7 +125,7 @@ namespace ignition
       /// (excluding shadow nodes', otherwise it becomes too unpredictable)
       /// \param[in] _startNewFrame whether we ignore
       /// SetCameraPassCountPerGpuFlush.
-      /// Only PostFrame should set this to true.
+      /// Only PostRender should set this to true.
       public: void FlushGpuCommandsAndStartNewFrame(uint8_t _numPasses,
                                                     bool _startNewFrame);
 
@@ -133,7 +134,7 @@ namespace ignition
       protected: void FlushGpuCommandsOnly();
 
       /// \internal
-      /// \brief Ends the frame, i.e. PostFrame wants to do this.
+      /// \brief Ends the frame, i.e. PostRender wants to do this.
       ///
       /// Ogre::SceneManager::updateSceneGraph can't be called again until
       /// this function is called

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -97,6 +97,12 @@ namespace ignition
       // Documentation inherited
       public: virtual void PostRenderGpuFlush() override;
 
+      // Documentation inherited.
+      public: virtual void SetLegacyAutoGpuFlush( bool _autoFlush ) override;
+
+      // Documentation inherited.
+      public: virtual bool GetLegacyAutoGpuFlush() const override;
+
       /// \brief Get a pointer to the ogre scene manager
       /// \return Pointer to the ogre scene manager
       public: virtual Ogre::SceneManager *OgreSceneManager() const;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -94,11 +94,9 @@ namespace ignition
       // Documentation inherited
       public: virtual bool SkyEnabled() const override;
 
-      // Documentation inherited
-      public: virtual void PostRenderGpuFlush() override;
-
       // Documentation inherited.
-      public: virtual void SetLegacyAutoGpuFlush( bool _autoFlush ) override;
+      public: virtual void SetNumCameraPassesPerGpuFlush(
+            uint8_t _numPass) override;
 
       // Documentation inherited.
       public: virtual bool GetLegacyAutoGpuFlush() const override;
@@ -107,7 +105,42 @@ namespace ignition
       /// \return Pointer to the ogre scene manager
       public: virtual Ogre::SceneManager *OgreSceneManager() const;
 
+      // Documentation inherited
+      public: virtual void PostRender() override;
+
       /// \cond PRIVATE
+      /// \internal
+      /// \brief Every Render() function calls this function with
+      /// the number of pass_scene passes it just performed, so
+      /// that we decide if we should flush or not (based on
+      /// SetNumCameraPassesPerGpuFlush)
+      ///
+      /// \param[in] _numPasses Number of pass_scene passes just performed
+      /// (excluding shadow nodes', otherwise it becomes too unpredictable)
+      /// \param[in] _startNewFrame whether we ignore
+      /// SetNumCameraPassesPerGpuFlush.
+      /// Only PostFrame should set this to true.
+      public: void FlushGpuCommandsAndStartNewFrame(uint8_t _numPasses,
+                                                    bool _startNewFrame);
+
+      /// \internal
+      /// \brief Performs actual flushing to GPU
+      protected: void FlushGpuCommandsOnly();
+
+      /// \internal
+      /// \brief Ends the frame, i.e. PostFrame wants to do this.
+      ///
+      /// Ogre::SceneManager::updateSceneGraph can't be called again until
+      /// this function is called
+      ///
+      /// After calling this function again,
+      /// Ogre::SceneManager::updateSceneGraph must be called before
+      /// rendering anything (i.e. done inside PreRender)
+      ///
+      /// This is why every PreRender should be paired with a PostRender
+      /// call when in GetLegacyAutoGpuFlush == false
+      protected: void EndFrame();
+
       /// \internal
       /// \brief Mark shadows dirty to rebuild compostior shadow node
       /// This is set when the number of shadow casting lighst changes

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -109,6 +109,25 @@ namespace ignition
       public: virtual void PostRender() override;
 
       /// \cond PRIVATE
+      /// \brief Certain functions like Ogre2Camera::VisualAt would
+      /// need to call PreRender and PostFrame, which is very unintuitive
+      /// and use hostile.
+      ///
+      /// More over, it's likely that we don't want to advance the frame
+      /// in those cases (e.g. particle FXs should not advance), but we
+      /// still have to initialize and cleanup Ogre once we're done.
+      ///
+      /// This function performs some PreRender steps but only if we're
+      /// not already inside PreRender/PostRender, necessary for rendering
+      /// Ogre2Camera::VisualAt (via Ogre2SelectionBuffer)
+      public: void StartForcedRender();
+
+      /// \brief Opposite of StartForcedRender
+      ///
+      /// This function performs some PostRender steps but only if we're
+      /// not already inside PreRender/PostRender pairs
+      public: void EndForcedRender();
+
       /// \internal
       /// \brief When LegacyAutoGpuFlush(), this function mimics
       /// legacy behavior.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -94,6 +94,9 @@ namespace ignition
       // Documentation inherited
       public: virtual bool SkyEnabled() const override;
 
+      // Documentation inherited
+      public: virtual void PostRenderGpuFlush() override;
+
       /// \brief Get a pointer to the ogre scene manager
       /// \return Pointer to the ogre scene manager
       public: virtual Ogre::SceneManager *OgreSceneManager() const;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -95,11 +95,11 @@ namespace ignition
       public: virtual bool SkyEnabled() const override;
 
       // Documentation inherited.
-      public: virtual void SetNumCameraPassesPerGpuFlush(
+      public: virtual void SetCameraPassCountPerGpuFlush(
             uint8_t _numPass) override;
 
       // Documentation inherited.
-      public: virtual bool GetLegacyAutoGpuFlush() const override;
+      public: virtual bool LegacyAutoGpuFlush() const override;
 
       /// \brief Get a pointer to the ogre scene manager
       /// \return Pointer to the ogre scene manager
@@ -110,7 +110,7 @@ namespace ignition
 
       /// \cond PRIVATE
       /// \internal
-      /// \brief When GetLegacyAutoGpuFlush(), render targets will
+      /// \brief When LegacyAutoGpuFlush(), render targets will
       /// call this function at start to mimic legacy behavior
       public: void LegacyStartFrame();
 
@@ -118,12 +118,12 @@ namespace ignition
       /// \brief Every Render() function calls this function with
       /// the number of pass_scene passes it just performed, so
       /// that we decide if we should flush or not (based on
-      /// SetNumCameraPassesPerGpuFlush)
+      /// SetCameraPassCountPerGpuFlush)
       ///
       /// \param[in] _numPasses Number of pass_scene passes just performed
       /// (excluding shadow nodes', otherwise it becomes too unpredictable)
       /// \param[in] _startNewFrame whether we ignore
-      /// SetNumCameraPassesPerGpuFlush.
+      /// SetCameraPassCountPerGpuFlush.
       /// Only PostFrame should set this to true.
       public: void FlushGpuCommandsAndStartNewFrame(uint8_t _numPasses,
                                                     bool _startNewFrame);
@@ -143,7 +143,7 @@ namespace ignition
       /// rendering anything (i.e. done inside PreRender)
       ///
       /// This is why every PreRender should be paired with a PostRender
-      /// call when in GetLegacyAutoGpuFlush == false
+      /// call when in LegacyAutoGpuFlush == false
       protected: void EndFrame();
 
       /// \internal

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -110,6 +110,11 @@ namespace ignition
 
       /// \cond PRIVATE
       /// \internal
+      /// \brief When GetLegacyAutoGpuFlush(), render targets will
+      /// call this function at start to mimic legacy behavior
+      public: void LegacyStartFrame();
+
+      /// \internal
       /// \brief Every Render() function calls this function with
       /// the number of pass_scene passes it just performed, so
       /// that we decide if we should flush or not (based on

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -99,6 +99,9 @@ namespace ignition
             uint8_t _numPass) override;
 
       // Documentation inherited.
+      public: virtual uint8_t CameraPassCountPerGpuFlush() const override;
+
+      // Documentation inherited.
       public: virtual bool LegacyAutoGpuFlush() const override;
 
       /// \brief Get a pointer to the ogre scene manager
@@ -111,7 +114,7 @@ namespace ignition
       /// \cond PRIVATE
       /// \brief Certain functions like Ogre2Camera::VisualAt would
       /// need to call PreRender and PostFrame, which is very unintuitive
-      /// and use hostile.
+      /// and user-hostile.
       ///
       /// More over, it's likely that we don't want to advance the frame
       /// in those cases (e.g. particle FXs should not advance), but we

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -940,7 +940,7 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
-  if (this->scene->GetLegacyAutoGpuFlush())
+  if (this->scene->LegacyAutoGpuFlush())
     this->scene->LegacyStartFrame();
 
   // update the compositors

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -944,14 +944,13 @@ void Ogre2DepthCamera::Render()
 
   // update the compositors
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
-  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace->_update();
   this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
 
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
-  swappedTargets.reserve( 2u );
-  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+  swappedTargets.reserve(2u);
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget(swappedTargets);
 
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -940,13 +940,12 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
-  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
-  if (legacyAutoGpuFlush)
+  if (this->scene->GetLegacyAutoGpuFlush())
     this->scene->OgreSceneManager()->updateSceneGraph();
 
   // update the compositors
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
-  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace->_update();
   this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
@@ -955,8 +954,7 @@ void Ogre2DepthCamera::Render()
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 
-  if (legacyAutoGpuFlush)
-    this->scene->PostRenderGpuFlush();
+  this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -940,8 +940,7 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
-  if (this->scene->LegacyAutoGpuFlush())
-    this->scene->LegacyStartFrame();
+  this->scene->StartRendering();
 
   // update the compositors
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -941,7 +941,7 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 void Ogre2DepthCamera::Render()
 {
   if (this->scene->GetLegacyAutoGpuFlush())
-    this->scene->OgreSceneManager()->updateSceneGraph();
+    this->scene->LegacyStartFrame();
 
   // update the compositors
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -940,6 +940,10 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
+  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
+  if (legacyAutoGpuFlush)
+    this->scene->OgreSceneManager()->updateSceneGraph();
+
   // update the compositors
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
   //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
@@ -950,6 +954,9 @@ void Ogre2DepthCamera::Render()
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+
+  if (legacyAutoGpuFlush)
+    this->scene->PostRenderGpuFlush();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -941,10 +941,15 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 void Ogre2DepthCamera::Render()
 {
   // update the compositors
-  this->dataPtr->ogreCompositorWorkspace->setEnabled(true);
-  auto engine = Ogre2RenderEngine::Instance();
-  engine->OgreRoot()->renderOneFrame();
-  this->dataPtr->ogreCompositorWorkspace->setEnabled(false);
+  this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
+  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
+  this->dataPtr->ogreCompositorWorkspace->_update();
+  this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
+
+  Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
+  swappedTargets.reserve( 2u );
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1119,7 +1119,7 @@ void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 void Ogre2GpuRays::Render()
 {
   if (this->scene->GetLegacyAutoGpuFlush())
-    this->scene->OgreSceneManager()->updateSceneGraph();
+    this->scene->LegacyStartFrame();
 
   this->UpdateRenderTarget1stPass();
   this->UpdateRenderTarget2ndPass();

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1091,10 +1091,15 @@ void Ogre2GpuRays::UpdateRenderTarget1stPass()
 /////////////////////////////////////////////////
 void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 {
-  this->dataPtr->ogreCompositorWorkspace2nd->setEnabled(true);
-  auto engine = Ogre2RenderEngine::Instance();
-  engine->OgreRoot()->renderOneFrame();
-  this->dataPtr->ogreCompositorWorkspace2nd->setEnabled(false);
+  this->dataPtr->ogreCompositorWorkspace2nd->_validateFinalTarget();
+  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  this->dataPtr->ogreCompositorWorkspace2nd->_beginUpdate(false);
+  this->dataPtr->ogreCompositorWorkspace2nd->_update();
+  this->dataPtr->ogreCompositorWorkspace2nd->_endUpdate(false);
+
+  Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
+  swappedTargets.reserve( 2u );
+  this->dataPtr->ogreCompositorWorkspace2nd->_swapFinalTarget( swappedTargets );
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1091,6 +1091,10 @@ void Ogre2GpuRays::UpdateRenderTarget1stPass()
 /////////////////////////////////////////////////
 void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 {
+  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
+  if (legacyAutoGpuFlush)
+    this->scene->OgreSceneManager()->updateSceneGraph();
+
   this->dataPtr->ogreCompositorWorkspace2nd->_validateFinalTarget();
   //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace2nd->_beginUpdate(false);
@@ -1100,6 +1104,9 @@ void Ogre2GpuRays::UpdateRenderTarget2ndPass()
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace2nd->_swapFinalTarget( swappedTargets );
+
+  if (legacyAutoGpuFlush)
+    this->scene->PostRenderGpuFlush();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1080,7 +1080,7 @@ void Ogre2GpuRays::CreateGpuRaysTextures()
 void Ogre2GpuRays::UpdateRenderTarget1stPass()
 {
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
-  swappedTargets.reserve( 2u );
+  swappedTargets.reserve(2u);
 
   // update the compositors
   for (auto i : this->dataPtr->cubeFaceIdx)
@@ -1088,7 +1088,6 @@ void Ogre2GpuRays::UpdateRenderTarget1stPass()
     this->dataPtr->ogreCompositorWorkspace1st[i]->setEnabled(true);
 
     this->dataPtr->ogreCompositorWorkspace1st[i]->_validateFinalTarget();
-    // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
     this->dataPtr->ogreCompositorWorkspace1st[i]->_beginUpdate(false);
     this->dataPtr->ogreCompositorWorkspace1st[i]->_update();
     this->dataPtr->ogreCompositorWorkspace1st[i]->_endUpdate(false);
@@ -1105,14 +1104,13 @@ void Ogre2GpuRays::UpdateRenderTarget1stPass()
 void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 {
   this->dataPtr->ogreCompositorWorkspace2nd->_validateFinalTarget();
-  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace2nd->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace2nd->_update();
   this->dataPtr->ogreCompositorWorkspace2nd->_endUpdate(false);
 
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
-  swappedTargets.reserve( 2u );
-  this->dataPtr->ogreCompositorWorkspace2nd->_swapFinalTarget( swappedTargets );
+  swappedTargets.reserve(2u);
+  this->dataPtr->ogreCompositorWorkspace2nd->_swapFinalTarget(swappedTargets);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1118,8 +1118,7 @@ void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 //////////////////////////////////////////////////
 void Ogre2GpuRays::Render()
 {
-  if (this->scene->LegacyAutoGpuFlush())
-    this->scene->LegacyStartFrame();
+  this->scene->StartRendering();
 
   this->UpdateRenderTarget1stPass();
   this->UpdateRenderTarget2ndPass();

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1118,7 +1118,7 @@ void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 //////////////////////////////////////////////////
 void Ogre2GpuRays::Render()
 {
-  if (this->scene->GetLegacyAutoGpuFlush())
+  if (this->scene->LegacyAutoGpuFlush())
     this->scene->LegacyStartFrame();
 
   this->UpdateRenderTarget1stPass();

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -428,14 +428,13 @@ void Ogre2RenderTarget::Render()
   this->scene->StartRendering();
 
   this->ogreCompositorWorkspace->_validateFinalTarget();
-  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->ogreCompositorWorkspace->_beginUpdate(false);
   this->ogreCompositorWorkspace->_update();
   this->ogreCompositorWorkspace->_endUpdate(false);
 
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
-  swappedTargets.reserve( 2u );
-  this->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+  swappedTargets.reserve(2u);
+  this->ogreCompositorWorkspace->_swapFinalTarget(swappedTargets);
 
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 }

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -426,7 +426,7 @@ void Ogre2RenderTarget::PostRender()
 void Ogre2RenderTarget::Render()
 {
   if (this->scene->GetLegacyAutoGpuFlush())
-    this->scene->OgreSceneManager()->updateSceneGraph();
+    this->scene->LegacyStartFrame();
 
   this->ogreCompositorWorkspace->_validateFinalTarget();
   // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -425,6 +425,10 @@ void Ogre2RenderTarget::PostRender()
 //////////////////////////////////////////////////
 void Ogre2RenderTarget::Render()
 {
+  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
+  if (legacyAutoGpuFlush)
+    this->scene->OgreSceneManager()->updateSceneGraph();
+
   this->ogreCompositorWorkspace->_validateFinalTarget();
   //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->ogreCompositorWorkspace->_beginUpdate(false);
@@ -434,6 +438,9 @@ void Ogre2RenderTarget::Render()
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
   swappedTargets.reserve( 2u );
   this->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+
+  if (legacyAutoGpuFlush)
+    this->scene->PostRenderGpuFlush();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -425,12 +425,11 @@ void Ogre2RenderTarget::PostRender()
 //////////////////////////////////////////////////
 void Ogre2RenderTarget::Render()
 {
-  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
-  if (legacyAutoGpuFlush)
+  if (this->scene->GetLegacyAutoGpuFlush())
     this->scene->OgreSceneManager()->updateSceneGraph();
 
   this->ogreCompositorWorkspace->_validateFinalTarget();
-  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->ogreCompositorWorkspace->_beginUpdate(false);
   this->ogreCompositorWorkspace->_update();
   this->ogreCompositorWorkspace->_endUpdate(false);
@@ -439,8 +438,7 @@ void Ogre2RenderTarget::Render()
   swappedTargets.reserve( 2u );
   this->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 
-  if (legacyAutoGpuFlush)
-    this->scene->PostRenderGpuFlush();
+  this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -425,7 +425,7 @@ void Ogre2RenderTarget::PostRender()
 //////////////////////////////////////////////////
 void Ogre2RenderTarget::Render()
 {
-  if (this->scene->GetLegacyAutoGpuFlush())
+  if (this->scene->LegacyAutoGpuFlush())
     this->scene->LegacyStartFrame();
 
   this->ogreCompositorWorkspace->_validateFinalTarget();

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -425,33 +425,15 @@ void Ogre2RenderTarget::PostRender()
 //////////////////////////////////////////////////
 void Ogre2RenderTarget::Render()
 {
-  // TODO(anyone)
-  // There is current not an easy solution to manually updating
-  // render textures:
-  // https://forums.ogre3d.org/viewtopic.php?t=84687
-  this->ogreCompositorWorkspace->setEnabled(true);
-  auto engine = Ogre2RenderEngine::Instance();
-  engine->OgreRoot()->renderOneFrame();
-  this->ogreCompositorWorkspace->setEnabled(false);
+  this->ogreCompositorWorkspace->_validateFinalTarget();
+  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  this->ogreCompositorWorkspace->_beginUpdate(false);
+  this->ogreCompositorWorkspace->_update();
+  this->ogreCompositorWorkspace->_endUpdate(false);
 
-  // The code below for manual updating render textures was suggested in ogre
-  // forum but it does not seem to work
-  // this->scene->OgreSceneManager()->updateSceneGraph();
-  // this->ogreCompositorWorkspace->_validateFinalTarget();
-  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
-  // this->ogreCompositorWorkspace->_beginUpdate(false);
-  // this->ogreCompositorWorkspace->_update();
-  // this->ogreCompositorWorkspace->_endUpdate(false);
-
-  // this->scene->OgreSceneManager()->_frameEnded();
-  // for (size_t i=0; i < Ogre::HLMS_MAX; ++i)
-  // {
-  //   Ogre::Hlms *hlms = engine->OgreRoot()->getHlmsManager()->getHlms(
-  //       static_cast<Ogre::HlmsTypes>(i));
-  //   if(hlms)
-  //     hlms->frameEnded();
-  // }
-  // engine->OgreRoot()->getRenderSystem()->_update();
+  Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
+  swappedTargets.reserve( 2u );
+  this->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -425,8 +425,7 @@ void Ogre2RenderTarget::PostRender()
 //////////////////////////////////////////////////
 void Ogre2RenderTarget::Render()
 {
-  if (this->scene->LegacyAutoGpuFlush())
-    this->scene->LegacyStartFrame();
+  this->scene->StartRendering();
 
   this->ogreCompositorWorkspace->_validateFinalTarget();
   // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -236,16 +236,20 @@ void Ogre2Scene::PostRender()
 }
 
 //////////////////////////////////////////////////
-void Ogre2Scene::LegacyStartFrame()
+void Ogre2Scene::StartRendering()
 {
-  IGN_ASSERT(this->LegacyAutoGpuFlush(),
-             "Ogre2Scene::LegacyStartFrame must "
-             "only be called in legacy mode");
+  if (this->LegacyAutoGpuFlush())
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    engine->OgreRoot()->_fireFrameStarted();
 
-  auto engine = Ogre2RenderEngine::Instance();
-  engine->OgreRoot()->_fireFrameStarted();
-
-  this->ogreSceneManager->updateSceneGraph();
+    this->ogreSceneManager->updateSceneGraph();
+  }
+  else
+  {
+    IGN_ASSERT( this->dataPtr->frameUpdateStarted == true,
+                "Started rendering without first calling Scene::PreRender");
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -236,6 +236,35 @@ void Ogre2Scene::PostRender()
 }
 
 //////////////////////////////////////////////////
+void Ogre2Scene::StartForcedRender()
+{
+  if (this->LegacyAutoGpuFlush() || !this->dataPtr->frameUpdateStarted)
+  {
+    this->ogreSceneManager->updateSceneGraph();
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2Scene::EndForcedRender()
+{
+  dataPtr->currNumCameraPasses = 0;
+  FlushGpuCommandsOnly();
+
+  if (this->LegacyAutoGpuFlush() || !this->dataPtr->frameUpdateStarted)
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    auto ogreRoot = engine->OgreRoot();
+
+    auto itor = ogreRoot->getSceneManagerIterator();
+    while (itor.hasMoreElements())
+    {
+      Ogre::SceneManager *sceneManager = itor.getNext();
+      sceneManager->clearFrameData();
+    }
+  }
+}
+
+//////////////////////////////////////////////////
 void Ogre2Scene::StartRendering()
 {
   if (this->LegacyAutoGpuFlush())

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -319,11 +319,11 @@ void Ogre2Scene::FlushGpuCommandsOnly()
 
 #if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 1
   auto hlmsManager = ogreRoot->getHlmsManager();
-  // Updating the compositor with all workspaces disables achieves our goal
+  // Updating the compositor with all workspaces disabled achieves our goal
   ogreCompMgr->_update(Ogre::SceneManagerEnumerator::getSingleton(),
                        hlmsManager);
 #else
-  // Updating the compositor with all workspaces disables achieves our goal
+  // Updating the compositor with all workspaces disabled achieves our goal
   ogreCompMgr->_update();
 #endif
 
@@ -352,6 +352,12 @@ void Ogre2Scene::EndFrame()
 void Ogre2Scene::SetCameraPassCountPerGpuFlush(uint8_t _numPass)
 {
   this->dataPtr->cameraPassCountPerGpuFlush = _numPass;
+}
+
+//////////////////////////////////////////////////
+uint8_t Ogre2Scene::CameraPassCountPerGpuFlush() const
+{
+  return this->dataPtr->cameraPassCountPerGpuFlush;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -158,7 +158,8 @@ void Ogre2Scene::PreRender()
 {
   IGN_ASSERT((this->LegacyAutoGpuFlush() ||
               this->dataPtr->frameUpdateStarted == false),
-             "Scene::PreRender called again before calling Scene::PostRender");
+             "Scene::PreRender called again before calling Scene::PostRender. "
+             "See Scene::SetCameraPassCountPerGpuFlush for details");
   this->dataPtr->frameUpdateStarted = true;
 
   if (this->ShadowsDirty())
@@ -208,7 +209,8 @@ void Ogre2Scene::PostRender()
 {
   IGN_ASSERT((this->LegacyAutoGpuFlush() ||
               this->dataPtr->frameUpdateStarted == true),
-             "Scene::PostRender called again before calling Scene::PreRender");
+             "Scene::PostRender called again before calling Scene::PreRender. "
+             "See Scene::SetCameraPassCountPerGpuFlush for details");
   this->dataPtr->frameUpdateStarted = false;
 
   if (dataPtr->cameraPassCountPerGpuFlush == 0u)

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -208,7 +208,7 @@ void Ogre2Scene::PostRender()
 
   if (dataPtr->numCameraPassesPerGpuFlush == 0u)
   {
-    ignwarn << "Calling Scene::PostRender but"
+    ignwarn << "Calling Scene::PostRender but "
                "SetNumCameraPassesPerGpuFlush is 0 (legacy mode for clients"
                " not calling PostRender)."
                "Read the documentation on SetNumCameraPassesPerGpuFlush, "

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -76,6 +76,9 @@ class ignition::rendering::Ogre2ScenePrivate
   /// \brief Flag to indicate if sky is enabled or not
   public: bool skyEnabled = false;
 
+  /// \brief Flag to indicate if we should flush GPU very often (per camera)
+  public: bool legacyAutoGpuFlush = false;
+
   /// \brief Name of shadow compositor node
   public: const std::string kShadowNodeName = "PbsMaterialsShadowNode";
 };
@@ -209,6 +212,18 @@ void Ogre2Scene::PostRenderGpuFlush()
       Ogre::SceneManager *sceneManager = itor.getNext();
       sceneManager->clearFrameData();
   }
+}
+
+//////////////////////////////////////////////////
+void Ogre2Scene::SetLegacyAutoGpuFlush(bool _autoFlush)
+{
+  this->dataPtr->legacyAutoGpuFlush = _autoFlush;
+}
+
+//////////////////////////////////////////////////
+bool Ogre2Scene::GetLegacyAutoGpuFlush() const
+{
+  return this->dataPtr->legacyAutoGpuFlush;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -85,7 +85,7 @@ class ignition::rendering::Ogre2ScenePrivate
   public: uint32_t currNumCameraPasses = 0u;
 
   /// \brief Flag to indicate if we should flush GPU very often (per camera)
-  public: uint8_t cameraPassCountPerGpuFlush = 0u;
+  public: uint8_t cameraPassCountPerGpuFlush = 6u;
 
   /// \brief Name of shadow compositor node
   public: const std::string kShadowNodeName = "PbsMaterialsShadowNode";

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -84,7 +84,7 @@ class ignition::rendering::Ogre2ScenePrivate
   public: uint32_t currNumCameraPasses = 0u;
 
   /// \brief Flag to indicate if we should flush GPU very often (per camera)
-  public: uint8_t cameraPassCountPerGpuFlush = 0u;
+  public: uint8_t cameraPassCountPerGpuFlush = 6u;
 
   /// \brief Name of shadow compositor node
   public: const std::string kShadowNodeName = "PbsMaterialsShadowNode";
@@ -294,7 +294,7 @@ void Ogre2Scene::FlushGpuCommandsAndStartNewFrame(uint8_t _numPasses,
     FlushGpuCommandsOnly();
 
     // Legacy mode requires to do EndFrame here every time
-    if (dataPtr->cameraPassCountPerGpuFlush == 0u)
+    if (dataPtr->cameraPassCountPerGpuFlush == 0u || _startNewFrame)
       EndFrame();
   }
 }

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -310,13 +310,18 @@ void Ogre2Scene::FlushGpuCommandsOnly()
   auto ogreRoot = engine->OgreRoot();
   Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
 
-  // engine->OgreRoot()->renderOneFrame();
+  // The following code is equivalent to calling:
+  //  engine->OgreRoot()->renderOneFrame();
+  //
+  // however without updating SceneManager::updateSceneGraph
+  // because that has already been done; and most (all?) workspaces
+  // are updated manually (since they're created as disabled)
 
 #if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 1
   auto hlmsManager = ogreRoot->getHlmsManager();
   // Updating the compositor with all workspaces disables achieves our goal
-  ogreCompMgr->_update( Ogre::SceneManagerEnumerator::getSingleton(),
-                        hlmsManager );
+  ogreCompMgr->_update(Ogre::SceneManagerEnumerator::getSingleton(),
+                       hlmsManager);
 #else
   // Updating the compositor with all workspaces disables achieves our goal
   ogreCompMgr->_update();

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -80,11 +80,12 @@ class ignition::rendering::Ogre2ScenePrivate
   /// is incorrect
   public: bool frameUpdateStarted = false;
 
-  /// \brief Flag to indicate if we should flush GPU very often (per camera)
+  /// \brief Keeps track how many passes we've done so far and
+  /// compares it to cameraPassCountPerGpuFlush
   public: uint32_t currNumCameraPasses = 0u;
 
   /// \brief Flag to indicate if we should flush GPU very often (per camera)
-  public: uint8_t cameraPassCountPerGpuFlush = 6u;
+  public: uint8_t cameraPassCountPerGpuFlush = 0u;
 
   /// \brief Name of shadow compositor node
   public: const std::string kShadowNodeName = "PbsMaterialsShadowNode";

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -277,7 +277,8 @@ void Ogre2Scene::StartRendering()
   else
   {
     IGN_ASSERT( this->dataPtr->frameUpdateStarted == true,
-                "Started rendering without first calling Scene::PreRender");
+                "Started rendering without first calling Scene::PreRender. "
+                "See Scene::SetCameraPassCountPerGpuFlush for details");
   }
 }
 

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -195,7 +195,12 @@ void Ogre2Scene::PreRender()
   BaseScene::PreRender();
 
   if (!GetLegacyAutoGpuFlush())
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    engine->OgreRoot()->_fireFrameStarted();
+
     this->ogreSceneManager->updateSceneGraph();
+  }
 }
 
 //////////////////////////////////////////////////
@@ -228,6 +233,19 @@ void Ogre2Scene::PostRender()
       EndFrame();
     }
   }
+}
+
+//////////////////////////////////////////////////
+void Ogre2Scene::LegacyStartFrame()
+{
+  IGN_ASSERT(this->GetLegacyAutoGpuFlush(),
+             "Ogre2Scene::LegacyStartFrame must "
+             "only be called in legacy mode");
+
+  auto engine = Ogre2RenderEngine::Instance();
+  engine->OgreRoot()->_fireFrameStarted();
+
+  this->ogreSceneManager->updateSceneGraph();
 }
 
 //////////////////////////////////////////////////
@@ -275,12 +293,17 @@ void Ogre2Scene::EndFrame()
 {
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
+
+  ogreRoot->_fireFrameRenderingQueued();
+
   auto itor = ogreRoot->getSceneManagerIterator();
   while (itor.hasMoreElements())
   {
       Ogre::SceneManager *sceneManager = itor.getNext();
       sceneManager->clearFrameData();
   }
+
+  ogreRoot->_fireFrameEnded();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -127,7 +127,7 @@ void Ogre2SelectionBuffer::Update()
 
   this->dataPtr->materialSwitcher->Reset();
 
-  if (this->dataPtr->scene->GetLegacyAutoGpuFlush())
+  if (this->dataPtr->scene->LegacyAutoGpuFlush())
     this->dataPtr->scene->LegacyStartFrame();
 
   // manual update

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -128,10 +128,16 @@ void Ogre2SelectionBuffer::Update()
   this->dataPtr->materialSwitcher->Reset();
 
   // manual update
-  this->dataPtr->ogreCompositorWorkspace->setEnabled(true);
-  auto engine = Ogre2RenderEngine::Instance();
-  engine->OgreRoot()->renderOneFrame();
-  this->dataPtr->ogreCompositorWorkspace->setEnabled(false);
+  this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
+  this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
+  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
+  this->dataPtr->ogreCompositorWorkspace->_update();
+  this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
+
+  Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
+  swappedTargets.reserve( 2u );
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 
   this->dataPtr->renderTexture->copyContentsToMemory(*this->dataPtr->pixelBox,
       Ogre::RenderTarget::FB_FRONT);

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -127,6 +127,11 @@ void Ogre2SelectionBuffer::Update()
 
   this->dataPtr->materialSwitcher->Reset();
 
+  const bool legacyAutoGpuFlush =
+      this->dataPtr->scene->GetLegacyAutoGpuFlush();
+  if (legacyAutoGpuFlush)
+    this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
+
   // manual update
   this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
@@ -138,6 +143,9 @@ void Ogre2SelectionBuffer::Update()
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+
+  if (legacyAutoGpuFlush)
+    this->dataPtr->scene->PostRenderGpuFlush();
 
   this->dataPtr->renderTexture->copyContentsToMemory(*this->dataPtr->pixelBox,
       Ogre::RenderTarget::FB_FRONT);

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -127,7 +127,7 @@ void Ogre2SelectionBuffer::Update()
 
   this->dataPtr->materialSwitcher->Reset();
 
-  this->dataPtr->scene->StartRendering();
+  this->dataPtr->scene->StartForcedRender();
 
   // manual update
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
@@ -141,6 +141,8 @@ void Ogre2SelectionBuffer::Update()
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 
   this->dataPtr->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
+
+  this->dataPtr->scene->EndForcedRender();
 
   this->dataPtr->renderTexture->copyContentsToMemory(*this->dataPtr->pixelBox,
       Ogre::RenderTarget::FB_FRONT);

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -127,15 +127,13 @@ void Ogre2SelectionBuffer::Update()
 
   this->dataPtr->materialSwitcher->Reset();
 
-  const bool legacyAutoGpuFlush =
-      this->dataPtr->scene->GetLegacyAutoGpuFlush();
-  if (legacyAutoGpuFlush)
+  if (this->dataPtr->scene->GetLegacyAutoGpuFlush())
     this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
 
   // manual update
   this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
-  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace->_update();
   this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
@@ -144,8 +142,7 @@ void Ogre2SelectionBuffer::Update()
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 
-  if (legacyAutoGpuFlush)
-    this->dataPtr->scene->PostRenderGpuFlush();
+  this->dataPtr->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
   this->dataPtr->renderTexture->copyContentsToMemory(*this->dataPtr->pixelBox,
       Ogre::RenderTarget::FB_FRONT);

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -127,8 +127,7 @@ void Ogre2SelectionBuffer::Update()
 
   this->dataPtr->materialSwitcher->Reset();
 
-  if (this->dataPtr->scene->LegacyAutoGpuFlush())
-    this->dataPtr->scene->LegacyStartFrame();
+  this->dataPtr->scene->StartRendering();
 
   // manual update
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -131,14 +131,13 @@ void Ogre2SelectionBuffer::Update()
 
   // manual update
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
-  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace->_update();
   this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
 
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
-  swappedTargets.reserve( 2u );
-  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+  swappedTargets.reserve(2u);
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget(swappedTargets);
 
   this->dataPtr->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -128,10 +128,9 @@ void Ogre2SelectionBuffer::Update()
   this->dataPtr->materialSwitcher->Reset();
 
   if (this->dataPtr->scene->GetLegacyAutoGpuFlush())
-    this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
+    this->dataPtr->scene->LegacyStartFrame();
 
   // manual update
-  this->dataPtr->scene->OgreSceneManager()->updateSceneGraph();
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
   // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);

--- a/ogre2/src/Ogre2Sensor.cc
+++ b/ogre2/src/Ogre2Sensor.cc
@@ -16,6 +16,13 @@
  */
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
+#include <ignition/rendering/ogre2/Ogre2RenderEngine.hh>
+
+#include <Compositor/OgreCompositorManager2.h>
+#include <OgreHlms.h>
+#include <OgreHlmsManager.h>
+#include <OgreRoot.h>
+
 using namespace ignition;
 using namespace rendering;
 

--- a/ogre2/src/Ogre2Sensor.cc
+++ b/ogre2/src/Ogre2Sensor.cc
@@ -16,13 +16,6 @@
  */
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
-#include <ignition/rendering/ogre2/Ogre2RenderEngine.hh>
-
-#include <Compositor/OgreCompositorManager2.h>
-#include <OgreHlms.h>
-#include <OgreHlmsManager.h>
-#include <OgreRoot.h>
-
 using namespace ignition;
 using namespace rendering;
 

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -827,12 +827,11 @@ void Ogre2ThermalCamera::CreateThermalTexture()
 void Ogre2ThermalCamera::Render()
 {
   // update the compositors
-  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
-  if (legacyAutoGpuFlush)
+  if (this->scene->GetLegacyAutoGpuFlush())
     this->scene->OgreSceneManager()->updateSceneGraph();
 
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
-  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace->_update();
   this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
@@ -841,8 +840,7 @@ void Ogre2ThermalCamera::Render()
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 
-  if (legacyAutoGpuFlush)
-    this->scene->PostRenderGpuFlush();
+  this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -827,7 +827,10 @@ void Ogre2ThermalCamera::CreateThermalTexture()
 void Ogre2ThermalCamera::Render()
 {
   // update the compositors
-  this->scene->OgreSceneManager()->updateSceneGraph();
+  const bool legacyAutoGpuFlush = this->scene->GetLegacyAutoGpuFlush();
+  if (legacyAutoGpuFlush)
+    this->scene->OgreSceneManager()->updateSceneGraph();
+
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
   //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
@@ -837,6 +840,9 @@ void Ogre2ThermalCamera::Render()
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
   swappedTargets.reserve( 2u );
   this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+
+  if (legacyAutoGpuFlush)
+    this->scene->PostRenderGpuFlush();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -827,8 +827,7 @@ void Ogre2ThermalCamera::CreateThermalTexture()
 void Ogre2ThermalCamera::Render()
 {
   // update the compositors
-  if (this->scene->LegacyAutoGpuFlush())
-    this->scene->LegacyStartFrame();
+  this->scene->StartRendering();
 
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
   // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -827,7 +827,7 @@ void Ogre2ThermalCamera::CreateThermalTexture()
 void Ogre2ThermalCamera::Render()
 {
   // update the compositors
-  if (this->scene->GetLegacyAutoGpuFlush())
+  if (this->scene->LegacyAutoGpuFlush())
     this->scene->LegacyStartFrame();
 
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -828,7 +828,7 @@ void Ogre2ThermalCamera::Render()
 {
   // update the compositors
   if (this->scene->GetLegacyAutoGpuFlush())
-    this->scene->OgreSceneManager()->updateSceneGraph();
+    this->scene->LegacyStartFrame();
 
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
   // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -827,10 +827,16 @@ void Ogre2ThermalCamera::CreateThermalTexture()
 void Ogre2ThermalCamera::Render()
 {
   // update the compositors
-  this->dataPtr->ogreCompositorWorkspace->setEnabled(true);
-  auto engine = Ogre2RenderEngine::Instance();
-  engine->OgreRoot()->renderOneFrame();
-  this->dataPtr->ogreCompositorWorkspace->setEnabled(false);
+  this->scene->OgreSceneManager()->updateSceneGraph();
+  this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
+  //engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
+  this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
+  this->dataPtr->ogreCompositorWorkspace->_update();
+  this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
+
+  Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
+  swappedTargets.reserve( 2u );
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -830,14 +830,13 @@ void Ogre2ThermalCamera::Render()
   this->scene->StartRendering();
 
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
-  // engine->OgreRoot()->getRenderSystem()->_beginFrameOnce();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
   this->dataPtr->ogreCompositorWorkspace->_update();
   this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
 
   Ogre::vector<Ogre::RenderTarget*>::type swappedTargets;
-  swappedTargets.reserve( 2u );
-  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget( swappedTargets );
+  swappedTargets.reserve(2u);
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget(swappedTargets);
 
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1302,7 +1302,7 @@ void BaseScene::PostRender()
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetCameraPassCountPerGpuFlush(uint8_t _numPass)
+void BaseScene::SetCameraPassCountPerGpuFlush(uint8_t /*_numPass*/)
 {
 }
 

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1302,6 +1302,17 @@ void BaseScene::PostRenderGpuFlush()
 }
 
 //////////////////////////////////////////////////
+void BaseScene::SetLegacyAutoGpuFlush(bool _autoFlush)
+{
+}
+
+//////////////////////////////////////////////////
+bool BaseScene::GetLegacyAutoGpuFlush() const
+{
+  return true;
+}
+
+//////////////////////////////////////////////////
 void BaseScene::Clear()
 {
   this->nodes->DestroyAll();

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1302,18 +1302,18 @@ void BaseScene::PostRender()
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetNumCameraPassesPerGpuFlush(uint8_t _numPass)
+void BaseScene::SetCameraPassCountPerGpuFlush(uint8_t _numPass)
 {
 }
 
 //////////////////////////////////////////////////
-uint8_t BaseScene::GetNumCameraPassesPerGpuFlush() const
+uint8_t BaseScene::GetCameraPassCountPerGpuFlush() const
 {
   return 0u;
 }
 
 //////////////////////////////////////////////////
-bool BaseScene::GetLegacyAutoGpuFlush() const
+bool BaseScene::LegacyAutoGpuFlush() const
 {
   return true;
 }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1307,7 +1307,7 @@ void BaseScene::SetCameraPassCountPerGpuFlush(uint8_t /*_numPass*/)
 }
 
 //////////////////////////////////////////////////
-uint8_t BaseScene::GetCameraPassCountPerGpuFlush() const
+uint8_t BaseScene::CameraPassCountPerGpuFlush() const
 {
   return 0u;
 }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1297,6 +1297,11 @@ void BaseScene::PreRender()
 }
 
 //////////////////////////////////////////////////
+void BaseScene::PostRenderGpuFlush()
+{
+}
+
+//////////////////////////////////////////////////
 void BaseScene::Clear()
 {
   this->nodes->DestroyAll();

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1297,13 +1297,19 @@ void BaseScene::PreRender()
 }
 
 //////////////////////////////////////////////////
-void BaseScene::PostRenderGpuFlush()
+void BaseScene::PostRender()
 {
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetLegacyAutoGpuFlush(bool _autoFlush)
+void BaseScene::SetNumCameraPassesPerGpuFlush(uint8_t _numPass)
 {
+}
+
+//////////////////////////////////////////////////
+uint8_t BaseScene::GetNumCameraPassesPerGpuFlush() const
+{
+  return 0u;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Implements #323 for ign-rendering

## Summary

Explanation is in the [ticket](https://github.com/ignitionrobotics/ign-rendering/issues/323)

The ticket shouldn't be closed until all modules are merged.

## Test it

This PR is currently defaulting `SetCameraPassCountPerGpuFlush` to 0 avoid breaking ign-sensors.

In order to fully test it, checkout:

1. https://github.com/darksylinc/ign-rendering/tree/matias-PostFrame5
2. https://github.com/darksylinc/ign-gazebo/tree/matias-PostFrame5
3. https://github.com/darksylinc/ign-sensors/tree/matias-PostFrame5

And set `SetCameraPassCountPerGpuFlush` to non-0 (e.g. set `Ogre2ScenePrivate::cameraPassCountPerGpuFlush` to 6)

This change is mostly a performance one; but it also affects particle FXs (and possibly some postprocessing FXs) because without this PR, Ogre2GpuRays rendering a cubemap with particle FXs will render each of the 6 faces in a different time; i.e. as if the simulation moved forward 6 times

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
