### PR TITLE
Small crash fix on shutdown

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -118,19 +118,19 @@ void Ogre2RenderEngine::Destroy()
   delete this->ogreOverlaySystem;
   this->ogreOverlaySystem = nullptr;
 
-  // Clean up any textures that may still be in flight.
-  Ogre::TextureGpuManager *mgr =
-    this->ogreRoot->getRenderSystem()->getTextureGpuManager();
-
-  auto entries = mgr->getEntries();
-  for (auto& [name, entry] : entries)
-  {
-    if (entry.resourceGroup == "General")
-      mgr->destroyTexture(entry.texture);
-  }
-
   if (this->ogreRoot)
   {
+    // Clean up any textures that may still be in flight.
+    Ogre::TextureGpuManager *mgr =
+    this->ogreRoot->getRenderSystem()->getTextureGpuManager();
+
+    auto entries = mgr->getEntries();
+    for (auto& [name, entry] : entries)
+    {
+      if (entry.resourceGroup == "General" && !entry.destroyRequested)
+        mgr->destroyTexture(entry.texture);
+    }
+
     try
     {
       // TODO(anyone): do we need to catch segfault on delete?


### PR DESCRIPTION
# 🦟 Bug fix

Fixes UNIT_RenderingIface_TEST failure.

## Summary

It's too simple. Check for Nullptr. Also I noticed gazebo could crash if it tried to destroy a texture already scheduled for destruction.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
