### PR TITLE
Add SetSize API for Marker point size

### DIFF
--- a/include/ignition/rendering/Marker.hh
+++ b/include/ignition/rendering/Marker.hh
@@ -108,6 +108,16 @@ namespace ignition
       /// \return The render type of the marker
       public: virtual ignition::rendering::MarkerType Type() const = 0;
 
+      /// \brief Set size of the marker. Only affects MT_POINTS.
+      /// e.g. size of rasterized points in pixels
+      /// \param[in] _size Size of the marker
+      public: virtual void SetSize(double _size) = 0;
+
+      /// \brief Get the size of the marker.
+      /// \return The size of the marker
+      /// \sa SetSize
+      public: virtual double Size() const = 0;
+
       /// \brief Clear the points of the marker, if applicable
       public: virtual void ClearPoints() = 0;
 

--- a/include/ignition/rendering/base/BaseMarker.hh
+++ b/include/ignition/rendering/base/BaseMarker.hh
@@ -61,6 +61,12 @@ namespace ignition
       public: virtual MarkerType Type() const override;
 
       // Documentation inherited
+      public: virtual void SetSize(double _size) override;
+
+      // Documentation inherited
+      public: virtual double Size() const override;
+
+      // Documentation inherited
       public: virtual void SetLayer(int32_t _layer) override;
 
       // Documentation inherited
@@ -97,6 +103,9 @@ namespace ignition
       /// \brief Marker type
       protected: MarkerType markerType =
           ignition::rendering::MarkerType::MT_NONE;
+
+      /// \brief Marker size
+      protected: double size = 1.0;
     };
 
     /////////////////////////////////////////////////
@@ -157,6 +166,21 @@ namespace ignition
     MarkerType BaseMarker<T>::Type() const
     {
       return this->markerType;
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    void BaseMarker<T>::SetSize(double _size)
+    {
+      this->size = _size;
+      this->markerDirty = true;
+    }
+
+    /////////////////////////////////////////////////
+    template <class T>
+    double BaseMarker<T>::Size() const
+    {
+      return this->size;
     }
 
     /////////////////////////////////////////////////

--- a/ogre/src/OgreMarker.cc
+++ b/ogre/src/OgreMarker.cc
@@ -58,13 +58,20 @@ void OgreMarker::PreRender()
       this->dataPtr->dynamicRenderable &&
       this->dataPtr->dynamicRenderable->PointCount() > 0u)
   {
+    std::string pointsMatName = "PointCloudPoint";
     if (this->dataPtr->dynamicRenderable->getMaterial().isNull() ||
         this->dataPtr->dynamicRenderable->getMaterial()->getName()
-        != "PointCloudPoint")
+        != pointsMatName)
     {
-      this->dataPtr->dynamicRenderable->setMaterial("PointCloudPoint");
+#if (OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7))
+      this->dataPtr->dynamicRenderable->setMaterial(pointsMatName);
+#else
+      Ogre::MaterialPtr pointsMat =
+          Ogre::MaterialManager::getSingleton().getByName(
+          pointsMatName);
+      this->dataPtr->dynamicRenderable->setMaterial(pointsMat);
+#endif
     }
-
     auto pass = this->dataPtr->dynamicRenderable->getMaterial()->getTechnique(
         0)->getPass(0);
     auto vertParams = pass->getVertexProgramParameters();

--- a/ogre/src/OgreMarker.cc
+++ b/ogre/src/OgreMarker.cc
@@ -34,10 +34,6 @@ class ignition::rendering::OgreMarkerPrivate
 
   /// \brief Geometry Object for primitive shapes
   public: OgreGeometryPtr geom{nullptr};
-
-  /// \brief Pointer to point cloud material.
-  /// Used when MarkerType = MT_POINTS.
-  public: Ogre::MaterialPtr pointsMat;
 };
 
 using namespace ignition;
@@ -62,14 +58,15 @@ void OgreMarker::PreRender()
       this->dataPtr->dynamicRenderable &&
       this->dataPtr->dynamicRenderable->PointCount() > 0u)
   {
-    if (this->dataPtr->dynamicRenderable->getMaterial() !=
-        this->dataPtr->pointsMat)
+    if (this->dataPtr->dynamicRenderable->getMaterial().isNull() ||
+        this->dataPtr->dynamicRenderable->getMaterial()->getName()
+        != "PointCloudPoint")
     {
-      this->dataPtr->dynamicRenderable->setMaterial(
-          this->dataPtr->pointsMat->getName());
+      this->dataPtr->dynamicRenderable->setMaterial("PointCloudPoint");
     }
 
-    auto pass = this->dataPtr->pointsMat->getTechnique(0)->getPass(0);
+    auto pass = this->dataPtr->dynamicRenderable->getMaterial()->getTechnique(
+        0)->getPass(0);
     auto vertParams = pass->getVertexProgramParameters();
     vertParams->setNamedConstant("size", static_cast<Ogre::Real>(this->size));
   }
