### PR TITLE
Hide heightmap visibility for segmentation camera

### DIFF
--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -127,6 +127,10 @@ class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationMaterialSwitcher :
   /// access to things like the segmentation type, background color, background
   /// label, and if colored map is enabled
   private: SegmentationCamera *segmentationCamera {nullptr};
+
+  /// \brief Map of all heightmap visuals to their original visibility flags.
+  /// The key is the ID of the visual
+  private: std::unordered_map<unsigned int, uint32_t> heightmapVisFlags;
 };
 }
 }  // namespace rendering


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The segmentation camera appears to show parts of heightmaps, even if they don't have a label. This shouldn't happen. I'm trying to make a temporary patch for this by disabling the heightmap visibility during material switching.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**