### PR TITLE
Joint visual

### DIFF
--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -186,10 +186,10 @@ void buildScene(ScenePtr _scene)
   JointVisualPtr jointVisual = _scene->CreateJointVisual();
   jointChildBox->AddChild(jointVisual);
   jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
-  ignition::math::Vector3d axis2(0.0, 1.0, 0.0);
+  ignition::math::Vector3d axis2(1.0, 0.0, 0.0);
   jointVisual->SetAxis(axis2, "");
 
-  ignition::math::Vector3d axis1(0.0, 1.0, 0.0);
+  ignition::math::Vector3d axis1(1.0, 0.0, 0.0);
   jointVisual->SetParentAxis(axis1, "__model__", jointParentBox->Name());
 
   // create camera

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -187,10 +187,10 @@ void buildScene(ScenePtr _scene)
   jointChildBox->AddChild(jointVisual);
   jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
   ignition::math::Vector3d axis2(1.0, 0.0, 0.0);
-  jointVisual->SetAxis(axis2, "");
+  jointVisual->SetAxis(axis2);
 
   ignition::math::Vector3d axis1(1.0, 0.0, 0.0);
-  jointVisual->SetParentAxis(axis1, "__model__", jointParentBox->Name());
+  jointVisual->SetParentAxis(axis1, jointParentBox->Name(), true);
 
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -118,6 +118,16 @@ void buildScene(ScenePtr _scene)
   blue->SetTransparency(0.5);
   blue->SetDepthWriteEnabled(false);
 
+  // create gray material
+  MaterialPtr gray = _scene->CreateMaterial();
+  gray->SetAmbient(0.7, 0.7, 0.7);
+  gray->SetDiffuse(0.7, 0.7, 0.7);
+  gray->SetSpecular(0.7, 0.7, 0.7);
+  gray->SetShininess(50);
+  gray->SetReflectivity(0);
+  gray->SetTransparency(0.75);
+  gray->SetDepthWriteEnabled(false);
+
   // create box visual
   VisualPtr box = _scene->CreateVisual("parent_box");
   box->AddGeometry(_scene->CreateBox());
@@ -177,9 +187,7 @@ void buildScene(ScenePtr _scene)
   jointParentBox->SetOrigin(0.0, 0.0, 0.0);
   jointParentBox->SetLocalPosition(2.0, 0.5, 0.0);
   jointParentBox->SetLocalRotation(0, 0, 0);
-  jointParentBox->SetMaterial(blue);
-  jointParentBox->Material()->SetTransparency(0.5);
-  jointParentBox->Material()->SetDepthWriteEnabled(false);
+  jointParentBox->SetMaterial(gray);
   root->AddChild(jointParentBox);
 
   // create joint visual

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -122,7 +122,7 @@ void buildScene(ScenePtr _scene)
   VisualPtr box = _scene->CreateVisual("parent_box");
   box->AddGeometry(_scene->CreateBox());
   box->SetOrigin(0.0, 0.0, 0.0);
-  box->SetLocalPosition(4.5, 0.0, 0.0);
+  box->SetLocalPosition(4.5, -0.5, 0.0);
   box->SetLocalRotation(0, 0, 0);
   box->SetMaterial(blue);
   root->AddChild(box);
@@ -149,7 +149,7 @@ void buildScene(ScenePtr _scene)
   ignition::math::Pose3d p(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
   ignition::math::Inertiald inertial{massMatrix, p};
   inertiaVisual->SetInertial(inertial);
-  inertiaVisual->SetLocalPosition(1, 0, 0);
+  inertiaVisual->SetLocalPosition(1.5, -0.5, 0);
   root->AddChild(inertiaVisual);
 
   // create CoM visual
@@ -163,20 +163,34 @@ void buildScene(ScenePtr _scene)
   box->AddChild(comVisual);
 
   // create joint child visual
-  VisualPtr jointBox = _scene->CreateVisual("joint_child");
-  jointBox->AddGeometry(_scene->CreateBox());
-  jointBox->SetOrigin(0.0, 0.0, 0.0);
-  jointBox->SetLocalPosition(3.0, 1.0, 0.0);
-  jointBox->SetLocalRotation(0, 0, 0);
-  jointBox->SetMaterial(blue);
-  root->AddChild(jointBox);
+  VisualPtr jointChildBox = _scene->CreateVisual("joint_child");
+  jointChildBox->AddGeometry(_scene->CreateBox());
+  jointChildBox->SetOrigin(0.0, 0.0, 0.0);
+  jointChildBox->SetLocalPosition(3.5, 0.5, 0.0);
+  jointChildBox->SetLocalRotation(0, 0, 0);
+  jointChildBox->SetMaterial(blue);
+  root->AddChild(jointChildBox);
+
+  // create joint parent visual
+  VisualPtr jointParentBox = _scene->CreateVisual("joint_parent");
+  jointParentBox->AddGeometry(_scene->CreateBox());
+  jointParentBox->SetOrigin(0.0, 0.0, 0.0);
+  jointParentBox->SetLocalPosition(2.0, 0.5, 0.0);
+  jointParentBox->SetLocalRotation(0, 0, 0);
+  jointParentBox->SetMaterial(blue);
+  jointParentBox->Material()->SetTransparency(0.5);
+  jointParentBox->Material()->SetDepthWriteEnabled(false);
+  root->AddChild(jointParentBox);
 
   // create joint visual
   JointVisualPtr jointVisual = _scene->CreateJointVisual();
-  jointBox->AddChild(jointVisual);
-  ignition::math::Vector3d axis(0.0, 1.0, 0.0);
+  jointChildBox->AddChild(jointVisual);
   jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
-  jointVisual->CreateAxis(axis, "__model__");
+  ignition::math::Vector3d axis2(0.0, 0.0, 1.0);
+  jointVisual->CreateAxis(axis2, "");
+
+  ignition::math::Vector3d axis1(0.0, 1.0, 0.0);
+  jointVisual->CreateParentAxis(axis1, "__model__", jointParentBox->Name());
 
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -162,6 +162,22 @@ void buildScene(ScenePtr _scene)
   comVisual->SetInertial(comVisualInertial);
   box->AddChild(comVisual);
 
+  // create joint child visual
+  VisualPtr jointBox = _scene->CreateVisual("joint_child");
+  jointBox->AddGeometry(_scene->CreateBox());
+  jointBox->SetOrigin(0.0, 0.0, 0.0);
+  jointBox->SetLocalPosition(3.0, 1.0, 0.0);
+  jointBox->SetLocalRotation(0, 0, 0);
+  jointBox->SetMaterial(blue);
+  root->AddChild(jointBox);
+
+  // create joint visual
+  JointVisualPtr jointVisual = _scene->CreateJointVisual();
+  jointBox->AddChild(jointVisual);
+  ignition::math::Vector3d axis(0.0, 1.0, 0.0);
+  jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
+  jointVisual->CreateAxis(axis, "__model__");
+
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");
   camera->SetLocalPosition(0.0, 0.0, 0.0);

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -186,7 +186,7 @@ void buildScene(ScenePtr _scene)
   jointParentBox->AddGeometry(_scene->CreateBox());
   jointParentBox->SetOrigin(0.0, 0.0, 0.0);
   jointParentBox->SetLocalPosition(2.0, 0.5, 0.0);
-  jointParentBox->SetLocalRotation(0, 0, 0);
+  jointParentBox->SetLocalRotation(1.5, -1.0, 0);
   jointParentBox->SetMaterial(gray);
   root->AddChild(jointParentBox);
 
@@ -194,7 +194,7 @@ void buildScene(ScenePtr _scene)
   JointVisualPtr jointVisual = _scene->CreateJointVisual();
   jointChildBox->AddChild(jointVisual);
   jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
-  ignition::math::Vector3d axis2(1.0, 0.0, 0.0);
+  ignition::math::Vector3d axis2(1.0, 1.0, 1.0);
   jointVisual->SetAxis(axis2);
 
   ignition::math::Vector3d axis1(1.0, 0.0, 0.0);

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -193,7 +193,7 @@ void buildScene(ScenePtr _scene)
   // create joint visual
   JointVisualPtr jointVisual = _scene->CreateJointVisual();
   jointChildBox->AddChild(jointVisual);
-  jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
+  jointVisual->SetType(JointVisualType::JVT_REVOLUTE2);
   ignition::math::Vector3d axis2(1.0, 1.0, 1.0);
   jointVisual->SetAxis(axis2);
 

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -122,7 +122,7 @@ void buildScene(ScenePtr _scene)
   VisualPtr box = _scene->CreateVisual("parent_box");
   box->AddGeometry(_scene->CreateBox());
   box->SetOrigin(0.0, 0.0, 0.0);
-  box->SetLocalPosition(4.5, -0.5, 0.0);
+  box->SetLocalPosition(4.5, -1.0, 0.0);
   box->SetLocalRotation(0, 0, 0);
   box->SetMaterial(blue);
   root->AddChild(box);
@@ -149,7 +149,7 @@ void buildScene(ScenePtr _scene)
   ignition::math::Pose3d p(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
   ignition::math::Inertiald inertial{massMatrix, p};
   inertiaVisual->SetInertial(inertial);
-  inertiaVisual->SetLocalPosition(1.5, -0.5, 0);
+  inertiaVisual->SetLocalPosition(1.5, -1.0, 0);
   root->AddChild(inertiaVisual);
 
   // create CoM visual
@@ -186,11 +186,11 @@ void buildScene(ScenePtr _scene)
   JointVisualPtr jointVisual = _scene->CreateJointVisual();
   jointChildBox->AddChild(jointVisual);
   jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
-  ignition::math::Vector3d axis2(0.0, 0.0, 1.0);
-  jointVisual->CreateAxis(axis2, "");
+  ignition::math::Vector3d axis2(0.0, 1.0, 0.0);
+  jointVisual->SetAxis(axis2, "");
 
   ignition::math::Vector3d axis1(0.0, 1.0, 0.0);
-  jointVisual->CreateParentAxis(axis1, "__model__", jointParentBox->Name());
+  jointVisual->SetParentAxis(axis1, "__model__", jointParentBox->Name());
 
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");

--- a/include/ignition/rendering/ArrowVisual.hh
+++ b/include/ignition/rendering/ArrowVisual.hh
@@ -42,6 +42,10 @@ namespace ignition
       /// \return The arrow-shaft visual
       public: virtual VisualPtr Shaft() const = 0;
 
+      /// \brief Get arrow-rotation visual
+      /// \return The arrow-rotation visual
+      public: virtual VisualPtr Rotation() const = 0;
+
       /// \brief set true to show the arrow head, false otherwise
       /// \param[in] _b true to show the arrow head, false otherwise
       public: virtual void ShowArrowHead(bool _b) = 0;

--- a/include/ignition/rendering/ArrowVisual.hh
+++ b/include/ignition/rendering/ArrowVisual.hh
@@ -49,6 +49,10 @@ namespace ignition
       /// \brief set true to show the arrow shaft, false otherwise
       /// \param[in] _b true to show the arrow shaft, false otherwise
       public: virtual void ShowArrowShaft(bool _b) = 0;
+
+      /// \brief Set true to show the rotation of the arrow, false otherwise
+      /// \param[in] _b True to show the arrow rotation.
+      public: virtual void ShowArrowRotation(bool _b) = 0;
     };
     }
   }

--- a/include/ignition/rendering/ArrowVisual.hh
+++ b/include/ignition/rendering/ArrowVisual.hh
@@ -45,6 +45,10 @@ namespace ignition
       /// \brief set true to show the arrow head, false otherwise
       /// \param[in] _b true to show the arrow head, false otherwise
       public: virtual void ShowArrowHead(bool _b) = 0;
