### PR TITLE
ogre: Add missing required Paging component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 
 #--------------------------------------
 # Find OGRE
-list(APPEND ign_ogre_components "RTShaderSystem" "Terrain" "Overlay")
+list(APPEND ign_ogre_components "RTShaderSystem" "Terrain" "Overlay" "Paging")
 
 # Ogre versions greater than 1.9 are not officialy supported.
 # Display a warning for the users on this setup unless they provide


### PR DESCRIPTION
# 🦟 Bug fix

Add the missing dependency on `Paging` Ogre component for the `ogre` renderer. See https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering5/ogre/include/ignition/rendering/ogre/OgreIncludes.hh#L66 for a Paging-related include that is required. 

## Summary

I noticed this missing component while working on https://github.com/conda-forge/libignition-rendering4-feedstock/pull/19#issuecomment-933532319 . Not sure if that failure was just related to this fix, but given that this fix seems to be correct in any case, I tought it could make sense to submit it.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers


