### PR TITLE
Disable flaky tests on mac

### DIFF
--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -254,9 +254,10 @@ void DepthCameraTest::DepthCameraBoxes(
       unsigned int ma = *mrgba >> 0 & 0xFF;
       EXPECT_EQ(0u, mr);
       EXPECT_EQ(0u, mg);
-      // Note: If it fails here, it may be this problem again:
+#ifndef __APPLE__
       // https://github.com/ignitionrobotics/ign-rendering/issues/332
       EXPECT_GT(mb, 0u);
+#endif
 
       // Far left and right points should be red (background color)
       float lc = pointCloudData[pcLeft + 3];
@@ -455,10 +456,11 @@ void DepthCameraTest::DepthCameraBoxes(
           unsigned int a = *rgba >> 0 & 0xFF;
           EXPECT_EQ(0u, r);
           EXPECT_EQ(0u, g);
-          // Note: If it fails here, it may be this problem again:
+#ifndef __APPLE__
           // https://github.com/ignitionrobotics/ign-rendering/issues/332
           EXPECT_GT(b, 0u);
           EXPECT_EQ(255u, a);
+#endif
         }
       }
     }

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -236,7 +236,10 @@ void ThermalCameraTest::ThermalCameraBoxes(
       for (unsigned int j = 0; j < thermalCamera->ImageWidth(); ++j)
       {
         float temp = thermalData[step + j] * linearResolution;
+#ifndef __APPLE__
+        // https://github.com/ignitionrobotics/ign-rendering/issues/253
         EXPECT_NEAR(boxTemp, temp, boxTempRange);
+#endif
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Related to #369 and #253

## Summary

These tests have been failing from time to time on macOs. 

There was a [pull request]( https://github.com/ignitionrobotics/ign-rendering/pull/333) to address #369 but I think the test still fails on certain graphics card, e.g. Intel HD Graphics 4000 as described in #369

Disabling the tests until we have time to fix them.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

