### PR TITLE
Disable using selection buffer for ray queries

### DIFF
--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -95,6 +95,11 @@ RayQueryResult Ogre2RayQuery::ClosestPoint()
 {
   RayQueryResult result;
 
+  // ray query using selection buffer does not seem to work on some machines
+  // using cpu based ray-triangle intersection method
+  // \todo remove this line if selection buffer is working again
+  return this->ClosestPointByIntersection();
+
 #ifdef __APPLE__
   return this->ClosestPointByIntersection();
 #else


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Switch back to using the cpu based ray-triangle intersection method for doing ray queries as the selection buffer mehtod does not seem to work on all machines.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