+
+      /// \brief set true to show the arrow shaft, false otherwise
+      /// \param[in] _b true to show the arrow shaft, false otherwise
+      public: virtual void ShowArrowShaft(bool _b) = 0;
     };
     }
   }

--- a/include/ignition/rendering/AxisVisual.hh
+++ b/include/ignition/rendering/AxisVisual.hh
@@ -37,6 +37,11 @@ namespace ignition
       /// \brief set true to show the axis heads, false otherwise
       /// \param[in] _b true to show the axis heads, false otherwise
       public: virtual void ShowAxisHead(bool _b) = 0;
+
+      /// \brief set true to show the specified axis head, false otherwise
+      /// \param[in] _axis Axis index. 0: x, 1: y, 2: z
+      /// \param[in] _b true to show the specified axis head, false otherwise
+      public: virtual void ShowAxisHead(unsigned int _axis, bool _b) = 0;
     };
     }
   }

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -18,7 +18,9 @@
 #define IGNITION_RENDERING_JOINTVISUAL_HH_
 
 #include <string>
+
 #include <ignition/math/Vector3.hh>
+
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Object.hh"
 #include "ignition/rendering/RenderTypes.hh"
@@ -113,11 +115,9 @@ namespace ignition
           const std::string &_xyzExpressedIn) = 0;
 
       /// \brief Update the parent axis' arrow visual if it exists.
-      /// \param[in] _arrowVisual Arrow visual to be updated.
       /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      /// \param[in] _parentName Name of the joint parent.
       /// \return True if parent axis was updated else false.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -84,7 +84,8 @@ namespace ignition
       /// expressed.
       public: virtual void CreateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) = 0;
+          const std::string &_xyzExpressedIn,
+          const std::string &_parentName) = 0;
 
       /// \brief Update an axis' arrow visual.
       /// \param[in] _axis Axis vector.
@@ -98,6 +99,7 @@ namespace ignition
       /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
+      /// \param[in] _parentName Name of the joint parent
       public: virtual void UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -106,6 +106,10 @@ namespace ignition
       /// \param[in] _type The type of visualisation for joint
       public: virtual void SetType(const JointVisualType _type) = 0;
 
+      /// \brief Get joint visual type
+      /// \return The joint visual type
+      public: virtual JointVisualType Type() const = 0;
+
       /// \brief Get the JointVisual which is attached to the parent.
       /// \return Parent axis visual.
       public: virtual JointVisualPtr ParentAxisVisual() const = 0;

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -17,7 +17,8 @@
 #ifndef IGNITION_RENDERING_JOINTVISUAL_HH_
 #define IGNITION_RENDERING_JOINTVISUAL_HH_
 
-#include <ignition/math/Inertial.hh>
+#include <string>
+#include <ignition/math/Vector3.hh>
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Object.hh"
 #include "ignition/rendering/RenderTypes.hh"
@@ -73,30 +74,46 @@ namespace ignition
       /// \param[in] _axis Axis vector
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      /// \param[in] _type Type of axis.
-      /// \returns Newly created arrow visual.
-      public: ArrowVisualPtr CreateAxis(const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn, const JointVisualType _type);
+      public: virtual void CreateAxis(const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) = 0;
+
+      /// \brief Create a parent axis for hinge2 and universal joint types
+      /// and attach it to the joint visual.
+      /// \param[in] _axis Axis vector
+      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
+      /// expressed.
+      public: virtual void CreateParentAxis(
+          const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) = 0;
 
       /// \brief Update an axis' arrow visual.
+      /// \param[in] _axis Axis vector.
+      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
+      /// expressed.
+      public: virtual void UpdateAxis(const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) = 0;
+
+      /// \brief Update the parent axis' arrow visual if it exists.
       /// \param[in] _arrowVisual Arrow visual to be updated.
       /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      /// \param[in] _type Type of axis.
-      public: void UpdateAxis(ArrowVisualPtr _arrowVisual,
-                              const ignition::math::Vector3d &_axis,
-                              const std::string &_xyzExpressedIn,
-                              const JointVisualType _type);
+      public: virtual void UpdateParentAxis(
+          const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) = 0;
 
-      /// \brief Get the JointVisual which is attached to the parent link.
+      /// \brief Set type for joint visual
+      /// \param[in] _type The type of visualisation for joint
+      public: virtual void SetType(const JointVisualType _type) = 0;
+
+      /// \brief Get the JointVisual which is attached to the parent.
       /// \return Parent axis visual.
-      public: virtual VisualPtr ParentAxisVisual() const = 0;
+      public: virtual JointVisualPtr ParentAxisVisual() const = 0;
 
       /// \brief Get the arrow visual which represents the axis attached to the
       /// child.
       /// \return Arrow visual.
-      public: ArrowVisualPtr GetArrowVisual() const;
+      public: virtual ArrowVisualPtr ArrowVisual() const = 0;
     };
     }
   }

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -71,28 +71,44 @@ namespace ignition
       public: virtual ~JointVisual() {}
 
       /// \brief Create an axis and attach it to the joint visual.
-      /// \param[in] _axis Axis vector
+      /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;
 
+      /// \brief Get axis vector.
+      /// \return The axis vector.
+      public: virtual ignition::math::Vector3d Axis() const = 0;
+
+      /// \brief Get axis frame.
+      /// \return The axis frame.
+      public: virtual std::string AxisFrame() const = 0;
+
       /// \brief Create a parent axis for hinge2 and universal joint types
       /// and attach it to the joint visual.
-      /// \param[in] _axis Axis vector
+      /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      /// \param[in] _parentName Joint parent name
+      /// \param[in] _parentName Joint parent name.
       public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn,
           const std::string &_parentName) = 0;
 
+      /// \brief Get parent axis vector.
+      /// \return The parent axis vector.
+      public: virtual ignition::math::Vector3d ParentAxis() const = 0;
+
+      /// \brief Get parent axis frame.
+      /// \return The parent axis frame.
+      public: virtual std::string ParentAxisFrame() const = 0;
+
       /// \brief Update an axis' arrow visual.
       /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      /// \return True if axis was updated else false
+      /// \return True if axis was updated else false.
       public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;
 
@@ -101,18 +117,18 @@ namespace ignition
       /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      /// \param[in] _parentName Name of the joint parent
-      /// \return True if parent axis was updated else false
+      /// \param[in] _parentName Name of the joint parent.
+      /// \return True if parent axis was updated else false.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;
 
-      /// \brief Set type for joint visual
-      /// \param[in] _type The type of visualisation for joint
+      /// \brief Set type for joint visual.
+      /// \param[in] _type The type of visualisation for joint.
       public: virtual void SetType(const JointVisualType _type) = 0;
 
-      /// \brief Get joint visual type
-      /// \return The joint visual type
+      /// \brief Get joint visual type.
+      /// \return The joint visual type.
       public: virtual JointVisualType Type() const = 0;
 
       /// \brief Get the JointVisual which is attached to the parent.

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_JOINTVISUAL_HH_
+#define IGNITION_RENDERING_JOINTVISUAL_HH_
+
+#include <ignition/math/Inertial.hh>
+#include "ignition/rendering/config.hh"
+#include "ignition/rendering/Object.hh"
+#include "ignition/rendering/RenderTypes.hh"
+#include "ignition/rendering/Visual.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief Enum for JointVisual types
+    enum IGNITION_RENDERING_VISIBLE JointVisualType
+    {
+      /// \brief No type
+      JVT_NONE           = 0,
+
+      /// \brief Revolute joint type
+      JVT_REVOLUTE       = 1,
+
+      /// \brief Revolute2 joint type
+      JVT_REVOLUTE2      = 2,
+
+      /// \brief Prismatic joint type
+      JVT_PRISMATIC      = 3,
+
+      /// \brief Universal joint type
+      JVT_UNIVERSAL      = 4,
+
+      /// \brief Ball joint type
+      JVT_BALL           = 5,
+
+      /// \brief Screw joint type
+      JVT_SCREW          = 6,
+
+      /// \brief Gearbox joint type
+      JVT_GEARBOX        = 7,
+
+      /// \brief Fixed joint type
+      JVT_FIXED          = 8
+    };
+
+    /// \class JointVisual JointVisual.hh
+    /// ignition/rendering/JointVisual.hh
+    /// \brief Represents a joint visual
+    class IGNITION_RENDERING_VISIBLE JointVisual :
+      public virtual Visual
+    {
+      /// \brief Destructor
+      public: virtual ~JointVisual() {}
+
+      /// \brief Create an axis and attach it to the joint visual.
+      /// \param[in] _axis Axis vector
+      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
+      /// expressed.
+      /// \param[in] _type Type of axis.
+      /// \returns Newly created arrow visual.
+      public: ArrowVisualPtr CreateAxis(const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn, const JointVisualType _type);
+
+      /// \brief Update an axis' arrow visual.
+      /// \param[in] _arrowVisual Arrow visual to be updated.
+      /// \param[in] _axis Axis vector.
+      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
+      /// expressed.
+      /// \param[in] _type Type of axis.
+      public: void UpdateAxis(ArrowVisualPtr _arrowVisual,
+                              const ignition::math::Vector3d &_axis,
+                              const std::string &_xyzExpressedIn,
+                              const JointVisualType _type);
+
+      /// \brief Get the JointVisual which is attached to the parent link.
+      /// \return Parent axis visual.
+      public: virtual VisualPtr ParentAxisVisual() const = 0;
+
+      /// \brief Get the arrow visual which represents the axis attached to the
+      /// child.
+      /// \return Arrow visual.
+      public: ArrowVisualPtr GetArrowVisual() const;
+    };
+    }
+  }
+}
+#endif

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -74,7 +74,7 @@ namespace ignition
       /// \param[in] _axis Axis vector
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      public: virtual void CreateAxis(const ignition::math::Vector3d &_axis,
+      public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;
 
       /// \brief Create a parent axis for hinge2 and universal joint types
@@ -82,7 +82,8 @@ namespace ignition
       /// \param[in] _axis Axis vector
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      public: virtual void CreateParentAxis(
+      /// \param[in] _parentName Joint parent name
+      public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn,
           const std::string &_parentName) = 0;
@@ -91,7 +92,8 @@ namespace ignition
       /// \param[in] _axis Axis vector.
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
-      public: virtual void UpdateAxis(const ignition::math::Vector3d &_axis,
+      /// \return True if axis was updated else false
+      public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;
 
       /// \brief Update the parent axis' arrow visual if it exists.
@@ -100,7 +102,8 @@ namespace ignition
       /// \param[in] _xyzExpressedIn Frame in which the axis vector is
       /// expressed.
       /// \param[in] _parentName Name of the joint parent
-      public: virtual void UpdateParentAxis(
+      /// \return True if parent axis was updated else false
+      public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) = 0;
 

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -77,7 +77,7 @@ namespace ignition
       /// \param[in] _useParentFrame True if axis vector is expressed in
       /// parent frame.
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame = false) = 0;
+          bool _useParentFrame = false) = 0;
 
       /// \brief Get axis vector.
       /// \return The axis vector.
@@ -92,7 +92,7 @@ namespace ignition
       public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_parentName,
-          const bool _useParentFrame = false) = 0;
+          bool _useParentFrame = false) = 0;
 
       /// \brief Get parent axis vector.
       /// \return The parent axis vector.
@@ -104,7 +104,7 @@ namespace ignition
       /// parent frame.
       /// \return True if axis was updated else false.
       public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame = false) = 0;
+          bool _useParentFrame = false) = 0;
 
       /// \brief Update the parent axis' arrow visual if it exists.
       /// \param[in] _axis Axis vector.
