### PR TITLE
Visual cloning: check for null children and recursively delete cloned visuals if failure occurs

### DIFF
--- a/include/ignition/rendering/base/BaseVisual.hh
+++ b/include/ignition/rendering/base/BaseVisual.hh
@@ -528,8 +528,14 @@ namespace ignition
       {
         NodePtr child = it->second;
         VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
-        if (nullptr != visual)
-          visual->Clone("", result);
+        // recursively delete all cloned visuals if the child cannot be
+        // retrieved, or if cloning the child visual failed
+        if (!visual || !visual->Clone("", result))
+        {
+          ignerr << "Cloning a child visual failed.\n";
+          scene_->DestroyVisual(result, true);
+          return nullptr;
+        }
       }
 
       for (unsigned int i = 0; i < this->GeometryCount(); ++i)


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

# 🦟 Bug fix

## Summary
Follow-up to #397 

If cloning a visual fails, we should destroy the top-level cloned visual recursively in order to ensure that all cloned child visuals are also destroyed. I also added a check to make sure that the child visual to clone isn't `nullptr`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**