### PR TITLE
Temporarily set number of camera pass count per flush to 0 in ogre2 to prevent downstream build failures

### DIFF
--- a/include/ignition/rendering/Scene.hh
+++ b/include/ignition/rendering/Scene.hh
@@ -1089,9 +1089,9 @@ namespace ignition
       ///
       /// \code
       ///   scene->PreRender();
-      ///   for( auto& camera in cameras )
+      ///   for (auto &camera in cameras)
       ///     camera->Render();
-      ///   for( auto& camera in cameras )
+      ///   for (auto &camera in cameras)
       ///     camera->PostRender();
       ///   scene->PostRender();
       /// \endcode


### PR DESCRIPTION
# 🦟 Bug fix

Temporarily switching `Ogre2Scene::cameraPassCountPerGpuFlush` back to 0 (old behavior) in ogre2 until all related PRs are merged:
* https://github.com/ignitionrobotics/ign-sensors/pull/145
* https://github.com/ignitionrobotics/ign-gazebo/pull/921

Also applied style fixes as mentioned in #353


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

