### PR TITLE
Avoid configure warning when checking ogre-1.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ list(APPEND ign_ogre_components "RTShaderSystem" "Terrain" "Overlay")
 # USE_UNOFFICAL_OGRE_VERSIONS flag
 if (NOT USE_UNOFFICAL_OGRE_VERSIONS)
   # Only for checking the ogre version
-  ign_find_package(IgnOGRE VERSION 1.10)
+  ign_find_package(IgnOGRE VERSION 1.10 QUIET)
 
   if (OGRE_FOUND)
     IGN_BUILD_WARNING("Ogre 1.x versions greater than 1.9 are not officially supported."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,13 +65,17 @@ list(APPEND ign_ogre_components "RTShaderSystem" "Terrain" "Overlay")
 # Display a warning for the users on this setup unless they provide
 # USE_UNOFFICAL_OGRE_VERSIONS flag
 if (NOT USE_UNOFFICAL_OGRE_VERSIONS)
-  ign_find_package(IgnOGRE VERSION 1.10
-    COMPONENTS ${ign_ogre_components})
+  # Only for checking the ogre version
+  ign_find_package(IgnOGRE VERSION 1.10)
 
   if (OGRE_FOUND)
     IGN_BUILD_WARNING("Ogre 1.x versions greater than 1.9 are not officially supported."
                       "The software might compile and even work but support from upstream"
                       "could be reduced to accepting patches for newer versions")
+    ign_find_package(IgnOGRE VERSION 1.10
+      COMPONENTS ${ign_ogre_components}
+      REQUIRED_BY ogre
+      PRIVATE_FOR ogre)
   else()
     # If ogre 1.10 or greater was not found, then proceed to look for 1.9.x
     # versions which are offically supported


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #400

## Summary

After #376, the check for Ogre-1.10 is generating warnings during the configuration of the software. The PR changes the behavior to do a fake check with `QUIET` to avoid warnings and a real check afterwards if the unofficial ogre version is used.

## Checklist
- [x] Signed all commits for DCO
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))

**Note to maintainers**: Remember to use **Squash-Merge**