### PR TITLE
Add a method to render targets and cameras to retrieve a Metal texture

### DIFF
--- a/include/ignition/rendering/Camera.hh
+++ b/include/ignition/rendering/Camera.hh
@@ -317,6 +317,14 @@ namespace ignition
       /// \return Texture Id of type GLuint.
       public: virtual unsigned int RenderTextureGLId() const = 0;
 
+      /// \brief Get the Metal texture id associated with the render texture
+      /// used by this camera. A valid Id is obtained only if the underlying
+      /// render engine is Metal based.
+      /// The pointer set by this function must be released to an
+      /// id<MTLTexture> using CFBridgingRelease.
+      /// \param[out] _textureIdPtr the address of a void* pointer.
+      public: virtual void RenderTextureMetalId(void *_textureIdPtr) const = 0;
+
       /// \brief Add a render pass to the camera
       /// \param[in] _pass New render pass to add
       public: virtual void AddRenderPass(const RenderPassPtr &_pass) = 0;

--- a/include/ignition/rendering/RenderTarget.hh
+++ b/include/ignition/rendering/RenderTarget.hh
@@ -109,6 +109,13 @@ namespace ignition
       /// \brief Returns the OpenGL texture Id. A valid Id is returned only
       // if this is an OpenGL render texture
       public: virtual unsigned int GLId() const = 0;
