### PR TITLE
(out-of-date) Prevent default-constructed variants from holding a type

### DIFF
--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -28,7 +28,15 @@ namespace ignition
   {
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     //
-    using Variant = std::variant<int, float, double, std::string>;
+    /// \brief Alias for a variant that can holds various types of data.
+    /// The first type of the variant is std::monostate in order to prevent
+    /// default-constructed variants from holding a type (a default-constructed
+    /// variant is returned when a user calls Visual::UserData with a key that
+    /// doesn't exist for the visual. In this case, since the key doesn't
+    /// exist, the variant that is returned shouldn't hold any types - an
+    /// "empty variant" should be returned for keys that don't exist)
+    using Variant = std::variant<std::monostate, int, float, double,
+          std::string>;
 
     /// \class Visual Visual.hh ignition/rendering/Visual.hh
     /// \brief Represents a visual node in a scene graph. A Visual is the only

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <string>
+#include <variant>
 
 #include <ignition/common/Console.hh>
 
@@ -346,6 +347,15 @@ void VisualTest::UserData(const std::string &_renderEngine)
     auto res = std::get<int>(value);
     igndbg << res << std::endl;
   }, std::bad_variant_access);
+
+  // Check the contents of a userData key that does not exist.
+  // This should give us a default-constructed variant, which should hold no
+  // types in it (i.e., is an "empty variant").
+  Variant valueEmpty = visual->UserData("randomKey");
+  EXPECT_FALSE(std::holds_alternative<int>(valueEmpty));
+  EXPECT_FALSE(std::holds_alternative<float>(valueEmpty));
+  EXPECT_FALSE(std::holds_alternative<double>(valueEmpty));
+  EXPECT_FALSE(std::holds_alternative<std::string>(valueEmpty));
 
   // Clean up
   engine->DestroyScene(scene);


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>


# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-rendering/pull/334#discussion_r647923514

## Summary
The [`std::variant` documentation](https://en.cppreference.com/w/cpp/utility/variant) states:
```
a default-constructed variant holds a value of its first alternative, unless that alternative is not default-constructible (in which case the variant is not default-constructible either).
```

This can be problematic if a user calls [`Visual::UserData`](https://github.com/ignitionrobotics/ign-rendering/blob/ignition-rendering3_3.5.0/include/ignition/rendering/Visual.hh#L125) with a key that does not exist, because this will [return a default-constructed variant](https://github.com/ignitionrobotics/ign-rendering/blob/ignition-rendering3_3.5.0/include/ignition/rendering/base/BaseVisual.hh#L347). The expected behavior should be that for calls to `Visual::UserData` with a key that does not exist, an "empty variant" is returned (i.e., a variant which holds no alternatives - see [`std::holds_alternative`](https://en.cppreference.com/w/cpp/utility/variant/holds_alternative)).

The fix proposed here is similar to what is proposed in https://github.com/ignitionrobotics/ign-rendering/pull/334#issuecomment-882382753. [`std::monostate`](https://en.cppreference.com/w/cpp/utility/variant/monostate) is used to guarantee empty alternatives for a default-constructed variant.

For a running example that shows the difference between the current behavior and proposed behavior using `std::monostate`, see https://godbolt.org/z/hcGM815Kh.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**