### PR TITLE
Fix JointVisual axis head visibility

### DIFF
--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -425,6 +425,10 @@ namespace ignition
       else
         return;
 
+      // Don't change the visibility of joint child axis
+      if (this->ArrowVisual() != _arrowVisual)
+        return;
+
        // Hide existing arrow head if it overlaps with the axis
       auto axisWorldRotation = _arrowVisual->WorldPose().Rot();
       auto jointWorldRotation = this->WorldPose().Rot();


### PR DESCRIPTION
Signed-off-by: Atharva Pusalkar <atharvapusalkar18@gmail.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix
## Summary
Fixes a bug in the joint child axis visual whenever the parent arrow visual is updated, as mentioned in https://github.com/ignitionrobotics/ign-gazebo/pull/961#issuecomment-904791304
![screenshot](https://user-images.githubusercontent.com/39728574/130661817-d4dd0b1d-b711-43e2-98a6-25d0dee4027d.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**