@@ -136,10 +133,6 @@ void OgreMarker::Init()
 //////////////////////////////////////////////////
 void OgreMarker::Create()
 {
-  this->dataPtr->pointsMat =
-      Ogre::MaterialManager::getSingleton().getByName(
-      "PointCloudPoint");
-
   this->markerType = MT_NONE;
   this->dataPtr->dynamicRenderable.reset(new OgreDynamicLines(MT_LINE_STRIP));
 

--- a/ogre2/src/Ogre2LidarVisual.cc
+++ b/ogre2/src/Ogre2LidarVisual.cc
@@ -26,6 +26,8 @@
 #endif
 
 #include <ignition/common/Console.hh>
+
+#include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2DynamicRenderable.hh"
 #include "ignition/rendering/ogre2/Ogre2LidarVisual.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
@@ -479,8 +481,14 @@ void Ogre2LidarVisual::Update()
     // point renderables use low level materials
     // get the material and set size uniform variable
     auto pass = this->dataPtr->pointsMat->getTechnique(0)->getPass(0);
-    auto params = pass->getVertexProgramParameters();
-    params->setNamedConstant("size", static_cast<Ogre::Real>(this->size));
+    auto vertParams = pass->getVertexProgramParameters();
+    vertParams->setNamedConstant("size", static_cast<Ogre::Real>(this->size));
+
+    // support setting color only from diffuse for now
+    MaterialPtr mat = this->Scene()->Material("Lidar/BlueRay");
+    auto fragParams = pass->getFragmentProgramParameters();
+    fragParams->setNamedConstant("color",
+        Ogre2Conversions::Convert(mat->Diffuse()));
   }
 
   // The newly created dynamic lines are having default visibility as true.

--- a/ogre2/src/media/materials/programs/point_fs.glsl
+++ b/ogre2/src/media/materials/programs/point_fs.glsl
@@ -17,13 +17,14 @@
 
 #version 330
 
+uniform vec4 color;
+
 out vec4 fragColor;
 
 void main()
 {
-  // hardcode to blue color for now
-  // todo(anyone) undate Ogre2DynamicRenderable to support vertex coloring
+  // todo(anyone) update Ogre2DynamicRenderable to support vertex coloring
   // so we can set color using the line below
   // fragColor = gl_Color;
-  fragColor = vec4(0.0f, 0.0f, 1.0f, 1.0f);
+  fragColor = color;
 }

--- a/ogre2/src/media/materials/scripts/point_cloud_point.material
+++ b/ogre2/src/media/materials/scripts/point_cloud_point.material
@@ -22,13 +22,17 @@ vertex_program PointCloudVS glsl
   default_params
   {
     param_named_auto worldViewProj worldviewproj_matrix
-    param_named size 1.0
+    param_named size float 1.0
   }
 }
 
 fragment_program PointCloudFS glsl
 {
   source point_fs.glsl
+  default_params
+  {
+    param_named color vec4 1.0 1.0 1.0 1.0
+  }
 }
 
 material PointCloudPoint

--- a/src/Marker_TEST.cc
+++ b/src/Marker_TEST.cc
@@ -109,6 +109,10 @@ void MarkerTest::Marker(const std::string &_renderEngine)
   EXPECT_NO_THROW(marker->SetPoint(0, math::Vector3d(3, 1, 2)));
   EXPECT_NO_THROW(marker->ClearPoints());
 
+  EXPECT_DOUBLE_EQ(1.0, marker->Size());
+  marker->SetSize(3.0);
+  EXPECT_DOUBLE_EQ(3.0, marker->Size());
+
   // Clean up
   engine->DestroyScene(scene);
   rendering::unloadEngine(engine->Name());


### PR DESCRIPTION
# 🎉 New feature

## Summary

Similar to #392, this PR add new function for setting size of a marker with `MT_POINTS` points

## Test it

It may be worth considering adding a marker example demo in the future for demo'ing the marker feature and it's also easier for testing.

For now, I test with the the [marker](https://github.com/ignitionrobotics/ign-gui/tree/main/examples/standalone/marker) standable example in ign-gui, and then manually modifying the marker size in ign-gazebo's `MarkerManager`

1. Build the ign-gui [marker](https://github.com/ignitionrobotics/ign-gui/tree/main/examples/standalone/marker) example

1.  We currently don't have a gui plugin or msg field for changing marker size. So manually test different marker size by applying this patch to ign-gazebo.

    ```cpp
    diff --git a/src/rendering/MarkerManager.cc b/src/rendering/MarkerManager.cc
    index 736815b4..4e64e096 100644
    --- a/src/rendering/MarkerManager.cc
    +++ b/src/rendering/MarkerManager.cc
    @@ -321,6 +321,7 @@ void MarkerManagerPrivate::SetMarker(const ignition::msgs::Marker &_msg,
       // Set Marker Render Type
       ignition::rendering::MarkerType markerType = MsgToType(_msg);
       _markerPtr->SetType(markerType);
    +  _markerPtr->SetSize(5.0);
     
       // Set Marker Material
       if (_msg.has_material())
        ```
1. rebuild and launch ign-gazebo

    ```
    ign gazebo -v 4 -r
    ```

1. In another terminal, run the ign-gui `marker` demo to see large points drawn in ign-gazebo near the end of the demo before all markers are erased:

![marker_point_size](https://user-images.githubusercontent.com/4000684/132817217-381713a0-e88a-4ce7-ac92-e691832ad295.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

