### PR TITLE
Fix Ogre2 assertions during ray queries

### DIFF
--- a/include/ignition/rendering/RayQuery.hh
+++ b/include/ignition/rendering/RayQuery.hh
@@ -89,8 +89,23 @@ namespace ignition
                 const math::Vector2d &_coord) = 0;
 
       /// \brief Compute intersections
+      /// \param[in] _forceSceneUpdate Performance optimization hint
+      /// When true Ogre2 will update all derived transforms to their
+      /// latest to get correct results.
+      ///
+      /// When false, that step is skipped. It is only safe to
+      /// set it to false when nothing has changed since the last
+      /// update (i.e. nothing moved, no new objects created).
+      ///
+      /// Ogre will assert if built in Debug mode if this value
+      /// is set to false when it shouldn't be.
+      ///
+      /// See https://ogrecave.github.io/ogre-next/api/2.2/
+      /// _ogre20_changes.html#AssersionCachedOutOfDate
+      /// for more info
       /// \return A vector of intersection results
-      public: virtual RayQueryResult ClosestPoint() = 0;
+      public: virtual RayQueryResult ClosestPoint(
+            bool _forceSceneUpdate = true) = 0;
     };
     }
   }

--- a/include/ignition/rendering/base/BaseRayQuery.hh
+++ b/include/ignition/rendering/base/BaseRayQuery.hh
@@ -60,7 +60,8 @@ namespace ignition
                 const math::Vector2d &_coord) override;
 
       // Documentation inherited
-      public: virtual RayQueryResult ClosestPoint() override;
+      public: virtual RayQueryResult ClosestPoint(
+            bool _forceSceneUpdate = true) override;
 
       /// \brief Ray origin
       protected: math::Vector3d origin;
