### PR TITLE
Fix Utils unit test

### DIFF
--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -259,11 +259,7 @@ VisualPtr Ogre2Camera::VisualAt(const ignition::math::Vector2i &_mousePos)
       this->ImageWidth(), this->ImageHeight());
   }
 
-#ifdef __APPLE__
-  float ratio = 1.0f;
-#else
   float ratio = screenScalingFactor();
-#endif
 
   ignition::math::Vector2i mousePos(
       static_cast<int>(std::rint(ratio * _mousePos.X())),

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -260,7 +260,6 @@ VisualPtr Ogre2Camera::VisualAt(const ignition::math::Vector2i &_mousePos)
   }
 
   float ratio = screenScalingFactor();
-
   ignition::math::Vector2i mousePos(
       static_cast<int>(std::rint(ratio * _mousePos.X())),
       static_cast<int>(std::rint(ratio * _mousePos.Y())));

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -259,7 +259,12 @@ VisualPtr Ogre2Camera::VisualAt(const ignition::math::Vector2i &_mousePos)
       this->ImageWidth(), this->ImageHeight());
   }
 
+#ifdef __APPLE__
+  float ratio = 1.0f;
+#else
   float ratio = screenScalingFactor();
+#endif
+
   ignition::math::Vector2i mousePos(
       static_cast<int>(std::rint(ratio * _mousePos.X())),
       static_cast<int>(std::rint(ratio * _mousePos.Y())));

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -130,15 +130,6 @@ void UtilTest::ClickToScene(const std::string &_renderEngine)
     return;
   }
 
-  // \todo(anyone)
-  // the centerClick var above is set to a screen pos of (width/2, height/2).
-  // This is off-by-1. The actual center pos should be at
-  // (width/2 - 1, height/2 - 1) so the result.X() and result.Y() is a bit off
-  // from the expected position. However, fixing the centerClick above caused
-  // the screenToPlane tests to fail so only modifying the pos here, and the
-  // cause of test failure need to be investigated.
-  centerClick = ignition::math::Vector2i(halfWidth-1, halfHeight-1);
-
   // API without RayQueryResult and default max distance
   result = screenToScene(centerClick, camera, rayQuery, rayResult);
 


### PR DESCRIPTION
# 🦟 Bug fix

Updates the click center pos used in the test. This should fix `ogre` test on macOs. This patch is part of #446.

There is a check added to skip `ogre2` tests because they are failing. That's fixed in #446.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