@@ -113,7 +113,7 @@ namespace ignition
       /// \return True if parent axis was updated else false.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame = false) = 0;
+          bool _useParentFrame = false) = 0;
 
       /// \brief Set type for joint visual.
       /// \param[in] _type The type of visualisation for joint.

--- a/include/ignition/rendering/JointVisual.hh
+++ b/include/ignition/rendering/JointVisual.hh
@@ -74,54 +74,46 @@ namespace ignition
 
       /// \brief Create an axis and attach it to the joint visual.
       /// \param[in] _axis Axis vector.
-      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
-      /// expressed.
+      /// \param[in] _useParentFrame True if axis vector is expressed in
+      /// parent frame.
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) = 0;
+          const bool _useParentFrame = false) = 0;
 
       /// \brief Get axis vector.
       /// \return The axis vector.
       public: virtual ignition::math::Vector3d Axis() const = 0;
 
-      /// \brief Get axis frame.
-      /// \return The axis frame.
-      public: virtual std::string AxisFrame() const = 0;
-
       /// \brief Create a parent axis for hinge2 and universal joint types
       /// and attach it to the joint visual.
       /// \param[in] _axis Axis vector.
-      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
-      /// expressed.
       /// \param[in] _parentName Joint parent name.
+      /// \param[in] _useParentFrame True if axis vector is expressed in
+      /// parent frame.
       public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn,
-          const std::string &_parentName) = 0;
+          const std::string &_parentName,
+          const bool _useParentFrame = false) = 0;
 
       /// \brief Get parent axis vector.
       /// \return The parent axis vector.
       public: virtual ignition::math::Vector3d ParentAxis() const = 0;
 
-      /// \brief Get parent axis frame.
-      /// \return The parent axis frame.
-      public: virtual std::string ParentAxisFrame() const = 0;
-
       /// \brief Update an axis' arrow visual.
       /// \param[in] _axis Axis vector.
-      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
-      /// expressed.
+      /// \param[in] _useParentFrame True if axis vector is expressed in
+      /// parent frame.
       /// \return True if axis was updated else false.
       public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) = 0;
+          const bool _useParentFrame = false) = 0;
 
       /// \brief Update the parent axis' arrow visual if it exists.
       /// \param[in] _axis Axis vector.
-      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
-      /// expressed.
+      /// \param[in] _useParentFrame True if axis vector is expressed in
+      /// parent frame.
       /// \return True if parent axis was updated else false.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) = 0;
+          const bool _useParentFrame = false) = 0;
 
       /// \brief Set type for joint visual.
       /// \param[in] _type The type of visualisation for joint.

--- a/include/ignition/rendering/Node.hh
+++ b/include/ignition/rendering/Node.hh
@@ -56,6 +56,10 @@ namespace ignition
       /// \return The local pose
       public: virtual math::Pose3d LocalPose() const = 0;
 
+      /// \brief Get the initial local pose
+      /// \return The initial local pose
+      public: virtual math::Pose3d InitialLocalPose() const = 0;
+
       /// \brief Set the local pose
       /// \param[in] _pose New local pose
       public: virtual void SetLocalPose(const math::Pose3d &_pose) = 0;

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -881,12 +881,12 @@ namespace ignition
       public: virtual InertiaVisualPtr CreateInertiaVisual(
                   unsigned int _id, const std::string &_name) = 0;
 
-      /// \brief Create new Joint visual. A unique ID and name will
+      /// \brief Create new joint visual. A unique ID and name will
       /// automatically be assigned to the Joint visual.
       /// \return The created Joint visual
       public: virtual JointVisualPtr CreateJointVisual() = 0;
 
-      /// \brief Create new Joint visual with the given ID. A unique name
+      /// \brief Create new joint visual with the given ID. A unique name
       /// will automatically be assigned to the visual. If the given ID is
       /// already in use, NULL will be returned.
       /// \param[in] _id ID of the new Joint visual
@@ -894,7 +894,7 @@ namespace ignition
       public: virtual JointVisualPtr CreateJointVisual(
                   unsigned int _id) = 0;
 
-      /// \brief Create new Joint visual with the given name. A unique ID
+      /// \brief Create new joint visual with the given name. A unique ID
       /// will automatically be assigned to the visual. If the given name is
       /// already in use, NULL will be returned.
       /// \param[in] _name Name of the new Joint visual
@@ -902,7 +902,7 @@ namespace ignition
       public: virtual JointVisualPtr CreateJointVisual(
                   const std::string &_name) = 0;
 
-      /// \brief Create new Joint visual with the given name. If either the
+      /// \brief Create new joint visual with the given name. If either the
       /// given ID or name is already in use, NULL will be returned.
       /// \param[in] _id ID of the new Joint visual
       /// \param[in] _name Name of the new Joint visual

--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -881,6 +881,35 @@ namespace ignition
       public: virtual InertiaVisualPtr CreateInertiaVisual(
                   unsigned int _id, const std::string &_name) = 0;
 
+      /// \brief Create new Joint visual. A unique ID and name will
+      /// automatically be assigned to the Joint visual.
+      /// \return The created Joint visual
+      public: virtual JointVisualPtr CreateJointVisual() = 0;
+
+      /// \brief Create new Joint visual with the given ID. A unique name
+      /// will automatically be assigned to the visual. If the given ID is
+      /// already in use, NULL will be returned.
+      /// \param[in] _id ID of the new Joint visual
+      /// \return The created Joint visual
+      public: virtual JointVisualPtr CreateJointVisual(
+                  unsigned int _id) = 0;
+
+      /// \brief Create new Joint visual with the given name. A unique ID
+      /// will automatically be assigned to the visual. If the given name is
+      /// already in use, NULL will be returned.
+      /// \param[in] _name Name of the new Joint visual
+      /// \return The created Joint visual
+      public: virtual JointVisualPtr CreateJointVisual(
+                  const std::string &_name) = 0;
+
+      /// \brief Create new Joint visual with the given name. If either the
+      /// given ID or name is already in use, NULL will be returned.
+      /// \param[in] _id ID of the new Joint visual
+      /// \param[in] _name Name of the new Joint visual
+      /// \return The created Joint visual
+      public: virtual JointVisualPtr CreateJointVisual(
+                  unsigned int _id, const std::string &_name) = 0;
+
       /// \brief Create new light visual. A unique ID and name will
       /// automatically be assigned to the light visual.
       /// \return The created light visual

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -46,6 +46,9 @@ namespace ignition
       // Documentation inherited.
       public: virtual VisualPtr Shaft() const override;
 
+      // Documentation inherited.
+      public: virtual VisualPtr Rotation() const override;
+
       // Documentation inherited
       public: virtual void ShowArrowHead(bool _b) override;
 
@@ -81,12 +84,19 @@ namespace ignition
     template <class T>
     VisualPtr BaseArrowVisual<T>::Head() const
     {
-      return std::dynamic_pointer_cast<Visual>(this->ChildByIndex(1));
+      return std::dynamic_pointer_cast<Visual>(this->ChildByIndex(2));
     }
 
     //////////////////////////////////////////////////
     template <class T>
     VisualPtr BaseArrowVisual<T>::Shaft() const
+    {
+      return std::dynamic_pointer_cast<Visual>(this->ChildByIndex(1));
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    VisualPtr BaseArrowVisual<T>::Rotation() const
     {
       return std::dynamic_pointer_cast<Visual>(this->ChildByIndex(0));
     }

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -87,13 +87,11 @@ namespace ignition
     template <class T>
     void BaseArrowVisual<T>::Destroy()
     {
-      auto shaft = this->Shaft();
-      auto head = this->Head();
-      auto rotation = this->Rotation();
-
-      shaft->Destroy();
-      head->Destroy();
-      rotation->Destroy();
+      while (this->ChildCount() > 0u)
+      {
+        auto visual = std::dynamic_pointer_cast<Visual>(this->ChildByIndex(0));
+        visual->Destroy();
+      }
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -140,15 +140,15 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseArrowVisual<T>::SetVisible(bool _b)
+    void BaseArrowVisual<T>::SetVisible(bool _visible)
     {
-      T::SetVisible(_b);
+      T::SetVisible(_visible);
 
       NodePtr child = this->ChildByIndex(0);
       VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
       if (visual)
       {
-        visual->SetVisible(this->rotationVisible && _b);
+        visual->SetVisible(this->rotationVisible && _visible);
       }
     }
 

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -17,6 +17,8 @@
 #ifndef IGNITION_RENDERING_BASE_BASEARROWVISUAL_HH_
 #define IGNITION_RENDERING_BASE_BASEARROWVISUAL_HH_
 
+#include <string>
+
 #include <ignition/common/MeshManager.hh>
 #include "ignition/rendering/ArrowVisual.hh"
 #include "ignition/rendering/Scene.hh"

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -41,6 +41,9 @@ namespace ignition
       public: virtual ~BaseArrowVisual();
 
       // Documentation inherited.
+      protected: virtual void Destroy() override;
+
+      // Documentation inherited.
       public: virtual VisualPtr Head() const override;
 
       // Documentation inherited.
@@ -78,6 +81,20 @@ namespace ignition
     template <class T>
     BaseArrowVisual<T>::~BaseArrowVisual()
     {
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseArrowVisual<T>::Destroy()
+    {
+      if (this->Head())
+        this->Head()->Destroy();
+
+      if (this->Shaft())
+        this->Shaft()->Destroy();
+
+      if (this->Rotation())
+        this->Rotation()->Destroy();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <ignition/common/MeshManager.hh>
+
 #include "ignition/rendering/ArrowVisual.hh"
 #include "ignition/rendering/Scene.hh"
 
@@ -90,7 +91,10 @@ namespace ignition
       while (this->ChildCount() > 0u)
       {
         auto visual = std::dynamic_pointer_cast<Visual>(this->ChildByIndex(0));
-        visual->Destroy();
+        if (visual)
+        {
+          visual->Destroy();
+        }
       }
     }
 

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -87,13 +87,13 @@ namespace ignition
     template <class T>
     void BaseArrowVisual<T>::Destroy()
     {
-      for (unsigned int i = 0; i < this->ChildCount(); ++i)
-      {
-        auto visual = std::dynamic_pointer_cast<rendering::Visual>(
-              this->ChildByIndex(i));
-        if (visual)
-          arrow->Destroy();
-      }
+      auto shaft = this->Shaft();
+      auto head = this->Head();
+      auto rotation = this->Rotation();
+
+      shaft->Destroy();
+      head->Destroy();
+      rotation->Destroy();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_BASE_BASEARROWVISUAL_HH_
 #define IGNITION_RENDERING_BASE_BASEARROWVISUAL_HH_
 
+#include <ignition/common/MeshManager.hh>
 #include "ignition/rendering/ArrowVisual.hh"
 #include "ignition/rendering/Scene.hh"
 
@@ -49,8 +50,17 @@ namespace ignition
       // Documentation inherited
       public: virtual void ShowArrowShaft(bool _b) override;
 
+      // Documentation inherited
+      public: virtual void ShowArrowRotation(bool _b) override;
+
+      // Documentation inherited
+      public: virtual void SetVisible(bool _visible) override;
+
       // Documentation inherited.
       protected: virtual void Init() override;
+
+      /// \brief Flag to indicate whether arrow rotation is visible
+      protected: bool rotationVisible = false;
     };
 
     //////////////////////////////////////////////////
@@ -83,7 +93,7 @@ namespace ignition
     template <class T>
     void BaseArrowVisual<T>::ShowArrowHead(bool _b)
     {
-      NodePtr child = this->ChildByIndex(1);
+      NodePtr child = this->ChildByIndex(2);
       VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
       if (visual)
       {
@@ -95,11 +105,38 @@ namespace ignition
     template <class T>
     void BaseArrowVisual<T>::ShowArrowShaft(bool _b)
     {
+      NodePtr child = this->ChildByIndex(1);
+      VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+      if (visual)
+      {
+        visual->SetVisible(_b);
+      }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseArrowVisual<T>::ShowArrowRotation(bool _b)
+    {
       NodePtr child = this->ChildByIndex(0);
       VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
       if (visual)
       {
         visual->SetVisible(_b);
+        this->rotationVisible = _b;
+      }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseArrowVisual<T>::SetVisible(bool _b)
+    {
+      T::SetVisible(_b);
+
+      NodePtr child = this->ChildByIndex(0);
+      VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+      if (visual)
+      {
+        visual->SetVisible(this->rotationVisible && _b);
       }
     }
 
@@ -122,6 +159,18 @@ namespace ignition
       cylinder->SetLocalPosition(0, 0, 0);
       cylinder->SetLocalScale(0.05, 0.05, 0.5);
       this->AddChild(cylinder);
+
+      common::MeshManager *meshMgr = common::MeshManager::Instance();
+      std::string rotMeshName = "arrow_rotation";
+      if (!meshMgr->HasMesh(rotMeshName))
+        meshMgr->CreateTube(rotMeshName, 0.070f, 0.075f, 0.01f, 1, 32);
+
+      VisualPtr rotationVis = this->Scene()->CreateVisual();
+      rotationVis->AddGeometry(this->Scene()->CreateMesh(rotMeshName));
+      rotationVis->SetOrigin(0, 0, -0.125);
+      rotationVis->SetLocalPosition(0, 0, 0);
+      rotationVis->SetVisible(this->rotationVisible);
+      this->AddChild(rotationVis);
 
       this->SetOrigin(0, 0, -0.5);
     }

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -166,6 +166,10 @@ namespace ignition
       VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
       if (visual)
       {
+        // Force rotation visual visibility to false
+        // if the arrow visual is not visible.
+        // Else, rotation visual's visibility overrides
+        // its parent's visibility.
         visual->SetVisible(this->rotationVisible && _visible);
       }
     }

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -87,14 +87,13 @@ namespace ignition
     template <class T>
     void BaseArrowVisual<T>::Destroy()
     {
-      if (this->Head())
-        this->Head()->Destroy();
-
-      if (this->Shaft())
-        this->Shaft()->Destroy();
-
-      if (this->Rotation())
-        this->Rotation()->Destroy();
+      for (unsigned int i = 0; i < this->ChildCount(); ++i)
+      {
+        auto visual = std::dynamic_pointer_cast<rendering::Visual>(
+              this->ChildByIndex(i));
+        if (visual)
+          arrow->Destroy();
+      }
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -46,6 +46,9 @@ namespace ignition
       // Documentation inherited
       public: virtual void ShowArrowHead(bool _b) override;
 
+      // Documentation inherited
+      public: virtual void ShowArrowShaft(bool _b) override;
+
       // Documentation inherited.
       protected: virtual void Init() override;
     };
@@ -81,6 +84,18 @@ namespace ignition
     void BaseArrowVisual<T>::ShowArrowHead(bool _b)
     {
       NodePtr child = this->ChildByIndex(1);
+      VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+      if (visual)
+      {
+        visual->SetVisible(_b);
+      }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseArrowVisual<T>::ShowArrowShaft(bool _b)
+    {
+      NodePtr child = this->ChildByIndex(0);
       VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
       if (visual)
       {

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -78,7 +78,8 @@ namespace ignition
       {
         auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
               this->ChildByIndex(i));
-        arrow->Destroy();
+        if (arrow)
+          arrow->Destroy();
       }
     }
 
@@ -110,7 +111,8 @@ namespace ignition
       {
         auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
               this->ChildByIndex(i));
-        arrow->ShowArrowHead(_b);
+        if (arrow)
+          arrow->ShowArrowHead(_b);
       }
     }
 

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -112,7 +112,9 @@ namespace ignition
         auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
               this->ChildByIndex(i));
         if (arrow)
+        {
           arrow->ShowArrowHead(_b);
+        }
       }
     }
 
@@ -123,7 +125,9 @@ namespace ignition
       auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
             this->ChildByIndex(2u - _axis));
       if (arrow)
