### PR TITLE
Update test config to run ogre 1.x tests in ign-rendering6 on macOS

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
@@ -285,7 +285,7 @@ namespace ignition
       public: virtual void Destroy() override;
 
       // Documentation inherited.
-      public: virtual bool IsRenderWindow() const;
+      public: virtual bool IsRenderWindow() const override;
 
       // Documentation inherited.
       public: virtual Ogre::TextureGpu *RenderTarget() const override;

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -24,6 +24,7 @@
 #endif
 
 #ifdef __APPLE__
+  #define GL_SILENCE_DEPRECATION
   #include <OpenGL/gl.h>
 #else
 #ifndef _WIN32

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -24,6 +24,7 @@
 #endif
 
 #ifdef __APPLE__
+  #define GL_SILENCE_DEPRECATION
   #include <OpenGL/gl.h>
 #else
 #ifndef _WIN32

--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -9,7 +9,12 @@
 #define RENDER_ENGINE_VALUES ::testing::ValuesIn(\
     ignition::rendering::TestValues())
 
+/// \todo(anyone) re-enable ogre2 test once ogre 2.2 works on macOS
+#ifdef __APPLE__
+static const std::vector<const char *> kRenderEngineTestValues{"ogre", "optix"};
+#else
 static const std::vector<const char *> kRenderEngineTestValues{"ogre2", "optix"};
+#endif
 
 #include <vector>
 #include <ignition/common/Util.hh>


### PR DESCRIPTION
# 🦟 Bug fix

tests started failing after updating our ign-rendering6 homebrew formula to depend on ogre 2.2:
https://github.com/osrf/homebrew-simulation/pull/1574

There should be some GL3+ support for ogre 2.2 on macOS as seen in:
https://github.com/OGRECave/ogre-next/pull/209

But updated to run ogre 1.x tests until we have time to investigate the cause of failing tests on macOS.

I also fixed some clang warnings.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
