### PR TITLE
Support OpenGL < 4.2 in PBS shader

### DIFF
--- a/ogre2/src/media/Hlms/Pbs/GLSL/BRDFs_piece_ps.glsl
+++ b/ogre2/src/media/Hlms/Pbs/GLSL/BRDFs_piece_ps.glsl
@@ -12,7 +12,7 @@
 @property( !fresnel_scalar )
 	@piece( maxR1F0 )max( 1.0 - ROUGHNESS, @insertpiece( F0 ).x )@end
 @end @property( fresnel_scalar )
-	@piece( maxR1F0 )max( (1.0 - ROUGHNESS).xxx, @insertpiece( F0 ).xyz )@end
+	@piece( maxR1F0 )max( (1.0 - vec3(ROUGHNESS, 0.0, 0.0)).xxx, @insertpiece( F0 ).xyz )@end
 @end
 
 //For mortals:


### PR DESCRIPTION
# 🦟 Bug fix

This PR addresses an issue with models using PBS with the ogre2 render engine on systems that do not support OpenGL 4.2 or higher (i.e. macOS).  

## Summary

The fix is a one line change to one of the ogre2 GLSL shader templates. The issue is that OpenGL < 4.2 does not support swizzling of scalars (e.g. float) and this feature is used in part of the Fresnel calculation.