+      {
         arrow->ShowArrowHead(_b);
+      }
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -39,6 +39,9 @@ namespace ignition
       public: virtual void Init() override;
 
       // Documentation inherited.
+      protected: virtual void Destroy() override;
+
+      // Documentation inherited.
       public: virtual void SetLocalScale(
           const math::Vector3d &_scale) override;
 
@@ -50,6 +53,9 @@ namespace ignition
 
       // Documentation inherited.
       public: void ShowAxisHead(unsigned int _axis, bool _b) override;
+
+      // Documentation inherited.
+      public: virtual void SetVisible(bool _visible) override;
     };
 
     //////////////////////////////////////////////////
@@ -62,6 +68,18 @@ namespace ignition
     template <class T>
     BaseAxisVisual<T>::~BaseAxisVisual()
     {
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseAxisVisual<T>::Destroy()
+    {
+      for (unsigned int i = 0; i < this->ChildCount(); ++i)
+      {
+        auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
+              this->ChildByIndex(i));
+        arrow->Destroy();
+      }
     }
 
     //////////////////////////////////////////////////
@@ -129,6 +147,20 @@ namespace ignition
       zArrow->SetLocalRotation(0, 0, 0);
       zArrow->SetMaterial("Default/TransBlue");
       this->AddChild(zArrow);
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseAxisVisual<T>::SetVisible(bool _visible)
+    {
+      T::SetVisible(_visible);
+
+      for (unsigned int i = 0; i < this->ChildCount(); ++i)
+      {
+        auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
+              this->ChildByIndex(i));
+        arrow->SetVisible(_visible);
+      }
     }
     }
   }

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -79,7 +79,9 @@ namespace ignition
         auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
               this->ChildByIndex(i));
         if (arrow)
+        {
           arrow->Destroy();
+        }
       }
     }
 

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -47,6 +47,9 @@ namespace ignition
 
       // Documentation inherited.
       public: void ShowAxisHead(bool _b) override;
+
+      // Documentation inherited.
+      public: void ShowAxisHead(unsigned int _axis, bool _b) override;
     };
 
     //////////////////////////////////////////////////
@@ -91,6 +94,15 @@ namespace ignition
               this->ChildByIndex(i));
         arrow->ShowArrowHead(_b);
       }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseAxisVisual<T>::ShowAxisHead(unsigned int _axis, bool _b)
+    {
+      auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
+            this->ChildByIndex(_axis));
+      arrow->ShowArrowHead(_b);
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -101,8 +101,9 @@ namespace ignition
     void BaseAxisVisual<T>::ShowAxisHead(unsigned int _axis, bool _b)
     {
       auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
-            this->ChildByIndex(_axis));
-      arrow->ShowArrowHead(_b);
+            this->ChildByIndex(2u - _axis));
+      if (arrow)
+        arrow->ShowArrowHead(_b);
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -387,7 +387,7 @@ namespace ignition
       double angle = acos(cosTheta);
       ignition::math::Quaterniond quat;
       // check the parallel case
-      if (ignition::math::equal(angle, M_PI))
+      if (ignition::math::equal(angle, IGN_PI))
         quat.Axis(u.Perpendicular(), angle);
       else
         quat.Axis((v.Cross(u)).Normalize(), angle);

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -58,34 +58,28 @@ namespace ignition
 
       // Documentation inherited.
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) override;
+          const bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual ignition::math::Vector3d Axis() const override;
 
       // Documentation inherited.
-      public: virtual std::string AxisFrame() const override;
-
-      // Documentation inherited.
       public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn,
-          const std::string &_parentName) override;
+          const std::string &_parentName,
+          const bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual ignition::math::Vector3d ParentAxis() const override;
 
       // Documentation inherited.
-      public: virtual std::string ParentAxisFrame() const override;
-
-      // Documentation inherited.
       public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) override;
+          const bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) override;
+          const bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual void SetType(const JointVisualType _type) override;
@@ -105,11 +99,11 @@ namespace ignition
       /// \brief Implementation for updating an axis' arrow visual.
       /// \param[in] _arrowVisual Arrow visual to be updated.
       /// \param[in] _axis Axis vector.
-      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
-      /// expressed.
+      /// \param[in] _useParentFrame True if the axis vector is
+      /// expressed in the joint parent frame.
       protected: void UpdateAxisImpl(ArrowVisualPtr _arrowVisual,
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn);
+          const bool _useParentFrame);
 
       /// \brief Helper function to create axis visual.
       protected: void CreateAxis();
@@ -153,8 +147,9 @@ namespace ignition
       protected: ignition::math::Vector3d axis =
           ignition::math::Vector3d::Zero;
 
-      /// \brief Frame in which axis vector is expressed.
-      protected: std::string xyzExpressedIn = "";
+      /// \brief Flag to indicate whether axis vector is
+      /// expressed in joint parent frame.
+      protected: bool useParentFrame = false;
 
       /// \brief Flag to update the axis visual.
       protected: bool updateAxis = false;
@@ -163,11 +158,12 @@ namespace ignition
       protected: ignition::math::Vector3d parentAxis =
           ignition::math::Vector3d::Zero;
 
-      /// \brief Frame in which parent axis vector is expressed.
-      protected: std::string parentXyzExpressedIn = "";
-
       /// \brief Joint parent name.
       protected: std::string jointParentName = "";
+
+      /// \brief Flag to indicate whether parent axis vector is
+      /// expressed in joint parent frame.
+      protected: bool parentAxisUseParentFrame = false;
 
       /// \brief Flag to update the parent axis visual.
       protected: bool updateParentAxis = false;
@@ -198,9 +194,9 @@ namespace ignition
 
       if (this->dirtyJointType)
       {
-        this->UpdateAxis(this->axis, this->xyzExpressedIn);
+        this->UpdateAxis(this->axis, this->useParentFrame);
         this->UpdateParentAxis(this->parentAxis,
-            this->parentXyzExpressedIn);
+            this->parentAxisUseParentFrame);
 
         this->dirtyJointType = false;
       }
@@ -220,14 +216,14 @@ namespace ignition
       if (this->updateAxis)
       {
         this->updateAxis =
-            !this->UpdateAxis(this->axis, this->xyzExpressedIn);
+            !this->UpdateAxis(this->axis, this->useParentFrame);
       }
 
       if (this->updateParentAxis)
       {
         this->updateParentAxis =
             !this->UpdateParentAxis(this->parentAxis,
-                this->parentXyzExpressedIn);
+                this->parentAxisUseParentFrame);
       }
     }
 
@@ -273,10 +269,10 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::SetAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn)
+          const bool _useParentFrame)
     {
       this->axis = _axis;
-      this->xyzExpressedIn = _xyzExpressedIn;
+      this->useParentFrame = _useParentFrame;
       this->dirtyAxis = true;
     }
 
@@ -304,11 +300,11 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::SetParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn,
-          const std::string &_parentName)
+          const std::string &_parentName,
+          const bool _useParentFrame)
     {
       this->parentAxis = _axis;
-      this->parentXyzExpressedIn = _xyzExpressedIn;
+      this->parentAxisUseParentFrame = _useParentFrame;
       this->jointParentName = _parentName;
       this->dirtyParentAxis = true;
     }
@@ -336,7 +332,7 @@ namespace ignition
       jointParentVis->AddChild(this->parentAxisVis);
       this->parentAxisVis->SetType(this->Type());
       this->parentAxisVis->SetAxis(this->parentAxis,
-          this->parentXyzExpressedIn);
+          this->parentAxisUseParentFrame);
 
       this->updateParentAxis = true;
       this->ScaleToChild();
