### PR TITLE
Don't clone visuals with an ignore flag

### DIFF
--- a/include/ignition/rendering/Visual.hh
+++ b/include/ignition/rendering/Visual.hh
@@ -149,6 +149,10 @@ namespace ignition
       /// \param[in] _newParent Parent of the cloned Visual. Set to nullptr if
       /// the cloned visual should have no parent.
       /// \return The visual. nullptr is returned if cloning failed.
+      /// \note If the visual to be cloned has boolean UserData with a key
+      /// "skip-visual-clone", nullptr is returned. If the visual to be cloned
+      /// does not have this UserData, but a child visual does, then the child
+      /// visuals with this UserData will not be cloned.
       public: virtual VisualPtr Clone(const std::string &_name,
                   NodePtr _newParent) const = 0;
     };


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

## Summary
While working on https://github.com/ignitionrobotics/ign-gazebo/pull/1013, I noticed that there are times where certain visuals shouldn't be cloned. I've added support for setting a boolean `UserData` flag with a key of `skip-visual-clone` on a visual. If a visual has `UserData` with this key, it will not be cloned.

For an example of how this is useful, see the second half of https://github.com/ignitionrobotics/ign-gazebo/pull/1013#issuecomment-919564106.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**