+
+      /// \brief Gets the Metal texture id. A valid Id is obtained only
+      /// if this is an Metal render texture.
+      /// The pointer set by this function must be released to an
+      /// id<MTLTexture> using CFBridgingRelease.
+      /// \param[out] _textureIdPtr the address of a void* pointer.
+      public: virtual void MetalId(void *_textureIdPtr) const = 0;
     };
 
     /* \class RenderWindow RenderWindow.hh \

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -810,7 +810,7 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseCamera<T>::RenderTextureMetalId(void *_textureIdPtr) const
+    void BaseCamera<T>::RenderTextureMetalId(void */*_textureIdPtr*/) const
     {
       ignerr << "RenderTextureMetalId is not supported by current render"
           << " engine" << std::endl;

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -180,7 +180,7 @@ namespace ignition
       public: virtual unsigned int RenderTextureGLId() const override;
 
       // Documentation inherited.
-      public: virtual void RenderTextureMetalId(void *_texturePtrId)
+      public: virtual void RenderTextureMetalId(void *_textureIdPtr)
           const override;
 
       // Documentation inherited.

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -180,6 +180,10 @@ namespace ignition
       public: virtual unsigned int RenderTextureGLId() const override;
 
       // Documentation inherited.
+      public: virtual void RenderTextureMetalId(void *_texturePtrId)
+          const override;
+
+      // Documentation inherited.
       public: virtual void AddRenderPass(const RenderPassPtr &_pass) override;
 
       // Documentation inherited.
@@ -802,6 +806,14 @@ namespace ignition
       ignerr << "RenderTextureGLId is not supported by current render"
           << " engine" << std::endl;
       return 0u;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseCamera<T>::RenderTextureMetalId(void *_textureIdPtr) const
+    {
+      ignerr << "RenderTextureMetalId is not supported by current render"
+          << " engine" << std::endl;
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseRenderTarget.hh
+++ b/include/ignition/rendering/base/BaseRenderTarget.hh
@@ -105,6 +105,9 @@ namespace ignition
 
       // Documentation inherited.
       public: virtual unsigned int GLId() const override;
+
+      // Documentation inherited.
+      public: virtual void MetalId(void *_texturePtrId) const override;
     };
 
     template <class T>
@@ -289,6 +292,12 @@ namespace ignition
     unsigned int BaseRenderTexture<T>::GLId() const
     {
       return 0u;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseRenderTexture<T>::MetalId(void *_textureIdPtr) const
+    {
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseRenderTarget.hh
+++ b/include/ignition/rendering/base/BaseRenderTarget.hh
@@ -296,7 +296,7 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseRenderTexture<T>::MetalId(void *_textureIdPtr) const
+    void BaseRenderTexture<T>::MetalId(void */*_textureIdPtr*/) const
     {
     }
 

--- a/include/ignition/rendering/base/BaseRenderTarget.hh
+++ b/include/ignition/rendering/base/BaseRenderTarget.hh
@@ -107,7 +107,7 @@ namespace ignition
       public: virtual unsigned int GLId() const override;
 
       // Documentation inherited.
-      public: virtual void MetalId(void *_texturePtrId) const override;
+      public: virtual void MetalId(void *_textureIdPtr) const override;
     };
 
     template <class T>

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
@@ -115,6 +115,10 @@ namespace ignition
       public: virtual unsigned int RenderTextureGLId() const override;
 
       // Documentation inherited.
+      public: virtual void RenderTextureMetalId(void *_textureIdPtr)
+          const override;
+
+      // Documentation inherited.
       public: void SetShadowsDirty() override;
 
       // Documentation inherited.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTarget.hh
@@ -136,6 +136,9 @@ namespace ignition
       // Documentation inherited
       public: unsigned int GLIdImpl() const;
 
+      // Documentation inherited
+      public: void MetalIdImpl(void *_textureIdPtr) const;
+
       /// \brief Destroy the render texture
       protected: void DestroyTargetImpl();
 
@@ -252,6 +255,9 @@ namespace ignition
 
       // Documentation inherited
       public: virtual unsigned int GLId() const override;
+
+      // Documentation inherited
+      public: virtual void MetalId(void *_textureIdPtr) const override;
 
       // Documentation inherited
       // TODO(anyone): this function should be removed.

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -208,6 +208,21 @@ unsigned int Ogre2Camera::RenderTextureGLId() const
 }
 
 //////////////////////////////////////////////////
+void Ogre2Camera::RenderTextureMetalId(void *_textureIdPtr) const
+{
+  if (!this->renderTexture)
+    return;
+
+  Ogre2RenderTexturePtr rt =
+      std::dynamic_pointer_cast<Ogre2RenderTexture>(this->renderTexture);
+
+  if (!rt)
+    return;
+
+  rt->MetalId(_textureIdPtr);
+}
+
+//////////////////////////////////////////////////
 void Ogre2Camera::SetShadowsDirty()
 {
   this->SetShadowsNodeDefDirty();

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -548,6 +548,16 @@ unsigned int Ogre2RenderTarget::GLIdImpl() const
 }
 
 //////////////////////////////////////////////////
+void Ogre2RenderTarget::MetalIdImpl(void *_textureIdPtr) const
+{
+  if (!this->dataPtr->ogreTexture[0])
+    return;
+
+  this->dataPtr->ogreTexture[1]->
+      getCustomAttribute("msFinalTextureBuffer", _textureIdPtr);
+}
+
+//////////////////////////////////////////////////
 uint8_t Ogre2RenderTarget::TargetFSAA() const
 {
   // check if target fsaa is supported
@@ -881,6 +891,12 @@ void Ogre2RenderTexture::BuildTarget()
 unsigned int Ogre2RenderTexture::GLId() const
 {
   return Ogre2RenderTarget::GLIdImpl();
+}
+
+//////////////////////////////////////////////////
+void Ogre2RenderTexture::MetalId(void *_textureIdPtr) const
+{
+  Ogre2RenderTarget::MetalIdImpl(_textureIdPtr);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Replaces #477 which targeted the wrong branch.

Relates to: https://github.com/ignitionrobotics/ign-rendering/issues/461 and discussions in https://github.com/ignitionrobotics/ign-rendering/issues/422. It accompanies PR https://github.com/ignitionrobotics/ign-rendering/pull/463 but does not depend upon it.

## Summary

This PR provides access to the underlying Metal texture object. The functions `MetalId()` and `RenderTextureMetalId()`
provide the Metal equivalent of `GLId()` and `RenderTextureGLId()` for OpenGL.

The functions expect a parameter `void* _texturePtr` which is the *address* of a pointer to `void*` as the object required for Metal is an Objective-C type `id<MTLTexture>` which we do not want exposed in the interface (the type is the id for an object
that implements the `MTLTexture` protocol).

Note: the functions do not add a dependency on Objective-C to the ignition rendering libraries, but they are intended to be used in Objective-C code as follows:

```c++
void *textureIdPtr = nullptr;
texture->RenderTextureMetalId(&textureIdPtr);
id<MTLTexture> metalTexture = CFBridgingRelease(textureIdPtr);
```

The translation unit containing the code should be compiled with ARC enabled and will need to link against the `AppKit` and `Metal` frameworks. When using `cmake` this is accomplished by  `CMakeLists.txt` entries such as:

```cmake
target_link_libraries(simple_demo_qml_metal PUBLIC
    ${IGNITION-RENDERING_LIBRARIES}
    ${OGRE2_LIBRARIES}
    ${OPENGL_LIBRARIES}
    Qt5::Core
    Qt5::Gui
    Qt5::Qml
    Qt5::Quick
    "-framework AppKit"
    "-framework Metal"
)

# Enable ARC on selected source files
set_source_files_properties(
    IgnitionRenderer.mm
    RenderThread.mm
    ThreadRenderer.mm
    PROPERTIES
    COMPILE_FLAGS
        "-fobjc-arc"
)
```

There is a runtime dependency on an upstream change to ogre-next: https://github.com/OGRECave/ogre-next/pull/237/commits/3b1187398f3410b0ec82d3fbd8ce564ace4d02f7. Note that this PR does not require the upstream change to build as the Ogre interface used, `getCustomAttribute`, is available on the base class `Ogre::TextureGpu` and is used by the OpenGL functions.

## Test it

These changes have no impact on existing functionality using the OpenGL render system.

To test these functions requires a version of ogre-next v2-2 that includes the change https://github.com/OGRECave/ogre-next/pull/237/commits/3b1187398f3410b0ec82d3fbd8ce564ace4d02f7.

There is work in progress to enable the use of Metal for the example `simple_demo_qml` and for `ign-gui` and `ign-gazebo`. They depend upon this PR and provide a means to test the changes:

https://github.com/srmainwaring/ign-rendering/tree/feature/ign-rendering6-metal-simple_demo_qml
https://github.com/srmainwaring/ign-gui/tree/feature/ign-gui7-metal
https://github.com/srmainwaring/ign-gazebo/tree/feature/ign-gazebo7-metal

For more detail see comment: https://github.com/ignitionrobotics/ign-rendering/pull/463#issuecomment-948030990

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage)) *
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

* Some tests fail on macOS:

```
89% tests passed, 11 tests failed out of 102

Total Test time (real) =  34.16 sec

The following tests FAILED:
	 19 - UNIT_Heightmap_TEST (SEGFAULT)
	 59 - UNIT_RenderingIface_TEST (SEGFAULT)
	 75 - UNIT_Utils_TEST (Failed)
	 83 - INTEGRATION_depth_camera (SEGFAULT)
	 85 - INTEGRATION_camera (Failed)
	 87 - INTEGRATION_render_pass (SEGFAULT)
	 89 - INTEGRATION_shadows (Failed)
	 91 - INTEGRATION_scene (Failed)
	 93 - INTEGRATION_segmentation_camera (Failed)
	 95 - INTEGRATION_sky (Failed)
	 97 - INTEGRATION_thermal_camera (Failed)
```

The SEGFAULTS occur on the tear down of tests using `ogre` (when deleting Ogre::Root) and the failed tests are because macOS does not have OpenGL support for `ogre2`. 

**Note to maintainers**: Remember to use **Squash-Merge**