@@ -345,11 +341,11 @@ namespace ignition
     //////////////////////////////////////////////////
     template <class T>
     bool BaseJointVisual<T>::UpdateAxis(const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn)
+          const bool _useParentFrame)
     {
       if (this->ArrowVisual() && this->HasParent())
       {
-        this->UpdateAxisImpl(this->ArrowVisual(), _axis, _xyzExpressedIn);
+        this->UpdateAxisImpl(this->ArrowVisual(), _axis, _useParentFrame);
         return true;
       }
 
@@ -360,14 +356,14 @@ namespace ignition
     template <class T>
     bool BaseJointVisual<T>::UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn)
+          const bool _useParentFrame)
     {
       if (this->ParentAxisVisual() &&
           this->ParentAxisVisual()->ArrowVisual() &&
           this->ParentAxisVisual()->HasParent())
       {
         this->UpdateAxisImpl(this->ParentAxisVisual()->ArrowVisual(),
-            _axis, _xyzExpressedIn);
+            _axis, _useParentFrame);
         return true;
       }
 
@@ -378,7 +374,7 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::UpdateAxisImpl(ArrowVisualPtr _arrowVisual,
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn)
+          const bool _useParentFrame)
     {
       // Get rotation to axis vector
       ignition::math::Vector3d axisDir = _axis;
@@ -394,7 +390,7 @@ namespace ignition
         quat.Axis((v.Cross(u)).Normalize(), angle);
       _arrowVisual->SetLocalRotation(quat);
 
-      if (_xyzExpressedIn == "__model__")
+      if (_useParentFrame)
       {
         ignition::math::Pose3d parentInitPose =
             this->Parent()->InitialLocalPose();
@@ -487,23 +483,9 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    std::string BaseJointVisual<T>::AxisFrame() const
-    {
-      return this->xyzExpressedIn;
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
     ignition::math::Vector3d BaseJointVisual<T>::ParentAxis() const
     {
       return this->parentAxis;
-    }
-
-    //////////////////////////////////////////////////
-    template <class T>
-    std::string BaseJointVisual<T>::ParentAxisFrame() const
-    {
-      return this->parentXyzExpressedIn;
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -303,6 +303,15 @@ namespace ignition
           const std::string &_parentName,
           bool _useParentFrame)
     {
+      if (this->Type() != JointVisualType::JVT_REVOLUTE2 &&
+          this->Type() != JointVisualType::JVT_UNIVERSAL)
+      {
+        ignlog << "Joint visual is not of type Revolute2 or "
+               << " Universal "
+               << " so the parent axis will not be shown\n";
+        return;
+      }
+
       this->parentAxis = _axis;
       this->parentAxisUseParentFrame = _useParentFrame;
       this->jointParentName = _parentName;
@@ -518,8 +527,12 @@ namespace ignition
       if (this->ArrowVisual())
         this->ArrowVisual()->SetVisible(_visible);
 
-      if (this->ParentAxisVisual())
-        this->ParentAxisVisual()->SetVisible(_visible);
+      if (this->Type() == JointVisualType::JVT_REVOLUTE2 ||
+          this->Type() == JointVisualType::JVT_UNIVERSAL)
+      {
+        if (this->ParentAxisVisual())
+          this->ParentAxisVisual()->SetVisible(_visible);
+      }
 
       if (this->axisVisual)
         this->axisVisual->SetVisible(_visible);

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -226,6 +226,7 @@ namespace ignition
 
       this->axisVisual = this->Scene()->CreateAxisVisual();
       this->AddChild(this->axisVisual);
+      this->SetInheritScale(false);
     }
 
     /////////////////////////////////////////////////
@@ -249,6 +250,10 @@ namespace ignition
         this->parentAxisVis->Destroy();
         this->parentAxisVis.reset();
       }
+
+      this->dirtyJointType = false;
+      this->dirtyAxis = false;
+      this->dirtyParentAxis = false;
     }
 
     /////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_BASE_BASEJOINTVISUAL_HH_
+#define IGNITION_RENDERING_BASE_BASEJOINTVISUAL_HH_
+
+#include <string>
+
+#include "ignition/rendering/base/BaseObject.hh"
+#include "ignition/rendering/base/BaseRenderTypes.hh"
+#include "ignition/rendering/JointVisual.hh"
+#include "ignition/rendering/Scene.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief Base implementation of a joint visual
+    template <class T>
+    class BaseJointVisual :
+      public virtual JointVisual,
+      public virtual T
+    {
+      /// \brief Constructor
+      protected: BaseJointVisual();
+
+      /// \brief Destructor
+      public: virtual ~BaseJointVisual();
+
+      // Documentation inherited.
+      protected: virtual void Init() override;
+
+      // Documentation inherited.
+      protected: virtual void PreRender() override;
+
+      // Documentation inherited
+      public: virtual void CreateAxis(const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) override;
+
+      // Documentation inherited
+      public: virtual void CreateParentAxis(
+          const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) override;
+
+      // Documentation inherited
+      public: virtual void UpdateAxis(const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) override;
+
+      // Documentation inherited
+      public: virtual void UpdateParentAxis(
+          const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn) override;
+
+      // Documentation inherited
+      public: virtual void SetType(const JointVisualType _type) override;
+
+      // Documentation inherited
+      public: virtual JointVisualPtr ParentAxisVisual() const override;
+
+      // Documentation inherited
+      public: virtual ArrowVisualPtr ArrowVisual() const override;
+
+      /// \brief Implementation for updating an axis' arrow visual.
+      /// \param[in] _arrowVisual Arrow visual to be updated.
+      /// \param[in] _axis Axis vector.
+      /// \param[in] _xyzExpressedIn Frame in which the axis vector is
+      /// expressed.
+      protected: void UpdateAxisImpl(ArrowVisualPtr _arrowVisual,
+          const ignition::math::Vector3d &_axis,
+          const std::string &_xyzExpressedIn);
+
+      /// \brief Type of joint visualization
+      protected: JointVisualType jointVisualType =
+          JointVisualType::JVT_NONE;
+
+      /// \brief The joint's XYZ frame visual.
+      protected: AxisVisualPtr axisVisual = nullptr;
+
+      /// \brief The visual representing the one joint axis. There can be only
+      /// one axis visual per joint visual, so joints with two axes have a 2nd
+      /// JointVisual with its own arrowVisual.
+      protected: ArrowVisualPtr arrowVisual = nullptr;
+
+      /// \brief Second joint visual for hinge2 and universal joints. It is a
+      /// simplified visual without an XYZ frame.
+      protected: JointVisualPtr parentAxisVis = nullptr;
+
+      /// \brief Scale based on the size of the joint's child.
+      protected: ignition::math::Vector3d scaleToChild =
+          ignition::math::Vector3d::One;
+    };
+
+    //////////////////////////////////////////////////
+    template <class T>
+    BaseJointVisual<T>::BaseJointVisual()
+    {
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    BaseJointVisual<T>::~BaseJointVisual()
+    {
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseJointVisual<T>::PreRender()
+    {
+      T::PreRender();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseJointVisual<T>::Init()
+    {
+      T::Init();
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseJointVisual<T>::SetType(const JointVisualType _type)
+    {
+      this->jointVisualType = _type;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    JointVisualPtr BaseJointVisual<T>::ParentAxisVisual() const
+    {
+      return nullptr;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    ArrowVisualPtr BaseJointVisual<T>::ArrowVisual() const
+    {
+      return nullptr;
+    }
+    }
+  }
+}
+#endif

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -53,6 +53,9 @@ namespace ignition
       // Documentation inherited.
       protected: virtual void PreRender() override;
 
+      // Documentation inherited.
+      protected: virtual void Destroy() override;
+
       // Documentation inherited
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) override;
@@ -220,6 +223,29 @@ namespace ignition
 
       this->axisVisual = this->Scene()->CreateAxisVisual();
       this->AddChild(this->axisVisual);
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseJointVisual<T>::Destroy()
+    {
+      if (this->arrowVisual)
+      {
+        this->arrowVisual->Destroy();
+        this->arrowVisual.reset();
+      }
+
+      if (this->axisVisual)
+      {
+        this->axisVisual->Destroy();
+        this->axisVisual.reset();
+      }
+
+      if (this->parentAxisVis)
+      {
+        this->parentAxisVis->Destroy();
+        this->parentAxisVis.reset();
+      }
     }
 
     /////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -60,7 +60,8 @@ namespace ignition
       // Documentation inherited
       public: virtual void CreateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn) override;
+          const std::string &_xyzExpressedIn,
+          const std::string &_parentName) override;
 
       // Documentation inherited
       public: virtual void UpdateAxis(const ignition::math::Vector3d &_axis,
@@ -179,12 +180,13 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::CreateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const std::string &_xyzExpressedIn)
+          const std::string &_xyzExpressedIn,
+          const std::string &_parentName)
     {
-      if (!this->HasParent())
+      if (!this->Scene()->HasNodeName(_parentName))
       {
-        ignlog << "Joint visual with name " << this->Name() <<
-            " isn't attached to a parent visual" <<
+        ignlog << "Joint parent with name " << _parentName <<
+            " does not exist" <<
             " so the parent axis won't be shown.\n";
         return;
       }
@@ -196,8 +198,8 @@ namespace ignition
       }
 
       this->parentAxisVis = this->Scene()->CreateJointVisual();
-      this->AddChild(this->parentAxisVis);
-      this->parentAxisVis->SetType(this->jointVisualType);
+      this->Scene()->NodeByName(_parentName)->AddChild(this->parentAxisVis);
+      this->parentAxisVis->SetType(this->Type());
       this->parentAxisVis->CreateAxis(_axis, _xyzExpressedIn);
       this->parentAxisVis->SetLocalScale(this->scaleToChild);
       this->UpdateParentAxis(_axis, _xyzExpressedIn);
@@ -313,8 +315,8 @@ namespace ignition
       {
         double childSize =
             std::max(0.1, parentVisual->BoundingBox().Size().Length());
-        this->scaleToChild = ignition::math::Vector3d(childSize * 0.7,
-            childSize * 0.7, childSize * 0.7);
+        this->scaleToChild = ignition::math::Vector3d(childSize * 0.4,
+            childSize * 0.4, childSize * 0.4);
         this->SetLocalScale(this->scaleToChild);
         if (this->ParentAxisVisual())
           this->ParentAxisVisual()->SetLocalScale(this->scaleToChild);
@@ -339,14 +341,14 @@ namespace ignition
     template <class T>
     JointVisualPtr BaseJointVisual<T>::ParentAxisVisual() const
     {
-      return nullptr;
+      return this->parentAxisVis;
     }
 
     //////////////////////////////////////////////////
     template <class T>
     ArrowVisualPtr BaseJointVisual<T>::ArrowVisual() const
     {
-      return nullptr;
+      return this->arrowVisual;
     }
     }
   }

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -201,7 +201,6 @@ namespace ignition
       this->Scene()->NodeByName(_parentName)->AddChild(this->parentAxisVis);
       this->parentAxisVis->SetType(this->Type());
       this->parentAxisVis->CreateAxis(_axis, _xyzExpressedIn);
-      this->parentAxisVis->SetLocalScale(this->scaleToChild);
       this->UpdateParentAxis(_axis, _xyzExpressedIn);
 
       this->ScaleToChild();

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -132,7 +132,7 @@ namespace ignition
       protected: bool dirtyAxis = false;
 
       /// \brief Flag to indicate parent axis data has changed.
-      protected: bool parentDirtyAxis = false;
+      protected: bool dirtyParentAxis = false;
 
       /// \brief Joint visual axis vector.
       protected: ignition::math::Vector3d axis =
