### PR TITLE
Find IgnOGRE once, then warn if version is too new

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ ign_find_package(IgnOGRE VERSION 1.9.0
 # Display a warning for the users on this setup unless they provide
 # USE_UNOFFICAL_OGRE_VERSIONS flag
 if (NOT USE_UNOFFICAL_OGRE_VERSIONS)
-  if (OGRE_FOUND AND OGRE_VERSION VERSION_GREATER "1.9.0")
+  if (OGRE_FOUND AND OGRE_VERSION VERSION_GREATER_EQUAL "1.10")
     IGN_BUILD_WARNING("Ogre 1.x versions greater than 1.9 are not officially supported."
                       "The software might compile and even work but support from upstream"
                       "could be reduced to accepting patches for newer versions")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,24 +63,19 @@ endif()
 # Find OGRE
 list(APPEND ign_ogre_components "RTShaderSystem" "Terrain" "Overlay")
 
+ign_find_package(IgnOGRE VERSION 1.9.0
+  COMPONENTS ${ign_ogre_components}
+  REQUIRED_BY ogre
+  PRIVATE_FOR ogre)
+
 # Ogre versions greater than 1.9 are not officialy supported.
 # Display a warning for the users on this setup unless they provide
 # USE_UNOFFICAL_OGRE_VERSIONS flag
 if (NOT USE_UNOFFICAL_OGRE_VERSIONS)
-  ign_find_package(IgnOGRE VERSION 1.10
-    COMPONENTS ${ign_ogre_components})
-
-  if (OGRE_FOUND)
+  if (OGRE_FOUND AND OGRE_VERSION VERSION_GREATER "1.9.0")
     IGN_BUILD_WARNING("Ogre 1.x versions greater than 1.9 are not officially supported."
                       "The software might compile and even work but support from upstream"
                       "could be reduced to accepting patches for newer versions")
-  else()
-    # If ogre 1.10 or greater was not found, then proceed to look for 1.9.x
-    # versions which are offically supported
-    ign_find_package(IgnOGRE VERSION 1.9.0
-      COMPONENTS ${ign_ogre_components}
-      REQUIRED_BY ogre
-      PRIVATE_FOR ogre)
   endif()
 endif()
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #400

## Summary

**Note: I have not tested this locally.**

This is an idea to fix #400. I would expect it to get rid of the CMake warning about missing Ogre when the installed version is `1.9.0`. It doesn't look like Ignition CMake ore Ignition Rendering pass the `EXACT` argument to the real `find_package()` call for either [`IgnOGRE`](https://github.com/ignitionrobotics/ign-cmake/blob/6c4e7daa24d287b3151da80e13973889e8ec0aee/cmake/IgnUtils.cmake#L153-L154) or [`OGRE`](https://github.com/ignitionrobotics/ign-cmake/blob/6c4e7daa24d287b3151da80e13973889e8ec0aee/cmake/FindIgnOGRE.cmake#L172-L173). Because of that, the compatibility is up to `OGRE`, [and it uses `SameMajorVersion` compatibility](https://github.com/OGRECave/ogre/blob/8b7088dee4345d7c07558ffca8c98b8c46f31599/CMake/InstallResources.cmake#L257-L260). That means `ign_find_package(IgnOGRE VERSION 1.9.0 ...)` should find OGRE `1.x` where `x >= 9`. This PR checks `OGRE_VERSION` after finding `IgnOGRE`, and only then warns if it is newer than the supported version.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
