### PR TITLE
Output warning message if a mesh with zero submeshes is created 

### DIFF
--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -450,6 +450,15 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
     return false;
   }
 
+  if (ogreMesh->getNumSubMeshes() == 0u)
+  {
+    std::string msg = "Unable to load mesh: '" + _desc.meshName + "'";
+    if (!_desc.subMeshName.empty())
+      msg += ", submesh: '" + _desc.subMeshName + "'";
+    msg += ". Mesh will be empty.";
+    ignwarn << msg << std::endl;
+  }
+
   return true;
 }
 

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -469,6 +469,15 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
     return false;
   }
 
+  if (ogreMesh->getNumSubMeshes() == 0u)
+  {
+    std::string msg = "Unable to load mesh: '" + _desc.meshName + "'";
+    if (!_desc.subMeshName.empty())
+      msg += ", submesh: '" + _desc.subMeshName + "'";
+    msg += ". Mesh will be empty.";
+    ignwarn << msg << std::endl;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Currently if a ign-gazebo user specifies a non-existent submesh through the `<submesh>` SDF element, an empty mesh with no submeshes will be created. The newly added warning msg is useful to help catch issues / typos with incorrectly specified submesh name.

To test:

you can change a submesh name in one of the ign-gazebo example worlds to see the warning msg printed in the console, e.g. edit [tunnel.sdf and change this submesh](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo4/examples/worlds/tunnel.sdf#L1106) from `BodyFront` to `FrontBody` then launch the tunnel world.

```
ign gazebo -v 4 tunnel.sdf
```

and you should see this warning msg:

```
[GUI] [Wrn] [Ogre2MeshFactory.cc:478] Unable to load mesh: 'https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/EXPLORER_R2_SENSOR_CONFIG_2/3/files/meshes/r2.dae', submesh: 'FrontBody'. Mesh will be empty.

```


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
