### PR TITLE
Fix point cloud material syntax error

### DIFF
--- a/ogre2/src/media/materials/scripts/point_cloud_point.material
+++ b/ogre2/src/media/materials/scripts/point_cloud_point.material
@@ -31,7 +31,7 @@ fragment_program PointCloudFS glsl
   source point_fs.glsl
   default_params
   {
-    param_named color vec4 1.0 1.0 1.0 1.0
+    param_named color float4 1.0 1.0 1.0 1.0
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix


## Summary

Without this fix, you would see an entry in `~/.ignition/rendering/ogre2.log`:

```
Compiler error: invalid parameters in point_cloud_point.material(34): incorrect type specified; only variants of int, uint, float, double, and bool allowed
```

Point cloud visualization still worked though. It could be just that the initial values are not set correctly.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