@@ -142,7 +143,7 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    RayQueryResult BaseRayQuery<T>::ClosestPoint()
+    RayQueryResult BaseRayQuery<T>::ClosestPoint(bool /*_forceSceneUpdate*/)
     {
       // TODO(anyone): implement a generic ray query here?
       RayQueryResult result;

--- a/include/ignition/rendering/base/BaseRayQuery.hh
+++ b/include/ignition/rendering/base/BaseRayQuery.hh
@@ -143,7 +143,8 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    RayQueryResult BaseRayQuery<T>::ClosestPoint(bool /*_forceSceneUpdate*/)
+    RayQueryResult BaseRayQuery<T>::ClosestPoint(
+        bool /*_forceSceneUpdate*/)  // NOLINT
     {
       // TODO(anyone): implement a generic ray query here?
       RayQueryResult result;

--- a/ogre/include/ignition/rendering/ogre/OgreRayQuery.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRayQuery.hh
@@ -50,7 +50,8 @@ namespace ignition
                 const math::Vector2d &_coord);
 
       // Documentation inherited
-      public: virtual RayQueryResult ClosestPoint();
+      public: virtual RayQueryResult ClosestPoint(
+            bool _forceSceneUpdate = true);
 
       /// \brief Get the mesh information for the given mesh.
       /// \param[in] _mesh Mesh to get info about.

--- a/ogre/src/OgreRayQuery.cc
+++ b/ogre/src/OgreRayQuery.cc
@@ -71,7 +71,7 @@ void OgreRayQuery::SetFromCamera(const CameraPtr &_camera,
 }
 
 //////////////////////////////////////////////////
-RayQueryResult OgreRayQuery::ClosestPoint(bool /*_forceSceneUpdate*/)
+RayQueryResult OgreRayQuery::ClosestPoint(bool /*_forceSceneUpdate*/) // NOLINT
 {
   RayQueryResult result;
   OgreScenePtr ogreScene = std::dynamic_pointer_cast<OgreScene>(this->Scene());

--- a/ogre/src/OgreRayQuery.cc
+++ b/ogre/src/OgreRayQuery.cc
@@ -71,7 +71,7 @@ void OgreRayQuery::SetFromCamera(const CameraPtr &_camera,
 }
 
 //////////////////////////////////////////////////
-RayQueryResult OgreRayQuery::ClosestPoint()
+RayQueryResult OgreRayQuery::ClosestPoint(bool /*_forceSceneUpdate*/)
 {
   RayQueryResult result;
   OgreScenePtr ogreScene = std::dynamic_pointer_cast<OgreScene>(this->Scene());

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RayQuery.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RayQuery.hh
@@ -49,7 +49,8 @@ namespace ignition
                 const math::Vector2d &_coord);
 
       // Documentation inherited
-      public: virtual RayQueryResult ClosestPoint();
+      public: virtual RayQueryResult ClosestPoint(
+            bool _forceSceneUpdate = true);
 
       /// \brief Get closest point by selection buffer.
       /// This is executed on the GPU.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RayQuery.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RayQuery.hh
@@ -58,7 +58,8 @@ namespace ignition
 
       /// \brief Get closest point by ray triangle intersection test.
       /// This is executed on the CPU.
-      private: RayQueryResult ClosestPointByIntersection();
+      private: RayQueryResult ClosestPointByIntersection(
+            bool _forceSceneUpdate);
 
       /// \brief Private data pointer
       private: std::unique_ptr<Ogre2RayQueryPrivate> dataPtr;

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -117,7 +117,7 @@ RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
   return this->ClosestPointByIntersection();
 
 #ifdef __APPLE__
-  return this->ClosestPointByIntersection();
+  return this->ClosestPointByIntersection(_forceSceneUpdate);
 #else
   if (!this->dataPtr->camera ||
       !this->dataPtr->camera->Parent() ||
@@ -126,7 +126,7 @@ RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
     // use legacy method for backward compatibility if no camera is set or
     // camera is not attached in the scene tree or
     // this function is called from non-rendering thread
-    return this->ClosestPointByIntersection();
+    return this->ClosestPointByIntersection(_forceSceneUpdate);
   }
   else
   {
@@ -172,7 +172,7 @@ RayQueryResult Ogre2RayQuery::ClosestPointBySelectionBuffer()
 }
 
 //////////////////////////////////////////////////
-RayQueryResult Ogre2RayQuery::ClosestPointByIntersection()
+RayQueryResult Ogre2RayQuery::ClosestPointByIntersection(bool _forceSceneUpdate)
 {
   RayQueryResult result;
   Ogre2ScenePtr ogreScene =

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -107,7 +107,7 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
 }
 
 //////////////////////////////////////////////////
-RayQueryResult Ogre2RayQuery::ClosestPoint()
+RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
 {
   RayQueryResult result;
 
@@ -179,6 +179,11 @@ RayQueryResult Ogre2RayQuery::ClosestPointByIntersection()
       std::dynamic_pointer_cast<Ogre2Scene>(this->Scene());
   if (!ogreScene)
     return result;
+
+  if (_forceSceneUpdate)
+  {
+    ogreScene->OgreSceneManager()->updateSceneGraph();
+  }
 
   Ogre::Ray mouseRay(Ogre2Conversions::Convert(this->origin),
       Ogre2Conversions::Convert(this->direction));

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -114,7 +114,7 @@ RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
   // ray query using selection buffer does not seem to work on some machines
   // using cpu based ray-triangle intersection method
   // \todo remove this line if selection buffer is working again
-  return this->ClosestPointByIntersection();
+  return this->ClosestPointByIntersection(_forceSceneUpdate);
 
 #ifdef __APPLE__
   return this->ClosestPointByIntersection(_forceSceneUpdate);


### PR DESCRIPTION
## Summary

This bug had been annoying me for months for which I silenced those asserts.

But given that I need to implement `SCENE_STATIC` to get global illumination going, it is dangerous to ignore those asserts so I had to fix this.

ign-rendering would assert (inside a debug build of Ogre2) every time the mouse hovers the GUI.

This PR changes both API and ABI. Technically speaking what ign-rendering was doing was wrong but it didn't seem to matter too much (if at all); which is why I don't care to break API/ABI without backporting.

If this fix makes it into Fortress then great, otherwise it's not a big deal. Ideally ogre2 fork should include [this fix](https://github.com/OGRECave/ogre-next/commit/e7f3d114102e125ab599346aa3dd4b722a9fac07) we added to 2.3 and that I just backported to 2.2; but again no rush.

## codecheck

Complains:

> /home/matias/Projects/ign/src/ign-rendering/include/ignition/rendering/base/BaseRayQuery.hh:146: Using C-style cast.  Use static_cast<bool>(...) instead  [readability/casting] [4]

It seems it doesn't like the argument getting commented out:

```cpp
RayQueryResult BaseRayQuery<T>::ClosestPoint(bool /*_forceSceneUpdate*/) {} // complains
RayQueryResult BaseRayQuery<T>::ClosestPoint(bool _forceSceneUpdate) {} // does not complain
```

However doing so will cause `unused argument` warning during build.
It may be possible to silence both using an UNUSED() macro if it doesn't exist already:

```cpp
#define IGN_UNUSED(x) do { (void)sizeof(x); } while(0)

RayQueryResult BaseRayQuery<T>::ClosestPoint(bool _forceSceneUpdate)
{
  IGN_UNUSED(_forceSceneUpdate);
}

// Alternatively C++17
RayQueryResult BaseRayQuery<T>::ClosestPoint([[maybe_unused]] bool _forceSceneUpdate) {}

// Attributes on GCC/Clang
RayQueryResult BaseRayQuery<T>::ClosestPoint(__attribute__((unused)) bool _forceSceneUpdate) {}

// It may be best to use a macro to abstract these changes:
RayQueryResult BaseRayQuery<T>::ClosestPoint(IGN_UNUSED_ARG bool _forceSceneUpdate) {}
```

## Commit msg

This change negatively affects performance as we now force a scene
update with each query.

Users can specify ClosestPoint(false) if they need to call this function
multiple times without modifying anything or if they know the scene is
up to date

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
