### PR TITLE
Be consistent in RGB channel notation for ogre2 segmentation camera

### DIFF
--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -368,9 +368,9 @@ void Ogre2SegmentationCamera::LabelMapFromColoredBuffer(
     for (uint32_t j = 0; j < width; ++j)
     {
       auto index = (i * width + j) * 3;
-      auto r = this->dataPtr->buffer[index + 2];
+      auto r = this->dataPtr->buffer[index];
       auto g = this->dataPtr->buffer[index + 1];
-      auto b = this->dataPtr->buffer[index];
+      auto b = this->dataPtr->buffer[index + 2];
 
       // get color 24 bit unique id, we don't multiply it by 255 like before
       // as they are not normalized we read it from the buffer in


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
When we updated the segmentation sensor (#329) to ogre2.2, it looks like inconsistencies were introduced in what pixel channels were considered RGB.

In `Ogre2SegmentationCamera::LabelMapFromColoredBuffer`, the notation is GBR: https://github.com/ignitionrobotics/ign-rendering/blob/7aade51f83171f2ada47089e6f8594fc3ccdddc5/ogre2/src/Ogre2SegmentationCamera.cc#L371-L373

But, in the material switcher, RGB is used:
https://github.com/ignitionrobotics/ign-rendering/blob/7aade51f83171f2ada47089e6f8594fc3ccdddc5/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc#L233-L234
https://github.com/ignitionrobotics/ign-rendering/blob/7aade51f83171f2ada47089e6f8594fc3ccdddc5/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc#L280-L281

This PR updates the indexing in `Ogre2SegmentationCamera::LabelMapFromColoredBuffer` to RGB instead of GBR.

Making this update fixes the label map data produced in https://github.com/ignitionrobotics/ign-sensors/pull/133. Before, the segmentation labels map was an image with all pixels set to the background label. Now, labels appear correctly:

![fixed_label_map](https://user-images.githubusercontent.com/42042756/134259432-0a6704f8-816e-4d19-9b76-de713f9147ff.png)


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**