### PR TITLE
Fix occasional flickering issue when skybox and directional light shadows are enabled.

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -153,6 +153,9 @@ class ignition::rendering::Ogre2DepthCameraPrivate
 
   /// \brief Name of sky box material
   public: const std::string kSkyboxMaterialName = "SkyBox";
+
+  /// \brief Name of shadow compositor node
+  public: const std::string kShadowNodeName = "PbsMaterialsShadowNode";
 };
 
 using namespace ignition;
@@ -696,6 +699,25 @@ void Ogre2DepthCamera::CreateDepthTexture()
     else
       colorTargetDef->setNumPasses(1);
     {
+      // scene pass - opaque
+      {
+        Ogre::CompositorPassSceneDef *passScene =
+            static_cast<Ogre::CompositorPassSceneDef *>(
+            colorTargetDef->addPass(Ogre::PASS_SCENE));
+        passScene->mShadowNode = this->dataPtr->kShadowNodeName;
+        passScene->mVisibilityMask = IGN_VISIBILITY_ALL;
+        passScene->mIncludeOverlays = false;
+        passScene->mFirstRQ = 0u;
+        passScene->mLastRQ = 2u;
+        if (!validBackground)
+        {
+          passScene->setAllLoadActions(Ogre::LoadAction::Clear);
+          passScene->setAllClearColours(Ogre::ColourValue(
+              Ogre2Conversions::Convert(this->Scene()->BackgroundColor())));
+        }
+      }
+
+      // render background, e.g. sky, after opaque stuff
       if (validBackground)
       {
         // quad pass
@@ -712,21 +734,16 @@ void Ogre2DepthCamera::CreateDepthTexture()
             Ogre2Conversions::Convert(this->Scene()->BackgroundColor())));
       }
 
-      // scene pass
-      Ogre::CompositorPassSceneDef *passScene =
-          static_cast<Ogre::CompositorPassSceneDef *>(
-          colorTargetDef->addPass(Ogre::PASS_SCENE));
-      passScene->mVisibilityMask = IGN_VISIBILITY_ALL;
-
-      // todo(anyone) PbsMaterialsShadowNode is hardcoded.
-      // Although this may be just fine
-      passScene->mShadowNode = "PbsMaterialsShadowNode";
-
-      if (!validBackground)
+      // scene pass - transparent stuff
       {
-        passScene->setAllLoadActions(Ogre::LoadAction::Clear);
-        passScene->setAllClearColours(Ogre::ColourValue(
-            Ogre2Conversions::Convert(this->Scene()->BackgroundColor())));
+        Ogre::CompositorPassSceneDef *passScene =
+            static_cast<Ogre::CompositorPassSceneDef *>(
+            colorTargetDef->addPass(Ogre::PASS_SCENE));
+        passScene->mVisibilityMask = IGN_VISIBILITY_ALL;
+        // todo(anyone) PbsMaterialsShadowNode is hardcoded.
+        // Although this may be just fine
+        passScene->mShadowNode = this->dataPtr->kShadowNodeName;
+        passScene->mFirstRQ = 2u;
       }
     }
 

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -189,6 +189,23 @@ void Ogre2RenderTarget::BuildCompositor()
     else
       rt0TargetDef->setNumPasses(1);
     {
+      // scene pass - opaque
+      {
+        Ogre::CompositorPassSceneDef *passScene =
+            static_cast<Ogre::CompositorPassSceneDef *>(
+            rt0TargetDef->addPass(Ogre::PASS_SCENE));
+        passScene->mShadowNode = this->dataPtr->kShadowNodeName;
+        passScene->mIncludeOverlays = false;
+        passScene->mFirstRQ = 0u;
+        passScene->mLastRQ = 2u;
+        if (!validBackground)
+        {
+          passScene->setAllLoadActions(Ogre::LoadAction::Clear);
+          passScene->setAllClearColours(this->ogreBackgroundColor);
+        }
+      }
+
+      // render background, e.g. sky, after opaque stuff
       if (validBackground)
       {
         // quad pass
@@ -204,17 +221,13 @@ void Ogre2RenderTarget::BuildCompositor()
         passQuad->setAllClearColours(this->ogreBackgroundColor);
       }
 
-      // scene pass
-      Ogre::CompositorPassSceneDef *passScene =
-          static_cast<Ogre::CompositorPassSceneDef *>(
-          rt0TargetDef->addPass(Ogre::PASS_SCENE));
-      passScene->mShadowNode = this->dataPtr->kShadowNodeName;
-      passScene->mIncludeOverlays = true;
-
-      if (!validBackground)
+      // scene pass - transparent stuff
       {
-        passScene->setAllLoadActions(Ogre::LoadAction::Clear);
-        passScene->setAllClearColours(this->ogreBackgroundColor);
+        Ogre::CompositorPassSceneDef *passScene =
+            static_cast<Ogre::CompositorPassSceneDef *>(
+            rt0TargetDef->addPass(Ogre::PASS_SCENE));
+        passScene->mIncludeOverlays = true;
+        passScene->mFirstRQ = 2u;
       }
     }
 

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -227,6 +227,7 @@ void Ogre2RenderTarget::BuildCompositor()
             static_cast<Ogre::CompositorPassSceneDef *>(
             rt0TargetDef->addPass(Ogre::PASS_SCENE));
         passScene->mIncludeOverlays = true;
+        passScene->mShadowNode = this->dataPtr->kShadowNodeName;
         passScene->mFirstRQ = 2u;
       }
     }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

When both skybox and shadows are enabled in a complex scene (with lots of textures), there seem to be a weird "flickering" issue of objects. Turns out the problem is due to the skybox being rendered out of order. The skybox texture just gets rendered over the scene - so objects look like they are flickering.

Note this doesn't happen all the time. It's easier to reproduce on some machines than others.

The updated compositor setup follows the same setup in ogre samples:
https://github.com/OGRECave/ogre-next/blob/v2-2/Samples/Media/2.0/scripts/Compositors/TutorialSky_Postprocess.compositor#L8-L32

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
