### PR TITLE
Don't keep DEPTH_CLAMP enabled after it's used

### DIFF
--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -855,7 +855,7 @@ void Ogre2ThermalCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
 #ifndef _WIN32
-  glEnable(GL_DEPTH_CLAMP);
+  glDisable(GL_DEPTH_CLAMP);
 #endif
 }
 


### PR DESCRIPTION
Probably a copy-paste bug, after enabling DEPTH_CLAMP we must disable
once we're done; but we call glEnable again instead of disabling it.

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

This is a silly bug

# 🦟 Bug fix

No number

## Summary


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
