### PR TITLE
More nullptr checking on Node classes

### DIFF
--- a/ogre/src/OgreNode.cc
+++ b/ogre/src/OgreNode.cc
@@ -58,8 +58,13 @@ Ogre::SceneNode *OgreNode::Node() const
 void OgreNode::Destroy()
 {
   BaseNode::Destroy();
-  Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
-  ogreSceneManager->destroySceneNode(this->ogreNode);
+
+  if (nullptr != this->scene)
+  {
+    Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+    if (nullptr != ogreSceneManager)
+      ogreSceneManager->destroySceneNode(this->ogreNode);
+  }
   this->ogreNode = nullptr;
 }
 
@@ -82,24 +87,36 @@ void OgreNode::SetRawLocalPose(const math::Pose3d &_Pose3d)
 //////////////////////////////////////////////////
 math::Vector3d OgreNode::RawLocalPosition() const
 {
+  if (nullptr == this->ogreNode)
+    return math::Vector3d();
+
   return OgreConversions::Convert(this->ogreNode->getPosition());
 }
 
 //////////////////////////////////////////////////
 void OgreNode::SetRawLocalPosition(const math::Vector3d &_position)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setPosition(OgreConversions::Convert(_position));
 }
 
 //////////////////////////////////////////////////
 math::Quaterniond OgreNode::RawLocalRotation() const
 {
+  if (nullptr == this->ogreNode)
+    return math::Quaterniond();
+
   return OgreConversions::Convert(this->ogreNode->getOrientation());
 }
 
 //////////////////////////////////////////////////
 void OgreNode::SetRawLocalRotation(const math::Quaterniond &_rotation)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setOrientation(OgreConversions::Convert(_rotation));
 }
 
@@ -117,12 +134,29 @@ void OgreNode::Load()
 //////////////////////////////////////////////////
 void OgreNode::Init()
 {
-  Ogre::SceneManager *sceneManager;
-  sceneManager = this->scene->OgreSceneManager();
+  if (nullptr == this->scene)
+  {
+    ignerr << "Failed to initialize node: scene is NULL" << std::endl;
+    return;
+  }
+
+  auto sceneManager = this->scene->OgreSceneManager();
+  if (nullptr == sceneManager)
+  {
+    ignerr << "Failed to initialize node: scene manager is NULL" << std::endl;
+    return;
+  }
+
   this->ogreNode = sceneManager->createSceneNode(this->name);
+  if (nullptr == this->ogreNode)
+  {
+    ignerr << "Failed to create Ogre node" << std::endl;
+    return;
+  }
   this->ogreNode->setInheritScale(true);
   this->children = OgreNodeStorePtr(new OgreNodeStore);
 }
+
 //////////////////////////////////////////////////
 NodeStorePtr OgreNode::Children() const
 {
@@ -132,6 +166,9 @@ NodeStorePtr OgreNode::Children() const
 //////////////////////////////////////////////////
 bool OgreNode::AttachChild(NodePtr _child)
 {
+  if (nullptr == this->ogreNode)
+    return false;
+
   OgreNodePtr derived = std::dynamic_pointer_cast<OgreNode>(_child);
 
   if (!derived)
@@ -149,6 +186,9 @@ bool OgreNode::AttachChild(NodePtr _child)
 //////////////////////////////////////////////////
 bool OgreNode::DetachChild(NodePtr _child)
 {
+  if (nullptr == this->ogreNode)
+    return false;
+
   OgreNodePtr derived = std::dynamic_pointer_cast<OgreNode>(_child);
 
   if (!derived)
@@ -159,6 +199,7 @@ bool OgreNode::DetachChild(NodePtr _child)
   }
 
   this->ogreNode->removeChild(derived->Node());
+
   return true;
 }
 
@@ -172,24 +213,36 @@ OgreNodePtr OgreNode::SharedThis()
 //////////////////////////////////////////////////
 math::Vector3d OgreNode::LocalScale() const
 {
+  if (nullptr == this->ogreNode)
+    return math::Vector3d();
+
   return OgreConversions::Convert(this->ogreNode->getScale());
 }
 
 //////////////////////////////////////////////////
 bool OgreNode::InheritScale() const
 {
+  if (nullptr == this->ogreNode)
+    return false;
+
   return this->ogreNode->getInheritScale();
 }
 
 //////////////////////////////////////////////////
 void OgreNode::SetInheritScale(bool _inherit)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setInheritScale(_inherit);
 }
 
 //////////////////////////////////////////////////
 void OgreNode::SetLocalScaleImpl(const math::Vector3d &_scale)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setScale(OgreConversions::Convert(_scale));
 }
 