@@ -195,10 +195,10 @@ namespace ignition
         this->dirtyAxis = false;
       }
 
-      if (this->parentDirtyAxis)
+      if (this->dirtyParentAxis)
       {
         this->CreateParentAxis();
-        this->parentDirtyAxis = false;
+        this->dirtyParentAxis = false;
       }
 
       if (this->updateAxis)
@@ -289,7 +289,7 @@ namespace ignition
       this->parentAxis = _axis;
       this->parentXyzExpressedIn = _xyzExpressedIn;
       this->jointParentName = _parentName;
-      this->parentDirtyAxis = true;
+      this->dirtyParentAxis = true;
     }
 
     /////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -87,6 +87,9 @@ namespace ignition
       // Documentation inherited
       public: virtual ArrowVisualPtr ArrowVisual() const override;
 
+      // Documentation inherited
+      public: virtual void SetVisible(bool _visible) override;
+
       /// \brief Implementation for updating an axis' arrow visual.
       /// \param[in] _arrowVisual Arrow visual to be updated.
       /// \param[in] _axis Axis vector.
@@ -229,19 +232,19 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::Destroy()
     {
-      if (this->arrowVisual)
+      if (this->arrowVisual != nullptr)
       {
         this->arrowVisual->Destroy();
         this->arrowVisual.reset();
       }
 
-      if (this->axisVisual)
+      if (this->axisVisual != nullptr)
       {
         this->axisVisual->Destroy();
         this->axisVisual.reset();
       }
 
-      if (this->parentAxisVis)
+      if (this->parentAxisVis != nullptr)
       {
         this->parentAxisVis->Destroy();
         this->parentAxisVis.reset();
@@ -441,8 +444,8 @@ namespace ignition
       {
         double childSize =
             std::max(0.1, parentVisual->BoundingBox().Size().Length());
-        this->scaleToChild = ignition::math::Vector3d(childSize * 0.4,
-            childSize * 0.4, childSize * 0.4);
+        this->scaleToChild = ignition::math::Vector3d(childSize * 0.2,
+            childSize * 0.2, childSize * 0.2);
         this->SetLocalScale(this->scaleToChild);
         if (this->ParentAxisVisual())
           this->ParentAxisVisual()->SetLocalScale(this->scaleToChild);
@@ -476,6 +479,22 @@ namespace ignition
     ArrowVisualPtr BaseJointVisual<T>::ArrowVisual() const
     {
       return this->arrowVisual;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseJointVisual<T>::SetVisible(bool _visible)
+    {
+      T::SetVisible(_visible);
+
+      if (this->ArrowVisual())
+        this->ArrowVisual()->SetVisible(_visible);
+
+      if (this->ParentAxisVisual())
+        this->ParentAxisVisual()->SetVisible(_visible);
+
+      if (this->axisVisual)
+        this->axisVisual->SetVisible(_visible);
     }
     }
   }

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -58,7 +58,7 @@ namespace ignition
 
       // Documentation inherited.
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame) override;
+          bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual ignition::math::Vector3d Axis() const override;
@@ -67,19 +67,19 @@ namespace ignition
       public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_parentName,
-          const bool _useParentFrame) override;
+          bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual ignition::math::Vector3d ParentAxis() const override;
 
       // Documentation inherited.
       public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame) override;
+          bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame) override;
+          bool _useParentFrame) override;
 
       // Documentation inherited.
       public: virtual void SetType(const JointVisualType _type) override;
@@ -103,7 +103,7 @@ namespace ignition
       /// expressed in the joint parent frame.
       protected: void UpdateAxisImpl(ArrowVisualPtr _arrowVisual,
           const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame);
+          bool _useParentFrame);
 
       /// \brief Helper function to create axis visual.
       protected: void CreateAxis();
@@ -269,7 +269,7 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::SetAxis(
           const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame)
+          bool _useParentFrame)
     {
       this->axis = _axis;
       this->useParentFrame = _useParentFrame;
@@ -301,7 +301,7 @@ namespace ignition
     void BaseJointVisual<T>::SetParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_parentName,
-          const bool _useParentFrame)
+          bool _useParentFrame)
     {
       this->parentAxis = _axis;
       this->parentAxisUseParentFrame = _useParentFrame;
@@ -341,7 +341,7 @@ namespace ignition
     //////////////////////////////////////////////////
     template <class T>
     bool BaseJointVisual<T>::UpdateAxis(const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame)
+          bool _useParentFrame)
     {
       if (this->ArrowVisual() && this->HasParent())
       {
@@ -356,7 +356,7 @@ namespace ignition
     template <class T>
     bool BaseJointVisual<T>::UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame)
+          bool _useParentFrame)
     {
       if (this->ParentAxisVisual() &&
           this->ParentAxisVisual()->ArrowVisual() &&
@@ -374,7 +374,7 @@ namespace ignition
     template <class T>
     void BaseJointVisual<T>::UpdateAxisImpl(ArrowVisualPtr _arrowVisual,
           const ignition::math::Vector3d &_axis,
-          const bool _useParentFrame)
+          bool _useParentFrame)
     {
       // Get rotation to axis vector
       ignition::math::Vector3d axisDir = _axis;

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -56,38 +56,50 @@ namespace ignition
       // Documentation inherited.
       protected: virtual void Destroy() override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual void SetAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) override;
 
-      // Documentation inherited
+      // Documentation inherited.
+      public: virtual ignition::math::Vector3d Axis() const override;
+
+      // Documentation inherited.
+      public: virtual std::string AxisFrame() const override;
+
+      // Documentation inherited.
       public: virtual void SetParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn,
           const std::string &_parentName) override;
 
-      // Documentation inherited
+      // Documentation inherited.
+      public: virtual ignition::math::Vector3d ParentAxis() const override;
+
+      // Documentation inherited.
+      public: virtual std::string ParentAxisFrame() const override;
+
+      // Documentation inherited.
       public: virtual bool UpdateAxis(const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual bool UpdateParentAxis(
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn) override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual void SetType(const JointVisualType _type) override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual JointVisualType Type() const override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual JointVisualPtr ParentAxisVisual() const override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual ArrowVisualPtr ArrowVisual() const override;
 
-      // Documentation inherited
+      // Documentation inherited.
       public: virtual void SetVisible(bool _visible) override;
 
       /// \brief Implementation for updating an axis' arrow visual.
@@ -99,10 +111,10 @@ namespace ignition
           const ignition::math::Vector3d &_axis,
           const std::string &_xyzExpressedIn);
 
-      /// \brief Helper function to create axis visual
+      /// \brief Helper function to create axis visual.
       protected: void CreateAxis();
 
-      /// \brief Helper function to create parent axis visual
+      /// \brief Helper function to create parent axis visual.
       protected: void CreateParentAxis();
 
       /// \brief Scale the joint visual according to the joint's child.
@@ -144,7 +156,7 @@ namespace ignition
       /// \brief Frame in which axis vector is expressed.
       protected: std::string xyzExpressedIn = "";
 
-      /// \brief Flag to indicate whether to update the axis visual
+      /// \brief Flag to update the axis visual.
       protected: bool updateAxis = false;
 
       /// \brief Parent axis vector.
@@ -154,10 +166,10 @@ namespace ignition
       /// \brief Frame in which parent axis vector is expressed.
       protected: std::string parentXyzExpressedIn = "";
 
-      /// \brief Joint parent name
+      /// \brief Joint parent name.
       protected: std::string jointParentName = "";
 
-      /// \brief Flag to indicate whether to update the parent axis visual
+      /// \brief Flag to update the parent axis visual.
       protected: bool updateParentAxis = false;
 
     };
