### PR TITLE
UserData methods moved from Visual to Node

### DIFF
--- a/include/ignition/rendering/Node.hh
+++ b/include/ignition/rendering/Node.hh
@@ -309,28 +309,16 @@ namespace ignition
       /// This detaches all the child nodes but does not destroy them
       public: virtual void RemoveChildren() = 0;
 
-      /// \brief A map of custom key value data
-      protected: std::map<std::string, Variant> userData;
-
       /// \brief Store any custom data associated with this visual
       /// \param[in] _key Unique key
       /// \param[in] _value Value in any type
-      public: virtual void SetUserData(const std::string &_key, Variant _value)
-      {
-        this->userData[_key] = _value;
-      }
+      public: virtual void SetUserData(
+        const std::string &_key, Variant _value) = 0;
 
       /// \brief Get custom data stored in this visual
       /// \param[in] _key Unique key
-      /// \param[in] _value Value in any type
-      public: virtual Variant UserData(const std::string &_key) const
-      {
-        Variant value;
-        auto it = this->userData.find(_key);
-        if (it != this->userData.end())
-          value = it->second;
-        return value;
-      }
+      /// \return Value in any type
+      public: virtual Variant UserData(const std::string &_key) const = 0;
     };
     }
   }

--- a/include/ignition/rendering/Node.hh
+++ b/include/ignition/rendering/Node.hh
@@ -18,6 +18,8 @@
 #define IGNITION_RENDERING_NODE_HH_
 
 #include <string>
+#include <variant>
+
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Quaternion.hh>
 
@@ -32,6 +34,8 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
+    using Variant = std::variant<int, float, double, std::string, bool, unsigned int>;
+
     /// \class Node Node.hh ignition/rendering/Node.hh
     /// \brief Represents a single posable node in the scene graph
     class IGNITION_RENDERING_VISIBLE Node :
@@ -302,6 +306,29 @@ namespace ignition
       /// \brief Remove all child nodes from this node
       /// This detaches all the child nodes but does not destroy them
       public: virtual void RemoveChildren() = 0;
+
+      /// \brief A map of custom key value data
+      protected: std::map<std::string, Variant> userData;
+
+      /// \brief Store any custom data associated with this visual
+      /// \param[in] _key Unique key
+      /// \param[in] _value Value in any type
+      public: virtual void SetUserData(const std::string &_key, Variant _value)
+      {
+        this->userData[_key] = _value;
+      }
+
+      /// \brief Get custom data stored in this visual
+      /// \param[in] _key Unique key
+      /// \param[in] _value Value in any type
+      public: virtual Variant UserData(const std::string &_key) const
+      {
+        Variant value;
+        auto it = this->userData.find(_key);
+        if (it != this->userData.end())
+          value = it->second;
+        return value;
+      }
     };
     }
   }

--- a/include/ignition/rendering/Node.hh
+++ b/include/ignition/rendering/Node.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_NODE_HH_
 #define IGNITION_RENDERING_NODE_HH_
 
+#include <map>
 #include <string>
 #include <variant>
 
@@ -34,7 +35,8 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
-    using Variant = std::variant<int, float, double, std::string, bool, unsigned int>;
+    using Variant =
+      std::variant<int, float, double, std::string, bool, unsigned int>;
 
     /// \class Node Node.hh ignition/rendering/Node.hh
     /// \brief Represents a single posable node in the scene graph

--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -17,7 +17,6 @@
 #ifndef IGNITION_RENDERING_VISUAL_HH_
 #define IGNITION_RENDERING_VISUAL_HH_
 
-#include <variant>
 #include <string>
 #include <ignition/math/AxisAlignedBox.hh>
 #include "ignition/rendering/config.hh"
@@ -28,9 +27,6 @@ namespace ignition
   namespace rendering
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
-    //
-    using Variant = std::variant<int, float, double, std::string>;
-
     /// \class Visual Visual.hh ignition/rendering/Visual.hh
     /// \brief Represents a visual node in a scene graph. A Visual is the only
     /// node that can have Geometry and other Visual children.
@@ -137,17 +133,6 @@ namespace ignition
       /// \brief Remove visibility flags
       /// \param[in] _visibility flags
       public: virtual void RemoveVisibilityFlags(uint32_t _flags) = 0;
-
-      /// \brief Store any custom data associated with this visual
-      /// \param[in] _key Unique key
-      /// \param[in] _value Value in any type
-      public: virtual void SetUserData(const std::string &_key,
-          Variant _value) = 0;
-
-      /// \brief Get custom data stored in this visual
-      /// \param[in] _key Unique key
-      /// \param[in] _value Value in any type
-      public: virtual Variant UserData(const std::string &_key) const = 0;
 
       /// \brief Get the bounding box in world frame coordinates.
       /// \return The axis aligned bounding box

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -171,10 +171,11 @@ namespace ignition
       public: virtual void PreRender() override;
 
       // Documentation inherited
-      public: virtual void SetUserData(const std::string &_key, Variant _value);
+      public: virtual void SetUserData(const std::string &_key, Variant _value)
+        override;
 
       // Documentation inherited