--- a/ogre2/src/Ogre2Node.cc
+++ b/ogre2/src/Ogre2Node.cc
@@ -65,8 +65,13 @@ Ogre::SceneNode *Ogre2Node::Node() const
 void Ogre2Node::Destroy()
 {
   BaseNode::Destroy();
-  Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
-  ogreSceneManager->destroySceneNode(this->ogreNode);
+
+  if (nullptr != this->scene)
+  {
+    Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+    if (nullptr != ogreSceneManager)
+      ogreSceneManager->destroySceneNode(this->ogreNode);
+  }
   this->ogreNode = nullptr;
 }
 
@@ -89,24 +94,36 @@ void Ogre2Node::SetRawLocalPose(const math::Pose3d &_Pose3d)
 //////////////////////////////////////////////////
 math::Vector3d Ogre2Node::RawLocalPosition() const
 {
+  if (nullptr == this->ogreNode)
+    return math::Vector3d();
+
   return Ogre2Conversions::Convert(this->ogreNode->getPosition());
 }
 
 //////////////////////////////////////////////////
 void Ogre2Node::SetRawLocalPosition(const math::Vector3d &_position)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setPosition(Ogre2Conversions::Convert(_position));
 }
 
 //////////////////////////////////////////////////
 math::Quaterniond Ogre2Node::RawLocalRotation() const
 {
+  if (nullptr == this->ogreNode)
+    return math::Quaterniond();
+
   return Ogre2Conversions::Convert(this->ogreNode->getOrientation());
 }
 
 //////////////////////////////////////////////////
 void Ogre2Node::SetRawLocalRotation(const math::Quaterniond &_rotation)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setOrientation(Ogre2Conversions::Convert(_rotation));
 }
 
@@ -124,9 +141,25 @@ void Ogre2Node::Load()
 //////////////////////////////////////////////////
 void Ogre2Node::Init()
 {
-  Ogre::SceneManager *sceneManager;
-  sceneManager = this->scene->OgreSceneManager();
+  if (nullptr == this->scene)
+  {
+    ignerr << "Failed to initialize node: scene is NULL" << std::endl;
+    return;
+  }
+
+  auto sceneManager = this->scene->OgreSceneManager();
+  if (nullptr == sceneManager)
+  {
+    ignerr << "Failed to initialize node: scene manager is NULL" << std::endl;
+    return;
+  }
+
   this->ogreNode = sceneManager->createSceneNode();
+  if (nullptr == this->ogreNode)
+  {
+    ignerr << "Failed to create Ogre node" << std::endl;
+    return;
+  }
   this->ogreNode->setInheritScale(true);
   this->children = Ogre2NodeStorePtr(new Ogre2NodeStore);
 }
@@ -140,6 +173,9 @@ NodeStorePtr Ogre2Node::Children() const
 //////////////////////////////////////////////////
 bool Ogre2Node::AttachChild(NodePtr _child)
 {
+  if (nullptr == this->ogreNode)
+    return false;
+
   Ogre2NodePtr derived = std::dynamic_pointer_cast<Ogre2Node>(_child);
 
   if (!derived)
@@ -184,6 +220,7 @@ bool Ogre2Node::DetachChild(NodePtr _child)
   }
 
   this->ogreNode->removeChild(derived->Node());
+
   return true;
 }
 