@@ -463,6 +475,34 @@ namespace ignition
     {
       this->jointVisualType = _type;
       this->dirtyJointType = true;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    ignition::math::Vector3d BaseJointVisual<T>::Axis() const
+    {
+      return this->axis;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    std::string BaseJointVisual<T>::AxisFrame() const
+    {
+      return this->xyzExpressedIn;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    ignition::math::Vector3d BaseJointVisual<T>::ParentAxis() const
+    {
+      return this->parentAxis;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    std::string BaseJointVisual<T>::ParentAxisFrame() const
+    {
+      return this->parentXyzExpressedIn;
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -22,12 +22,12 @@
 
 #include "ignition/common/Console.hh"
 
-#include "ignition/rendering/base/BaseObject.hh"
-#include "ignition/rendering/base/BaseRenderTypes.hh"
 #include "ignition/rendering/ArrowVisual.hh"
 #include "ignition/rendering/AxisVisual.hh"
 #include "ignition/rendering/JointVisual.hh"
 #include "ignition/rendering/Scene.hh"
+#include "ignition/rendering/base/BaseObject.hh"
+#include "ignition/rendering/base/BaseRenderTypes.hh"
 
 namespace ignition
 {
@@ -171,7 +171,6 @@ namespace ignition
 
       /// \brief Flag to update the parent axis visual.
       protected: bool updateParentAxis = false;
-
     };
 
     //////////////////////////////////////////////////
@@ -193,7 +192,9 @@ namespace ignition
       T::PreRender();
 
       if (this->ParentAxisVisual())
+      {
         this->ParentAxisVisual()->PreRender();
+      }
 
       if (this->dirtyJointType)
       {

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -198,8 +198,11 @@ namespace ignition
 
       protected: math::Vector3d origin;
 
+      /// \brief Flag to indicate whether initial local pose
+      /// is set for this node.
       protected: bool initialLocalPoseSet = false;
 
+      /// \brief Initial local pose for this node.
       protected: ignition::math::Pose3d initialLocalPose =
           ignition::math::Pose3d::Zero;
 

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -48,6 +48,7 @@ namespace ignition
 
       public: virtual math::Pose3d LocalPose() const override;
 
+      // Documentation inherited
       public: virtual math::Pose3d InitialLocalPose() const override;
 
       public: virtual void SetLocalPose(const math::Pose3d &_pose) override;

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -46,6 +46,8 @@ namespace ignition
 
       public: virtual math::Pose3d LocalPose() const override;
 
+      public: virtual math::Pose3d InitialLocalPose() const override;
+
       public: virtual void SetLocalPose(const math::Pose3d &_pose) override;
 
       public: virtual void SetLocalPosition(double _x, double _y, double _z)
@@ -186,6 +188,11 @@ namespace ignition
                      const math::Vector3d &_scale) = 0;
 
       protected: math::Vector3d origin;
+
+      protected: bool initialLocalPoseSet = false;
+
+      protected: ignition::math::Pose3d initialLocalPose =
+          ignition::math::Pose3d::Zero;
     };
 
     //////////////////////////////////////////////////
@@ -320,7 +327,20 @@ namespace ignition
         return;
       }
 
+      if (!initialLocalPoseSet)
+      {
+        this->initialLocalPose = pose;
+        this->initialLocalPoseSet = true;
+      }
+
       this->SetRawLocalPose(pose);
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    math::Pose3d BaseNode<T>::InitialLocalPose() const
+    {
+      return this->initialLocalPose;
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -277,6 +277,12 @@ namespace ignition
       protected: virtual InertiaVisualPtr CreateInertiaVisualImpl(
                      unsigned int _id, const std::string &_name) = 0;
 
+      /// \brief Implementation for creating Joint visual.
+      /// \param[in] _id Unique id
+      /// \param[in] _name Name of Joint visual
+      protected: virtual JointVisualPtr CreateJointVisualImpl(unsigned int _id,
+                     const std::string &_name) = 0;
+
       /// \brief Implementation for creating Light visual.
       /// \param[in] _id Unique id
       /// \param[in] _name Name of light visual
@@ -399,6 +405,21 @@ namespace ignition
 
       // Documentation inherited
       public: virtual InertiaVisualPtr CreateInertiaVisual(unsigned int _id,
+                  const std::string &_name) override;
+
+      // Documentation inherited
+      public: virtual JointVisualPtr CreateJointVisual() override;
+
+      // Documentation inherited
+      public: virtual JointVisualPtr CreateJointVisual(unsigned int _id)
+                      override;
+
+      // Documentation inherited
+      public: virtual JointVisualPtr CreateJointVisual(
+                  const std::string &_name) override;
+
+      // Documentation inherited
+      public: virtual JointVisualPtr CreateJointVisual(unsigned int _id,
                   const std::string &_name) override;
 
       // Documentation inherited

--- a/include/ignition/rendering/base/BaseScene.hh
+++ b/include/ignition/rendering/base/BaseScene.hh
@@ -268,24 +268,28 @@ namespace ignition
       /// \brief Implementation for creating CoM visual.
       /// \param[in] _id Unique id
       /// \param[in] _name Name of CoM visual
+      /// \return Pointer to a CoM visual object
       protected: virtual COMVisualPtr CreateCOMVisualImpl(unsigned int _id,
                      const std::string &_name) = 0;
 
       /// \brief Implementation for creating Inertia visual.
       /// \param[in] _id Unique id
       /// \param[in] _name Name of inertia visual
+      /// \return Pointer to a inertia visual object
       protected: virtual InertiaVisualPtr CreateInertiaVisualImpl(
                      unsigned int _id, const std::string &_name) = 0;
 
       /// \brief Implementation for creating Joint visual.
       /// \param[in] _id Unique id
       /// \param[in] _name Name of Joint visual
+      /// \return Pointer to a joint visual object
       protected: virtual JointVisualPtr CreateJointVisualImpl(unsigned int _id,
                      const std::string &_name) = 0;
 
       /// \brief Implementation for creating Light visual.
       /// \param[in] _id Unique id
       /// \param[in] _name Name of light visual
+      /// \return Pointer to a light visual object
       protected: virtual LightVisualPtr CreateLightVisualImpl(unsigned int _id,
                      const std::string &_name) = 0;
 

--- a/ogre/include/ignition/rendering/ogre/OgreJointVisual.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreJointVisual.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE_OGREJOINTVISUAL_HH_
+#define IGNITION_RENDERING_OGRE_OGREJOINTVISUAL_HH_
+
+#include "ignition/rendering/base/BaseJointVisual.hh"
+#include "ignition/rendering/ogre/OgreVisual.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+    //
+    class IGNITION_RENDERING_OGRE_VISIBLE OgreJointVisual :
+      public BaseJointVisual<OgreVisual>
+    {
+      /// \brief Constructor
+      protected: OgreJointVisual();
+
+      /// \brief Destructor
+      public: virtual ~OgreJointVisual();
+
+      /// \brief Only scene can instantiate this class
+      private: friend class OgreScene;
+    };
+    }
+  }
+}
+#endif

--- a/ogre/include/ignition/rendering/ogre/OgreScene.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreScene.hh
@@ -86,6 +86,10 @@ namespace ignition
       protected: virtual InertiaVisualPtr CreateInertiaVisualImpl(
                      unsigned int _id, const std::string &_name) override;
 
+      // Documentation inherited
+      protected: virtual JointVisualPtr CreateJointVisualImpl(unsigned int _id,
+                     const std::string &_name) override;
+
       protected: virtual LightVisualPtr CreateLightVisualImpl(unsigned int _id,
                      const std::string &_name) override;
 

--- a/ogre/src/OgreJointVisual.cc
+++ b/ogre/src/OgreJointVisual.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ignition/rendering/ogre/OgreJointVisual.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+OgreJointVisual::OgreJointVisual()
+{
+}
+
+//////////////////////////////////////////////////
+OgreJointVisual::~OgreJointVisual()
+{
+}

--- a/ogre/src/OgreScene.cc
+++ b/ogre/src/OgreScene.cc
@@ -31,6 +31,7 @@
 #include "ignition/rendering/ogre/OgreHeightmap.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
 #include "ignition/rendering/ogre/OgreInertiaVisual.hh"
+#include "ignition/rendering/ogre/OgreJointVisual.hh"
 #include "ignition/rendering/ogre/OgreLidarVisual.hh"
 #include "ignition/rendering/ogre/OgreLightVisual.hh"
 #include "ignition/rendering/ogre/OgreMarker.hh"
@@ -391,6 +392,15 @@ InertiaVisualPtr OgreScene::CreateInertiaVisualImpl(unsigned int _id,
 {
   OgreInertiaVisualPtr visual(new OgreInertiaVisual);
   bool result = this->InitObject(visual, _id, _name);
+  return (result) ? visual : nullptr;
+}
+
+//////////////////////////////////////////////////
+JointVisualPtr OgreScene::CreateJointVisualImpl(unsigned int _id,
+    const std::string &_name)
+{
+  OgreJointVisualPtr visual(new OgreJointVisual);
+    bool result = this->InitObject(visual, _id, _name);
   return (result) ? visual : nullptr;
 }
 

--- a/ogre/src/OgreScene.cc
+++ b/ogre/src/OgreScene.cc
@@ -400,7 +400,7 @@ JointVisualPtr OgreScene::CreateJointVisualImpl(unsigned int _id,
     const std::string &_name)
 {
   OgreJointVisualPtr visual(new OgreJointVisual);
-    bool result = this->InitObject(visual, _id, _name);
+  bool result = this->InitObject(visual, _id, _name);
   return (result) ? visual : nullptr;
 }
 

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2JointVisual.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2JointVisual.hh
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE2_OGRE2JOINTVISUAL_HH_
+#define IGNITION_RENDERING_OGRE2_OGRE2JOINTVISUAL_HH_
+
+#include "ignition/rendering/base/BaseJointVisual.hh"
+#include "ignition/rendering/ogre2/Ogre2Visual.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+    //
+    class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2JointVisual :
+      public BaseJointVisual<Ogre2Visual>
+    {
+      /// \brief Constructor
+      protected: Ogre2JointVisual();
+
+      /// \brief Destructor
+      public: virtual ~Ogre2JointVisual();
+
+      /// \brief Only scene can instantiate this class
+      private: friend class Ogre2Scene;
+    };
+    }
+  }
+}
+#endif

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
@@ -88,7 +88,7 @@ namespace ignition
     typedef shared_ptr<Ogre2GpuRays>              Ogre2GpuRaysPtr;
     typedef shared_ptr<Ogre2Grid>                 Ogre2GridPtr;
     typedef shared_ptr<Ogre2InertiaVisual>        Ogre2InertiaVisualPtr;
-    typedef shared_ptr<Ogre2JointVisual>        Ogre2JointVisualPtr;
+    typedef shared_ptr<Ogre2JointVisual>          Ogre2JointVisualPtr;
     typedef shared_ptr<Ogre2Light>                Ogre2LightPtr;
     typedef shared_ptr<Ogre2LightVisual>          Ogre2LightVisualPtr;
     typedef shared_ptr<Ogre2LidarVisual>          Ogre2LidarVisualPtr;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
@@ -40,6 +40,7 @@ namespace ignition
     class Ogre2GpuRays;
     class Ogre2Grid;
     class Ogre2InertiaVisual;
+    class Ogre2JointVisual;
     class Ogre2Light;
     class Ogre2LightVisual;
     class Ogre2LidarVisual;
@@ -87,6 +88,7 @@ namespace ignition
     typedef shared_ptr<Ogre2GpuRays>              Ogre2GpuRaysPtr;
     typedef shared_ptr<Ogre2Grid>                 Ogre2GridPtr;
     typedef shared_ptr<Ogre2InertiaVisual>        Ogre2InertiaVisualPtr;
+    typedef shared_ptr<Ogre2JointVisual>        Ogre2JointVisualPtr;
     typedef shared_ptr<Ogre2Light>                Ogre2LightPtr;
     typedef shared_ptr<Ogre2LightVisual>          Ogre2LightVisualPtr;
     typedef shared_ptr<Ogre2LidarVisual>          Ogre2LidarVisualPtr;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -123,8 +123,13 @@ namespace ignition
       protected: virtual COMVisualPtr CreateCOMVisualImpl(unsigned int _id,
                      const std::string &_name) override;
 
+      // Documentation inherited
       protected: virtual InertiaVisualPtr CreateInertiaVisualImpl(
                      unsigned int _id, const std::string &_name) override;
+
+      // Documentation inherited
+      protected: virtual JointVisualPtr CreateJointVisualImpl(unsigned int _id,
+                     const std::string &_name) override;
 
       // Documentation inherited
       protected: virtual LightVisualPtr CreateLightVisualImpl(unsigned int _id,

--- a/ogre2/src/Ogre2JointVisual.cc
+++ b/ogre2/src/Ogre2JointVisual.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "ignition/rendering/ogre2/Ogre2JointVisual.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+Ogre2JointVisual::Ogre2JointVisual()
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2JointVisual::~Ogre2JointVisual()
+{
+}

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -29,6 +29,7 @@
 #include "ignition/rendering/ogre2/Ogre2GpuRays.hh"
 #include "ignition/rendering/ogre2/Ogre2Grid.hh"
 #include "ignition/rendering/ogre2/Ogre2InertiaVisual.hh"
+#include "ignition/rendering/ogre2/Ogre2JointVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2Light.hh"
 #include "ignition/rendering/ogre2/Ogre2LightVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2LidarVisual.hh"
@@ -754,6 +755,15 @@ InertiaVisualPtr Ogre2Scene::CreateInertiaVisualImpl(unsigned int _id,
     const std::string &_name)
 {
   Ogre2InertiaVisualPtr visual(new Ogre2InertiaVisual);
+  bool result = this->InitObject(visual, _id, _name);
+  return (result) ? visual : nullptr;
+}
+
+//////////////////////////////////////////////////
+JointVisualPtr Ogre2Scene::CreateJointVisualImpl(unsigned int _id,
+    const std::string &_name)
+{
+  Ogre2JointVisualPtr visual(new Ogre2JointVisual);
   bool result = this->InitObject(visual, _id, _name);
   return (result) ? visual : nullptr;
 }

--- a/src/ArrowVisual_TEST.cc
+++ b/src/ArrowVisual_TEST.cc
@@ -64,15 +64,21 @@ void ArrowVisualTest::ArrowVisual(const std::string &_renderEngine)
   EXPECT_EQ(math::Vector3d(0.2, 0.3, 0.4), visual->LocalScale());
 
   // check children and geometry
-  EXPECT_EQ(2u, visual->ChildCount());
+  EXPECT_EQ(3u, visual->ChildCount());
 
   NodePtr node = visual->ChildByIndex(0u);
   VisualPtr child = std::dynamic_pointer_cast<Visual>(node);
   ASSERT_NE(nullptr, child);
   EXPECT_EQ(1u, child->GeometryCount());
-  EXPECT_EQ(node, visual->Shaft());
+  EXPECT_EQ(node, visual->Rotation());
 
   node = visual->ChildByIndex(1u);
+  child = std::dynamic_pointer_cast<Visual>(node);
+  ASSERT_NE(nullptr, child);
+  EXPECT_EQ(1u, child->GeometryCount());
+  EXPECT_EQ(node, visual->Shaft());
+
+  node = visual->ChildByIndex(2u);
   child = std::dynamic_pointer_cast<Visual>(node);
   ASSERT_NE(nullptr, child);
   EXPECT_EQ(1u, child->GeometryCount());

--- a/src/ArrowVisual_TEST.cc
+++ b/src/ArrowVisual_TEST.cc
@@ -84,6 +84,12 @@ void ArrowVisualTest::ArrowVisual(const std::string &_renderEngine)
   EXPECT_EQ(1u, child->GeometryCount());
   EXPECT_EQ(node, visual->Head());
 
+  // test destroy
+  ArrowVisualPtr visual2 = scene->CreateArrowVisual();
+  ASSERT_NE(nullptr, visual2);
+  visual2->Destroy();
+  EXPECT_EQ(0u, visual2->ChildCount());
+
   // Clean up
   engine->DestroyScene(scene);
   rendering::unloadEngine(engine->Name());

--- a/src/AxisVisual_TEST.cc
+++ b/src/AxisVisual_TEST.cc
@@ -73,12 +73,16 @@ void AxisVisualTest::AxisVisual(const std::string &_renderEngine)
     ArrowVisualPtr arrow = std::dynamic_pointer_cast<ArrowVisual>(node);
     ASSERT_NE(nullptr, arrow);
 
-    EXPECT_EQ(2u, arrow->ChildCount());
+    EXPECT_EQ(3u, arrow->ChildCount());
     NodePtr childNode = arrow->ChildByIndex(0u);
     VisualPtr child = std::dynamic_pointer_cast<Visual>(childNode);
     EXPECT_EQ(1u, child->GeometryCount());
 
     childNode = arrow->ChildByIndex(1u);
+    child = std::dynamic_pointer_cast<Visual>(childNode);
+    EXPECT_EQ(1u, child->GeometryCount());
+
+    childNode = arrow->ChildByIndex(2u);
     child = std::dynamic_pointer_cast<Visual>(childNode);
     EXPECT_EQ(1u, child->GeometryCount());
   }