-      public: virtual Variant UserData(const std::string &_key) const;
+      public: virtual Variant UserData(const std::string &_key) const override;
 
       protected: virtual void PreRenderChildren();
 

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -17,7 +17,9 @@
 #ifndef IGNITION_RENDERING_BASE_BASENODE_HH_
 #define IGNITION_RENDERING_BASE_BASENODE_HH_
 
+#include <map>
 #include <string>
+
 #include "ignition/rendering/Node.hh"
 #include "ignition/rendering/Storage.hh"
 #include "ignition/rendering/base/BaseStorage.hh"

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -168,6 +168,12 @@ namespace ignition
 
       public: virtual void PreRender() override;
 
+      // Documentation inherited
+      public: virtual void SetUserData(const std::string &_key, Variant _value);
+
+      // Documentation inherited
+      public: virtual Variant UserData(const std::string &_key) const;
+
       protected: virtual void PreRenderChildren();
 
       protected: virtual math::Pose3d RawLocalPose() const = 0;
@@ -186,6 +192,9 @@ namespace ignition
                      const math::Vector3d &_scale) = 0;
 
       protected: math::Vector3d origin;
+
+      /// \brief A map of custom key value data
+      protected: std::map<std::string, Variant> userData;
     };
 
     //////////////////////////////////////////////////
@@ -572,8 +581,6 @@ namespace ignition
       this->SetLocalScale(_scale * this->LocalScale());
     }
 
-
-
     //////////////////////////////////////////////////
     template <class T>
     void BaseNode<T>::Destroy()
@@ -630,6 +637,22 @@ namespace ignition
     {
       return this->Children()->GetByIndex(_index);
     }
+    }
+
+    template <class T>
+    void BaseNode<T>::SetUserData(const std::string &_key, Variant _value)
+    {
+     this->userData[_key] = _value;
+    }
+
+    template <class T>
+    Variant BaseNode<T>::UserData(const std::string &_key) const
+    {
+     Variant value;
+     auto it = this->userData.find(_key);
+     if (it != this->userData.end())
+       value = it->second;
+     return value;
     }
   }
 }

--- a/include/ignition/rendering/base/BaseVisual.hh
+++ b/include/ignition/rendering/base/BaseVisual.hh
@@ -107,13 +107,6 @@ namespace ignition
       public: virtual void Destroy() override;
 
       // Documentation inherited.
-      public: virtual void SetUserData(const std::string &_key,
-          Variant _value) override;
-
-      // Documentation inherited.
-      public: virtual Variant UserData(const std::string &_key) const override;
-
-      // Documentation inherited.
       public: virtual ignition::math::AxisAlignedBox BoundingBox()
               const override;
 
@@ -133,9 +126,6 @@ namespace ignition
 
       /// \brief Pointer to material assigned to this visual
       protected: MaterialPtr material;
-
-      /// \brief A map of custom key value data
-      protected: std::map<std::string, Variant> userData;
 
       /// \brief Visual's visibility flags
       protected: uint32_t visibilityFlags = IGN_VISIBILITY_ALL;
@@ -480,24 +470,6 @@ namespace ignition
     uint32_t BaseVisual<T>::VisibilityFlags() const
     {
       return this->visibilityFlags;
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    void BaseVisual<T>::SetUserData(const std::string &_key, Variant _value)
-    {
-      this->userData[_key] = _value;
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    Variant BaseVisual<T>::UserData(const std::string &_key) const
-    {
-      Variant value;
-      auto it = this->userData.find(_key);
-      if (it != this->userData.end())
-        value = it->second;
-      return value;
     }
     }
   }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -755,6 +755,7 @@ CameraPtr BaseScene::CreateCamera(const std::string &_name)
 CameraPtr BaseScene::CreateCamera(unsigned int _id, const std::string &_name)
 {
   CameraPtr camera = this->CreateCameraImpl(_id, _name);
+  camera->SetUserData("user-camera", false);
   bool result = this->RegisterSensor(camera);
   return (result) ? camera : nullptr;
 }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -755,7 +755,6 @@ CameraPtr BaseScene::CreateCamera(const std::string &_name)
 CameraPtr BaseScene::CreateCamera(unsigned int _id, const std::string &_name)
 {
   CameraPtr camera = this->CreateCameraImpl(_id, _name);
-  camera->SetUserData("user-camera", false);
   bool result = this->RegisterSensor(camera);
   return (result) ? camera : nullptr;
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-rendering/issues/58

## Summary

This PR is part of the effort to consolidate `ign-gui` and `ign-gazebo` (related to this conversation https://github.com/ignitionrobotics/ign-gui/pull/231#discussion_r662702693) and it also targets this issue https://github.com/ignitionrobotics/ign-rendering/issues/58. 

The idea is to move the `UserData` and `SetUserData` methods to the Node class. I'm not sure how to proceed about the change in the API if I should tick-tock the methods in the Visual class, this change should not affect the API because `Node` is a parent class of `Visual`, it will break ABI but this PR is targeting `main`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