@@ -197,24 +234,36 @@ Ogre2NodePtr Ogre2Node::SharedThis()
 //////////////////////////////////////////////////
 math::Vector3d Ogre2Node::LocalScale() const
 {
+  if (nullptr == this->ogreNode)
+    return math::Vector3d();
+
   return Ogre2Conversions::Convert(this->ogreNode->getScale());
 }
 
 //////////////////////////////////////////////////
 bool Ogre2Node::InheritScale() const
 {
+  if (nullptr == this->ogreNode)
+    return false;
+
   return this->ogreNode->getInheritScale();
 }
 
 //////////////////////////////////////////////////
 void Ogre2Node::SetInheritScale(bool _inherit)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setInheritScale(_inherit);
 }
 
 //////////////////////////////////////////////////
 void Ogre2Node::SetLocalScaleImpl(const math::Vector3d &_scale)
 {
+  if (nullptr == this->ogreNode)
+    return;
+
   this->ogreNode->setScale(Ogre2Conversions::Convert(_scale));
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This is motivated by a crash I had on `ign-gazebo` with this backtrace:

<details><summary>full backtrace</summary>
<p>

```
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v58Ogr
eNode11DetachChildESt10shared_ptrINS1_4NodeEE+0x74) [0x7efb8e273984] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/ogre/src/OgreNo
de.cc:161
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v58Bas
eNodeINS1_10OgreObjectEE11RemoveChildESt10shared_ptrINS1_4NodeEE+0xcb) [0x7efb8e20a91b] /home/chapulina/dev_bionic/ws_edifice/src/ign-render
ing/include/ignition/rendering/base/BaseNode.hh:239
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v58Bas
eNodeINS1_10OgreObjectEE12RemoveParentEv+0x10e) [0x7efb8e20c2fe] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/include/ignition/re
ndering/base/BaseNode.hh:213
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v58Ogr
eNode7DestroyEv+0x9) [0x7efb8e272fe9] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/ogre/src/OgreNode.cc:60
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v510Ba
seVisualINS1_8OgreNodeEE7DestroyEv+0xa9) [0x7efb8e20b7c9] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/include/ignition/rendering
/base/BaseVisual.hh:318
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v59Bas
eStoreINS1_6VisualENS1_10OgreVisualEE11DestroyImplESt17_Rb_tree_iteratorISt4pairIKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt10sh
ared_ptrIS4_EEE+0x39) [0x7efb8e263dd9] /usr/include/c++/8/bits/shared_ptr_base.h:728
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v59Bas
eStoreINS1_6VisualENS1_10OgreVisualEE10DestroyAllEv+0x32) [0x7efb8e260ad2] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/include/i
gnition/rendering/base/BaseStorage.hh:730
/home/chapulina/dev_bionic/ws_edifice/install/lib/libignition-rendering5.so.5(_ZN8ignition9rendering2v518BaseCompositeStoreINS1_4NodeEE10Des
troyAllEv+0x2e) [0x7efbe02a5b0e] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/include/ignition/rendering/base/BaseStorage.hh:1216
/home/chapulina/dev_bionic/ws_edifice/install/lib/libignition-rendering5.so.5(_ZN8ignition9rendering2v59BaseScene5ClearEv+0x14) [0x7efbe029b
2e4] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/src/base/BaseScene.cc:1241
/home/chapulina/dev_bionic/ws_edifice/install/lib/libignition-rendering5.so.5(_ZN8ignition9rendering2v59BaseScene7DestroyEv+0xd) [0x7efbe029
b31d] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/src/base/BaseScene.cc:1250
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v59Ogr
eScene7DestroyEv+0x9) [0x7efb8e287ce9] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/ogre/src/OgreScene.cc:296
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v59Bas
eStoreINS1_5SceneENS1_9OgreSceneEE11DestroyImplESt17_Rb_tree_iteratorISt4pairIKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt10share
d_ptrIS4_EEE+0x3c) [0x7efb8e26327c] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/include/ignition/rendering/base/BaseStorage.hh:9
56
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-rendering-5/engine-plugins/libignition-rendering-ogre.so(_ZN8ignition9rendering2v59Bas
eStoreINS1_5SceneENS1_9OgreSceneEE7DestroyESt10shared_ptrIS3_E+0x70) [0x7efb8e2647a0] /home/chapulina/dev_bionic/ws_edifice/src/ign-renderin
g/include/ignition/rendering/base/BaseStorage.hh:699
/home/chapulina/dev_bionic/ws_edifice/install/lib/libignition-rendering5.so.5(_ZN8ignition9rendering2v516BaseRenderEngine12DestroySceneESt10
shared_ptrINS1_5SceneEE+0x66) [0x7efbe029a3f6] /home/chapulina/dev_bionic/ws_edifice/src/ign-rendering/src/base/BaseRenderEngine.cc:163
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-gazebo-5/plugins/gui/libGzScene3D.so(_ZN8ignition6gazebo2v511IgnRenderer7DestroyEv+0x2
ac) [0x7efc001523cc] /home/chapulina/dev_bionic/ws_edifice/src/ign-gazebo/src/gui/plugins/scene3d/Scene3D.cc:1905
/home/chapulina/dev_bionic/ws_edifice/install/lib/ign-gazebo-5/plugins/gui/libGzScene3D.so(_ZN8ignition6gazebo2v512RenderThread8ShutDownEv+0
x25) [0x7efc00152475] /home/chapulina/dev_bionic/ws_edifice/src/ign-gazebo/src/gui/plugins/scene3d/Scene3D.cc:2311
```

</p>
</details>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
