### PR TITLE
Fix heightmap crash if only shadow casting spotlights are one scene

### DIFF
--- a/ogre2/src/media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
+++ b/ogre2/src/media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
@@ -34,7 +34,7 @@
     outVs.terrainShadow = mix( terraShadowData.x, 1.0, clamp( terraHeightWeight, 0.0, 1.0 ) );
 @end
 
-@property( hlms_num_shadow_map_lights )
+@property( hlms_lights_directional )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @else
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end

--- a/ogre2/src/media/Hlms/Terra/GLSLES/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
+++ b/ogre2/src/media/Hlms/Terra/GLSLES/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
@@ -28,7 +28,7 @@
     outVs.terrainShadow = mix( terraShadowData.x, 1.0, clamp( terraHeightWeight, 0.0, 1.0 ) );
 @end
 
-@property( hlms_num_shadow_map_lights )
+@property( hlms_lights_directional )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @end @property( !hlms_num_shadow_map_lights )
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end

--- a/ogre2/src/media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
+++ b/ogre2/src/media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
@@ -36,7 +36,7 @@
     outVs.terrainShadow = lerp( terraShadowData.x, 1.0, saturate( terraHeightWeight ) );
 @end
 
-@property( hlms_num_shadow_map_lights )
+@property( hlms_lights_directional )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @else
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end

--- a/ogre2/src/media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
+++ b/ogre2/src/media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
@@ -36,7 +36,7 @@
     outVs.terrainShadow = lerp( terraShadowData.x, 1.0, saturate( terraHeightWeight ) );
 @end
 
-@property( hlms_num_shadow_map_lights )
+@property( hlms_lights_directional )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @else
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #439

## Summary

Not much to say. This is a [fix from upstream](https://github.com/OGRECave/ogre-next/commit/b18f7a37da2ad24765fdcc12f52a94e08ac35e8d).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