--- a/src/JointVisual_TEST.cc
+++ b/src/JointVisual_TEST.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include <ignition/common/Console.hh>
+
+#include "test_config.h"  // NOLINT(build/include)
+
+#include "ignition/rendering/JointVisual.hh"
+#include "ignition/rendering/RenderEngine.hh"
+#include "ignition/rendering/RenderingIface.hh"
+#include "ignition/rendering/Scene.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+class JointVisualTest : public testing::Test,
+                        public testing::WithParamInterface<const char *>
+{
+  /// \brief Test basic API
+  public: void JointVisual(const std::string &_renderEngine);
+};
+
+/////////////////////////////////////////////////
+void JointVisualTest::JointVisual(const std::string &_renderEngine)
+{
+  RenderEngine *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
+
+  ScenePtr scene = engine->CreateScene("scene");
+
+  // create visual
+  JointVisualPtr jointVisual = scene->CreateJointVisual();
+  ASSERT_NE(nullptr, jointVisual);
+
+  // create joint child visual
+  VisualPtr jointChildVisual = scene->CreateVisual("joint_child");
+
+  // create joint parent visual
+  VisualPtr jointParentVisual = scene->CreateVisual("joint_parent");
+
+  // check initial values
+  EXPECT_EQ(JointVisualType::JVT_NONE, jointVisual->Type());
+  EXPECT_EQ(nullptr, jointVisual->ArrowVisual());
+  EXPECT_EQ(nullptr, jointVisual->ParentAxisVisual());
+  EXPECT_EQ(math::Vector3d::Zero, jointVisual->Axis());
+  EXPECT_EQ("", jointVisual->AxisFrame());
+  EXPECT_EQ(math::Vector3d::Zero, jointVisual->ParentAxis());
+  EXPECT_EQ("", jointVisual->ParentAxisFrame());
+
+  // set joint type
+  jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
+  EXPECT_EQ(JointVisualType::JVT_REVOLUTE, jointVisual->Type());
+
+  // set child axis
+  math::Vector3d axis2(0.0, 1.0, 0.0);
+  std::string xyzExpressedIn = "child_axis";
+  jointChildVisual->AddChild(jointVisual);
+  jointVisual->SetAxis(axis2, xyzExpressedIn);
+  jointVisual->PreRender();
+  EXPECT_NE(nullptr, jointVisual->ArrowVisual());
+  EXPECT_EQ(axis2, jointVisual->Axis());
+  EXPECT_EQ("child_axis", jointVisual->AxisFrame());
+  EXPECT_EQ(math::Vector3d::Zero, jointVisual->ParentAxis());
+  EXPECT_EQ("", jointVisual->ParentAxisFrame());
+  EXPECT_EQ(nullptr, jointVisual->ParentAxisVisual());
+
+  // set parent axis
+  math::Vector3d axis1(0.0, 1.0, 0.0);
+  std::string parentXyzExpressedIn = "__model__";
+  jointVisual->SetParentAxis(axis1, parentXyzExpressedIn, "joint_parent");
+  jointVisual->PreRender();
+  EXPECT_NE(nullptr, jointVisual->ArrowVisual());
+  EXPECT_EQ(axis2, jointVisual->Axis());
+  EXPECT_EQ("child_axis", jointVisual->AxisFrame());
+  EXPECT_EQ(axis1, jointVisual->ParentAxis());
+  EXPECT_EQ("__model__", jointVisual->ParentAxisFrame());
+  EXPECT_NE(nullptr, jointVisual->ParentAxisVisual());
+
+  // set visibility
+  jointVisual->SetVisible(false);
+  jointVisual->SetVisible(true);
+
+  // Clean up
+  engine->DestroyScene(scene);
+  rendering::unloadEngine(engine->Name());
+}
+
+/////////////////////////////////////////////////
+TEST_P(JointVisualTest, JointVisual)
+{
+  JointVisual(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(Visual, JointVisualTest,
+    RENDER_ENGINE_VALUES,
+    ignition::rendering::PrintToStringParam());
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/JointVisual_TEST.cc
+++ b/src/JointVisual_TEST.cc
@@ -68,8 +68,8 @@ void JointVisualTest::JointVisual(const std::string &_renderEngine)
   EXPECT_EQ(math::Vector3d::Zero, jointVisual->ParentAxis());
 
   // set joint type
-  jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
-  EXPECT_EQ(JointVisualType::JVT_REVOLUTE, jointVisual->Type());
+  jointVisual->SetType(JointVisualType::JVT_REVOLUTE2);
+  EXPECT_EQ(JointVisualType::JVT_REVOLUTE2, jointVisual->Type());
 
   // set child axis
   math::Vector3d axis2(0.0, 1.0, 0.0);

--- a/src/JointVisual_TEST.cc
+++ b/src/JointVisual_TEST.cc
@@ -65,9 +65,7 @@ void JointVisualTest::JointVisual(const std::string &_renderEngine)
   EXPECT_EQ(nullptr, jointVisual->ArrowVisual());
   EXPECT_EQ(nullptr, jointVisual->ParentAxisVisual());
   EXPECT_EQ(math::Vector3d::Zero, jointVisual->Axis());
-  EXPECT_EQ("", jointVisual->AxisFrame());
   EXPECT_EQ(math::Vector3d::Zero, jointVisual->ParentAxis());
-  EXPECT_EQ("", jointVisual->ParentAxisFrame());
 
   // set joint type
   jointVisual->SetType(JointVisualType::JVT_REVOLUTE);
@@ -75,27 +73,23 @@ void JointVisualTest::JointVisual(const std::string &_renderEngine)
 
   // set child axis
   math::Vector3d axis2(0.0, 1.0, 0.0);
-  std::string xyzExpressedIn = "child_axis";
+  bool useParentFrame = false;
   jointChildVisual->AddChild(jointVisual);
-  jointVisual->SetAxis(axis2, xyzExpressedIn);
+  jointVisual->SetAxis(axis2, useParentFrame);
   jointVisual->PreRender();
   EXPECT_NE(nullptr, jointVisual->ArrowVisual());
   EXPECT_EQ(axis2, jointVisual->Axis());
-  EXPECT_EQ("child_axis", jointVisual->AxisFrame());
   EXPECT_EQ(math::Vector3d::Zero, jointVisual->ParentAxis());
-  EXPECT_EQ("", jointVisual->ParentAxisFrame());
   EXPECT_EQ(nullptr, jointVisual->ParentAxisVisual());
 
   // set parent axis
   math::Vector3d axis1(0.0, 1.0, 0.0);
-  std::string parentXyzExpressedIn = "__model__";
-  jointVisual->SetParentAxis(axis1, parentXyzExpressedIn, "joint_parent");
+  useParentFrame = true;
+  jointVisual->SetParentAxis(axis1, "joint_parent", true);
   jointVisual->PreRender();
   EXPECT_NE(nullptr, jointVisual->ArrowVisual());
   EXPECT_EQ(axis2, jointVisual->Axis());
-  EXPECT_EQ("child_axis", jointVisual->AxisFrame());
   EXPECT_EQ(axis1, jointVisual->ParentAxis());
-  EXPECT_EQ("__model__", jointVisual->ParentAxisFrame());
   EXPECT_NE(nullptr, jointVisual->ParentAxisVisual());
 
   // set visibility

--- a/src/JointVisual_TEST.cc
+++ b/src/JointVisual_TEST.cc
@@ -44,7 +44,7 @@ void JointVisualTest::JointVisual(const std::string &_renderEngine)
   if (!engine)
   {
     igndbg << "Engine '" << _renderEngine
-              << "' is not supported" << std::endl;
+           << "' is not supported" << std::endl;
     return;
   }
 

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -29,6 +29,7 @@
 #include "ignition/rendering/AxisVisual.hh"
 #include "ignition/rendering/COMVisual.hh"
 #include "ignition/rendering/InertiaVisual.hh"
+#include "ignition/rendering/JointVisual.hh"
 #include "ignition/rendering/LidarVisual.hh"
 #include "ignition/rendering/LightVisual.hh"
 #include "ignition/rendering/Camera.hh"
@@ -975,6 +976,36 @@ InertiaVisualPtr BaseScene::CreateInertiaVisual(unsigned int _id,
     const std::string &_name)
 {
   InertiaVisualPtr visual = this->CreateInertiaVisualImpl(_id, _name);
+  bool result = this->RegisterVisual(visual);
+  return (result) ? visual : nullptr;
+}
+
+//////////////////////////////////////////////////
+JointVisualPtr BaseScene::CreateJointVisual()
+{
+  unsigned int objId = this->CreateObjectId();
+  return this->CreateJointVisual(objId);
+}
+
+//////////////////////////////////////////////////
+JointVisualPtr BaseScene::CreateJointVisual(unsigned int _id)
+{
+  std::string objName = this->CreateObjectName(_id, "JointVisual");
+  return this->CreateJointVisual(_id, objName);
+}
+
+//////////////////////////////////////////////////
+JointVisualPtr BaseScene::CreateJointVisual(const std::string &_name)
+{
+  unsigned int objId = this->CreateObjectId();
+  return this->CreateJointVisual(objId, _name);
+}
+
+//////////////////////////////////////////////////
+JointVisualPtr BaseScene::CreateJointVisual(unsigned int _id,
+    const std::string &_name)
+{
+  JointVisualPtr visual = this->CreateJointVisualImpl(_id, _name);
   bool result = this->RegisterVisual(visual);
   return (result) ? visual : nullptr;
 }


### PR DESCRIPTION
# 🎉 New feature
## Summary
Adds joint visual consisting of an axis and an arrow visual.
Gazebo Classic's implementation can be found here - https://github.com/osrf/gazebo/blob/gazebo11/gazebo/rendering/JointVisual.cc
![joint_visual](https://user-images.githubusercontent.com/39728574/126186775-e5009d4d-03bd-418b-a400-97aee49b9126.png)

## Test it
I have added an example in the `visualization_demo` folder. 
To test it with Ignition Gazebo use the [`visualize_joints`](https://github.com/atharva-18/ign-gazebo/tree/visualize_joints) branch.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**