(See: [Data_Type (GLSL) : Swizzling](https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)#Swizzling))

Without this change the ignition rendering example `ogre2_demo` will fail (crash because of an unhandled exception when the shader fails to compile).

With the change (and other changes specific to macOS not included in this PR) the `ogre2_demo` and other models that require PBS in ignition gazebo will work.

**Before Fix**

```console
$ ./ogre2_demo
[Msg] Loading plugin [ignition-rendering-ogre2]
Creating resource group General
Creating resource group Internal
Creating resource group Autodetect

...

Vertex Shader: 100000004VertexShader_vs
Fragment Shader: 100000004PixelShader_ps
 GLSL validation result : 
Validation Failed: Sampler error:
  Samplers of different types use the same texture image unit.
   - or -
  A sampler's texture unit is out of range (greater than max allowed or negative).
GLSL compile log: 100000005PixelShader_ps
ERROR: 0:1263: Swizzle of non-vector primitive float
ERROR: 0:1266: Use of undeclared identifier 'fresnelS'
ERROR: 0:1266: Use of undeclared identifier 'fresnelS'
ERROR: 0:1266: Use of undeclared identifier 'fresnelS'
ERROR: 0:1268: Use of undeclared identifier 'fresnelD'
ERROR: 0:1269: Use of undeclared identifier 'fresnelS'
libc++abi: terminating with uncaught exception of type Ogre::RenderingAPIException: OGRE EXCEPTION(3:RenderingAPIException): Fragment Program 100000005PixelShader_ps failed to compile. See compile log above for details. in GLSLShader::compile at /Users/rhys/Code/ogre/ogre-next2.1/RenderSystems/GL3Plus/src/GLSL/OgreGLSLShader.cpp (line 308)
zsh: abort      ./ogre2_demo
```

**After Fix**

`ogre2_demo`:

![ogre2_demo](https://user-images.githubusercontent.com/24916364/129108368-92dbd3e7-7a61-4ecf-b389-6ff8034f345b.png)

`ignition-gazebo` rendering the Panda model from the edifice demo world:

![edifice_demo_panda](https://user-images.githubusercontent.com/24916364/129108456-84f43280-605a-4c10-a611-b61fdf64afa0.png)

**Tests**

There are two tests failing on macOS, however these also fail before this change and I do not think the issue with them is related to the PBS shader.

```bash
make test
Running tests...
Test project /Users/rhys/Code/robotics/gazebo/ign_ediface_ws/src/ign-rendering/build
      Start  1: UNIT_ArrowVisual_TEST
 1/86 Test  #1: UNIT_ArrowVisual_TEST .................   Passed    0.19 sec
      Start  2: check_UNIT_ArrowVisual_TEST
 2/86 Test  #2: check_UNIT_ArrowVisual_TEST ...........   Passed    0.04 sec
      Start  3: UNIT_AxisVisual_TEST
 3/86 Test  #3: UNIT_AxisVisual_TEST ..................   Passed    0.19 sec
      Start  4: check_UNIT_AxisVisual_TEST
 4/86 Test  #4: check_UNIT_AxisVisual_TEST ............   Passed    0.04 sec
      Start  5: UNIT_Camera_TEST
 5/86 Test  #5: UNIT_Camera_TEST ......................   Passed    0.52 sec
      Start  6: check_UNIT_Camera_TEST
 6/86 Test  #6: check_UNIT_Camera_TEST ................   Passed    0.04 sec
      Start  7: UNIT_Capsule_TEST
 7/86 Test  #7: UNIT_Capsule_TEST .....................   Passed    0.19 sec
      Start  8: check_UNIT_Capsule_TEST
 8/86 Test  #8: check_UNIT_Capsule_TEST ...............   Passed    0.04 sec
      Start  9: UNIT_GaussianNoisePass_TEST
 9/86 Test  #9: UNIT_GaussianNoisePass_TEST ...........   Passed    0.18 sec
      Start 10: check_UNIT_GaussianNoisePass_TEST
10/86 Test #10: check_UNIT_GaussianNoisePass_TEST .....   Passed    0.04 sec
      Start 11: UNIT_GizmoVisual_TEST
11/86 Test #11: UNIT_GizmoVisual_TEST .................   Passed    0.28 sec
      Start 12: check_UNIT_GizmoVisual_TEST
12/86 Test #12: check_UNIT_GizmoVisual_TEST ...........   Passed    0.04 sec
      Start 13: UNIT_Grid_TEST
13/86 Test #13: UNIT_Grid_TEST ........................   Passed    0.19 sec
      Start 14: check_UNIT_Grid_TEST
14/86 Test #14: check_UNIT_Grid_TEST ..................   Passed    0.04 sec
      Start 15: UNIT_Heightmap_TEST
15/86 Test #15: UNIT_Heightmap_TEST ...................   Passed    0.01 sec
      Start 16: check_UNIT_Heightmap_TEST
16/86 Test #16: check_UNIT_Heightmap_TEST .............   Passed    0.04 sec
      Start 17: UNIT_LidarVisual_TEST
17/86 Test #17: UNIT_LidarVisual_TEST .................   Passed    0.19 sec
      Start 18: check_UNIT_LidarVisual_TEST
18/86 Test #18: check_UNIT_LidarVisual_TEST ...........   Passed    0.04 sec
      Start 19: UNIT_LightVisual_TEST
19/86 Test #19: UNIT_LightVisual_TEST .................   Passed    0.19 sec
      Start 20: check_UNIT_LightVisual_TEST
20/86 Test #20: check_UNIT_LightVisual_TEST ...........   Passed    0.04 sec
      Start 21: UNIT_Light_TEST
21/86 Test #21: UNIT_Light_TEST .......................   Passed    0.20 sec
      Start 22: check_UNIT_Light_TEST
22/86 Test #22: check_UNIT_Light_TEST .................   Passed    0.04 sec
      Start 23: UNIT_Marker_TEST
23/86 Test #23: UNIT_Marker_TEST ......................   Passed    0.20 sec
      Start 24: check_UNIT_Marker_TEST
24/86 Test #24: check_UNIT_Marker_TEST ................   Passed    0.04 sec
      Start 25: UNIT_Material_TEST
25/86 Test #25: UNIT_Material_TEST ....................   Passed    0.28 sec
      Start 26: check_UNIT_Material_TEST
26/86 Test #26: check_UNIT_Material_TEST ..............   Passed    0.04 sec
      Start 27: UNIT_MeshDescriptor_TEST
27/86 Test #27: UNIT_MeshDescriptor_TEST ..............   Passed    0.19 sec
      Start 28: check_UNIT_MeshDescriptor_TEST
28/86 Test #28: check_UNIT_MeshDescriptor_TEST ........   Passed    0.04 sec
      Start 29: UNIT_Mesh_TEST
29/86 Test #29: UNIT_Mesh_TEST ........................   Passed    0.44 sec
      Start 30: check_UNIT_Mesh_TEST
30/86 Test #30: check_UNIT_Mesh_TEST ..................   Passed    0.04 sec
      Start 31: UNIT_MoveToHelper_TEST
31/86 Test #31: UNIT_MoveToHelper_TEST ................   Passed    0.20 sec
      Start 32: check_UNIT_MoveToHelper_TEST
32/86 Test #32: check_UNIT_MoveToHelper_TEST ..........   Passed    0.04 sec
      Start 33: UNIT_Node_TEST
33/86 Test #33: UNIT_Node_TEST ........................   Passed    0.19 sec
      Start 34: check_UNIT_Node_TEST
34/86 Test #34: check_UNIT_Node_TEST ..................   Passed    0.04 sec
      Start 35: UNIT_OrbitViewController_TEST
35/86 Test #35: UNIT_OrbitViewController_TEST .........   Passed    0.29 sec
      Start 36: check_UNIT_OrbitViewController_TEST
36/86 Test #36: check_UNIT_OrbitViewController_TEST ...   Passed    0.04 sec
      Start 37: UNIT_ParticleEmitter_TEST
37/86 Test #37: UNIT_ParticleEmitter_TEST .............   Passed    0.20 sec
      Start 38: check_UNIT_ParticleEmitter_TEST
38/86 Test #38: check_UNIT_ParticleEmitter_TEST .......   Passed    0.04 sec
      Start 39: UNIT_PixelFormat_TEST
39/86 Test #39: UNIT_PixelFormat_TEST .................   Passed    0.01 sec
      Start 40: check_UNIT_PixelFormat_TEST
40/86 Test #40: check_UNIT_PixelFormat_TEST ...........   Passed    0.04 sec
      Start 41: UNIT_RayQuery_TEST
41/86 Test #41: UNIT_RayQuery_TEST ....................   Passed    0.20 sec
      Start 42: check_UNIT_RayQuery_TEST
42/86 Test #42: check_UNIT_RayQuery_TEST ..............   Passed    0.04 sec
      Start 43: UNIT_RenderEngine_TEST
43/86 Test #43: UNIT_RenderEngine_TEST ................   Passed    0.22 sec
      Start 44: check_UNIT_RenderEngine_TEST
44/86 Test #44: check_UNIT_RenderEngine_TEST ..........   Passed    0.04 sec
      Start 45: UNIT_RenderPassSystem_TEST
45/86 Test #45: UNIT_RenderPassSystem_TEST ............   Passed    0.19 sec
      Start 46: check_UNIT_RenderPassSystem_TEST
46/86 Test #46: check_UNIT_RenderPassSystem_TEST ......   Passed    0.04 sec
      Start 47: UNIT_RenderTarget_TEST
47/86 Test #47: UNIT_RenderTarget_TEST ................   Passed    0.19 sec
      Start 48: check_UNIT_RenderTarget_TEST
48/86 Test #48: check_UNIT_RenderTarget_TEST ..........   Passed    0.04 sec
      Start 49: UNIT_RenderingIface_TEST
49/86 Test #49: UNIT_RenderingIface_TEST ..............   Passed    0.27 sec
      Start 50: check_UNIT_RenderingIface_TEST
50/86 Test #50: check_UNIT_RenderingIface_TEST ........   Passed    0.04 sec
      Start 51: UNIT_Scene_TEST
51/86 Test #51: UNIT_Scene_TEST .......................   Passed    0.87 sec
      Start 52: check_UNIT_Scene_TEST
52/86 Test #52: check_UNIT_Scene_TEST .................   Passed    0.04 sec
      Start 53: UNIT_ShaderParam_TEST
53/86 Test #53: UNIT_ShaderParam_TEST .................   Passed    0.01 sec
      Start 54: check_UNIT_ShaderParam_TEST
54/86 Test #54: check_UNIT_ShaderParam_TEST ...........   Passed    0.04 sec
      Start 55: UNIT_ShaderParams_TEST
55/86 Test #55: UNIT_ShaderParams_TEST ................   Passed    0.01 sec
      Start 56: check_UNIT_ShaderParams_TEST
56/86 Test #56: check_UNIT_ShaderParams_TEST ..........   Passed    0.04 sec
      Start 57: UNIT_Text_TEST
57/86 Test #57: UNIT_Text_TEST ........................   Passed    0.01 sec
      Start 58: check_UNIT_Text_TEST
58/86 Test #58: check_UNIT_Text_TEST ..................   Passed    0.04 sec
      Start 59: UNIT_ThermalCamera_TEST
59/86 Test #59: UNIT_ThermalCamera_TEST ...............   Passed    0.19 sec
      Start 60: check_UNIT_ThermalCamera_TEST
60/86 Test #60: check_UNIT_ThermalCamera_TEST .........   Passed    0.04 sec
      Start 61: UNIT_TransformController_TEST
61/86 Test #61: UNIT_TransformController_TEST .........   Passed    0.45 sec
      Start 62: check_UNIT_TransformController_TEST
62/86 Test #62: check_UNIT_TransformController_TEST ...   Passed    0.04 sec
      Start 63: UNIT_Visual_TEST
63/86 Test #63: UNIT_Visual_TEST ......................   Passed    0.69 sec
      Start 64: check_UNIT_Visual_TEST
64/86 Test #64: check_UNIT_Visual_TEST ................   Passed    0.04 sec
      Start 65: UNIT_WireBox_TEST
65/86 Test #65: UNIT_WireBox_TEST .....................   Passed    0.19 sec
      Start 66: check_UNIT_WireBox_TEST
66/86 Test #66: check_UNIT_WireBox_TEST ...............   Passed    0.04 sec
      Start 67: INTEGRATION_gpu_rays
67/86 Test #67: INTEGRATION_gpu_rays ..................   Passed    0.20 sec
      Start 68: check_INTEGRATION_gpu_rays
68/86 Test #68: check_INTEGRATION_gpu_rays ............   Passed    0.04 sec
      Start 69: INTEGRATION_depth_camera
69/86 Test #69: INTEGRATION_depth_camera ..............***Failed   22.02 sec
      Start 70: check_INTEGRATION_depth_camera
70/86 Test #70: check_INTEGRATION_depth_camera ........   Passed    0.04 sec
      Start 71: INTEGRATION_camera
71/86 Test #71: INTEGRATION_camera ....................   Passed   10.53 sec
      Start 72: check_INTEGRATION_camera
72/86 Test #72: check_INTEGRATION_camera ..............   Passed    0.04 sec
      Start 73: INTEGRATION_render_pass
73/86 Test #73: INTEGRATION_render_pass ...............   Passed    7.76 sec
      Start 74: check_INTEGRATION_render_pass
74/86 Test #74: check_INTEGRATION_render_pass .........   Passed    0.04 sec
      Start 75: INTEGRATION_shadows
75/86 Test #75: INTEGRATION_shadows ...................   Passed    2.87 sec
      Start 76: check_INTEGRATION_shadows
76/86 Test #76: check_INTEGRATION_shadows .............   Passed    0.04 sec
      Start 77: INTEGRATION_scene
77/86 Test #77: INTEGRATION_scene .....................   Passed    5.27 sec
      Start 78: check_INTEGRATION_scene
78/86 Test #78: check_INTEGRATION_scene ...............   Passed    0.04 sec
      Start 79: INTEGRATION_sky
79/86 Test #79: INTEGRATION_sky .......................   Passed    0.33 sec
      Start 80: check_INTEGRATION_sky
80/86 Test #80: check_INTEGRATION_sky .................   Passed    0.04 sec
      Start 81: INTEGRATION_thermal_camera
81/86 Test #81: INTEGRATION_thermal_camera ............***Failed    1.17 sec
      Start 82: check_INTEGRATION_thermal_camera
82/86 Test #82: check_INTEGRATION_thermal_camera ......   Passed    0.04 sec
      Start 83: INTEGRATION_lidar_visual
83/86 Test #83: INTEGRATION_lidar_visual ..............   Passed    0.19 sec
      Start 84: check_INTEGRATION_lidar_visual
84/86 Test #84: check_INTEGRATION_lidar_visual ........   Passed    0.04 sec
      Start 85: PERFORMANCE_scene_factory
85/86 Test #85: PERFORMANCE_scene_factory .............   Passed    4.33 sec
      Start 86: check_PERFORMANCE_scene_factory
86/86 Test #86: check_PERFORMANCE_scene_factory .......   Passed    0.04 sec

98% tests passed, 2 tests failed out of 86

Total Test time (real) =  64.31 sec

The following tests FAILED:
	 69 - INTEGRATION_depth_camera (Failed)
	 81 - INTEGRATION_thermal_camera (Failed)
Errors while running CTest
Output from these tests are in: /Users/rhys/Code/robotics/gazebo/ign_ediface_ws/src/ign-rendering/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [test] Error 8
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**