### PR TITLE
Enable ray query for depth, segmentation and thermal cameras

### DIFF
--- a/examples/segmentation_camera/GlutWindow.cc
+++ b/examples/segmentation_camera/GlutWindow.cc
@@ -136,8 +136,7 @@ void motionCB(int _x, int _y)
 void handleMouse()
 {
   std::lock_guard<std::mutex> lock(g_mouseMutex);
-  // only ogre supports ray query for now so use
-  // ogre camera located at camera index = 0.
+
   ir::CameraPtr rayCamera = g_camera;
   if (!g_rayQuery)
   {
@@ -152,23 +151,44 @@ void handleMouse()
   if (g_mouse.buttonDirty)
   {
     g_mouse.buttonDirty = false;
+
+    // TODO: enable for segmentation cameras
+#if 0
+    // test mouse picking
+    if (g_mouse.button == GLUT_LEFT_BUTTON && g_mouse.state == GLUT_DOWN)
+    {
+      // Get visual using Selection Buffer from Camera
+      ir::VisualPtr visual;
+      ignition::math::Vector2i mousePos(g_mouse.x, g_mouse.y);
+      visual = rayCamera->VisualAt(mousePos);
+      if (visual)
+      {
+        std::cout << "Selected visual at position: ";
+        std::cout << g_mouse.x << " " << g_mouse.y << ": ";
+        std::cout << visual->Name() << "\n";
+      }
+      else
+      {
+        std::cout << "No visual found at position: ";
+        std::cout << g_mouse.x << " " << g_mouse.y << std::endl;
+      }
+    }
+#endif
+
+    // camera orbit
     double nx =
         2.0 * g_mouse.x / static_cast<double>(rayCamera->ImageWidth()) - 1.0;
     double ny = 1.0 -
         2.0 * g_mouse.y / static_cast<double>(rayCamera->ImageHeight());
+    g_rayQuery->SetFromCamera(rayCamera, ignition::math::Vector2d(nx, ny));
+    g_target  = g_rayQuery->ClosestPoint();
+    if (!g_target)
+    {
+      // set point to be 10m away if no intersection found
+      g_target.point = g_rayQuery->Origin() + g_rayQuery->Direction() * 10;
+      return;
+    }
 
-    // TODO(anyone) figure out why this code is causing a crash
-    // g_rayQuery->SetFromCamera(rayCamera, ignition::math::Vector2d(nx, ny));
-    // g_target  = g_rayQuery->ClosestPoint();
-    // if (!g_target)
-    // {
-    //   // set point to be 10m away if no intersection found
-    //   g_target.point = g_rayQuery->Origin() + g_rayQuery->Direction() * 10;
-    //   return;
-    // }
-
-    // TODO(anyone) get mouse wheel scroll zoom to work (currently isn't
-    // working)
     // mouse wheel scroll zoom
     if ((g_mouse.button == 3 || g_mouse.button == 4) &&
         g_mouse.state == GLUT_UP)
@@ -203,8 +223,7 @@ void handleMouse()
       g_viewControl.SetTarget(g_target.point);
       g_viewControl.Orbit(drag);
     }
-    // TODO(anyone) get right mouse button zoom to work. Seems to crash when
-    // used with the RayQuery
+
     // right mouse button zoom
     else if (g_mouse.button == GLUT_RIGHT_BUTTON && g_mouse.state == GLUT_DOWN)
     {

--- a/examples/thermal_camera/GlutWindow.cc
+++ b/examples/thermal_camera/GlutWindow.cc
@@ -34,8 +34,10 @@
 #include <ignition/common/Console.hh>
 #include <ignition/rendering/Camera.hh>
 #include <ignition/rendering/Image.hh>
+#include <ignition/rendering/RayQuery.hh>
 #include <ignition/rendering/Scene.hh>
 #include <ignition/rendering/ThermalCamera.hh>
+#include <ignition/rendering/OrbitViewController.hh>
 
 #include "GlutWindow.hh"
 
@@ -67,6 +69,186 @@ bool g_initContext = false;
   Display *g_glutDisplay;
   GLXDrawable g_glutDrawable;
 #endif
+
+// view control variables
+ir::RayQueryPtr g_rayQuery;
+ir::OrbitViewController g_viewControl;
+ir::RayQueryResult g_target;
+struct mouseButton
+{
+  int button = 0;
+  int state = GLUT_UP;
+  int x = 0;
+  int y = 0;
+  int motionX = 0;
+  int motionY = 0;
+  int dragX = 0;
+  int dragY = 0;
+  int scroll = 0;
+  bool buttonDirty = false;
+  bool motionDirty = false;
+};
+struct mouseButton g_mouse;
+std::mutex g_mouseMutex;
+
+//////////////////////////////////////////////////
+void mouseCB(int _button, int _state, int _x, int _y)
+{
+  // ignore unknown mouse button numbers
+  if (_button >= 5)
+    return;
+
+  std::lock_guard<std::mutex> lock(g_mouseMutex);
+  g_mouse.button = _button;
+  g_mouse.state = _state;
+  g_mouse.x = _x;
+  g_mouse.y = _y;
+  g_mouse.motionX = _x;
+  g_mouse.motionY = _y;
+  g_mouse.buttonDirty = true;
+}
+
+//////////////////////////////////////////////////
+void motionCB(int _x, int _y)
+{
+  std::lock_guard<std::mutex> lock(g_mouseMutex);
+  int deltaX = _x - g_mouse.motionX;
+  int deltaY = _y - g_mouse.motionY;
+  g_mouse.motionX = _x;
+  g_mouse.motionY = _y;
+
+  if (g_mouse.motionDirty)
+  {
+    g_mouse.dragX += deltaX;
+    g_mouse.dragY += deltaY;
+  }
+  else
+  {
+    g_mouse.dragX = deltaX;
+    g_mouse.dragY = deltaY;
+  }
+  g_mouse.motionDirty = true;
+}
+
+//////////////////////////////////////////////////
+void handleMouse()
+{
+  std::lock_guard<std::mutex> lock(g_mouseMutex);
+  // only ogre supports ray query for now so use
+  // ogre camera located at camera index = 0.
+  ir::CameraPtr rayCamera = g_cameras[0];
+  if (!g_rayQuery)
+  {
+    g_rayQuery = rayCamera->Scene()->CreateRayQuery();
+    if (!g_rayQuery)
+    {
+      ignerr << "Failed to create Ray Query" << std::endl;
+      return;
+    }
+  }
+  if (g_mouse.buttonDirty)
+  {
+    g_mouse.buttonDirty = false;
+
+    // TODO: enable for thermal cameras
+#if 0
+    // test mouse picking
+    if (g_mouse.button == GLUT_LEFT_BUTTON && g_mouse.state == GLUT_DOWN)
+    {
+      // Get visual using Selection Buffer from Camera
+      ir::VisualPtr visual;
+      ignition::math::Vector2i mousePos(g_mouse.x, g_mouse.y);
+      visual = rayCamera->VisualAt(mousePos);
+      if (visual)
+      {
+        std::cout << "Selected visual at position: ";
+        std::cout << g_mouse.x << " " << g_mouse.y << ": ";
+        std::cout << visual->Name() << "\n";
+      }
+      else
+      {
+        std::cout << "No visual found at position: ";
+        std::cout << g_mouse.x << " " << g_mouse.y << std::endl;
+      }
+    }
+#endif
+
+    // camera orbit
+    double nx =
+        2.0 * g_mouse.x / static_cast<double>(rayCamera->ImageWidth()) - 1.0;
+    double ny = 1.0 -
+        2.0 * g_mouse.y / static_cast<double>(rayCamera->ImageHeight());
+    g_rayQuery->SetFromCamera(rayCamera, ignition::math::Vector2d(nx, ny));
+    g_target  = g_rayQuery->ClosestPoint();
+    if (!g_target)
+    {
+      // set point to be 10m away if no intersection found
+      g_target.point = g_rayQuery->Origin() + g_rayQuery->Direction() * 10;
+      return;
+    }
+
+    // mouse wheel scroll zoom
+    if ((g_mouse.button == 3 || g_mouse.button == 4) &&
+        g_mouse.state == GLUT_UP)
+    {
+      double scroll = (g_mouse.button == 3) ? -1.0 : 1.0;
+      double distance = rayCamera->WorldPosition().Distance(
+          g_target.point);
+      int factor = 1;
+      double amount = -(scroll * factor) * (distance / 5.0);
+      for (ir::CameraPtr camera : g_cameras)
+      {
+        g_viewControl.SetCamera(camera);
+        g_viewControl.SetTarget(g_target.point);
+        g_viewControl.Zoom(amount);
+      }
+    }
+  }
+
+  if (g_mouse.motionDirty)
+  {
+    g_mouse.motionDirty = false;
+    auto drag = ignition::math::Vector2d(g_mouse.dragX, g_mouse.dragY);
+
+    // left mouse button pan
+    if (g_mouse.button == GLUT_LEFT_BUTTON && g_mouse.state == GLUT_DOWN)
+    {
+      for (ir::CameraPtr camera : g_cameras)
+      {
+        g_viewControl.SetCamera(camera);
+        g_viewControl.SetTarget(g_target.point);
+        g_viewControl.Pan(drag);
+      }
+    }
+    else if (g_mouse.button == GLUT_MIDDLE_BUTTON && g_mouse.state == GLUT_DOWN)
+    {
+      for (ir::CameraPtr camera : g_cameras)
+      {
+        g_viewControl.SetCamera(camera);
+        g_viewControl.SetTarget(g_target.point);
+        g_viewControl.Orbit(drag);
+      }
+    }
+    // right mouse button zoom
+    else if (g_mouse.button == GLUT_RIGHT_BUTTON && g_mouse.state == GLUT_DOWN)
+    {
+      double hfov = rayCamera->HFOV().Radian();
+      double vfov = 2.0f * atan(tan(hfov / 2.0f) /
+          rayCamera->AspectRatio());
+      double distance = rayCamera->WorldPosition().Distance(
+          g_target.point);
+      double amount = ((-g_mouse.dragY /
+          static_cast<double>(rayCamera->ImageHeight()))
+          * distance * tan(vfov/2.0) * 6.0);
+      for (ir::CameraPtr camera : g_cameras)
+      {
+        g_viewControl.SetCamera(camera);
+        g_viewControl.SetTarget(g_target.point);
+        g_viewControl.Zoom(amount);
+      }
+    }
+  }
+}
 
 //////////////////////////////////////////////////
 void OnNewThermalFrame(const uint16_t *_scan,
@@ -122,6 +304,8 @@ void displayCB()
 #endif
 
   g_cameras[g_cameraIndex]->Update();
+
+  handleMouse();
 
 #if __APPLE__
   CGLSetCurrentContext(g_glutContext);
@@ -191,6 +375,9 @@ void initContext()
   glutDisplayFunc(displayCB);
   glutIdleFunc(idleCB);
   glutKeyboardFunc(keyboardCB);
+
+  glutMouseFunc(mouseCB);
+  glutMotionFunc(motionCB);
 }
 
 //////////////////////////////////////////////////

--- a/ogre/include/ignition/rendering/ogre/OgreCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreCamera.hh
@@ -121,10 +121,6 @@ namespace ignition
       public: virtual void SetVisibilityMask(uint32_t _mask) override;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *Camera() const override;
 
       // Documentation inherited.

--- a/ogre/include/ignition/rendering/ogre/OgreCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreCamera.hh
@@ -21,6 +21,7 @@
 
 #include "ignition/rendering/base/BaseCamera.hh"
 #include "ignition/rendering/ogre/OgreRenderTypes.hh"
+#include "ignition/rendering/ogre/OgreObjectInterface.hh"
 #include "ignition/rendering/ogre/OgreSensor.hh"
 #include "ignition/rendering/ogre/OgreSelectionBuffer.hh"
 
@@ -39,7 +40,8 @@ namespace ignition
     class OgreSelectionBuffer;
 
     class IGNITION_RENDERING_OGRE_VISIBLE OgreCamera :
-      public BaseCamera<OgreSensor>
+      public virtual BaseCamera<OgreSensor>,
+      public virtual OgreObjectInterface
     {
       protected: OgreCamera();
 
@@ -118,8 +120,12 @@ namespace ignition
       // Documentation inherited.
       public: virtual void SetVisibilityMask(uint32_t _mask) override;
 
-      /// \brief Get underlying Ogre camera
-      public: Ogre::Camera *Camera() const;
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *Camera() const override;
 
       // Documentation inherited.
       // public: virtual uint32_t VisibilityMask() const override;

--- a/ogre/include/ignition/rendering/ogre/OgreDepthCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreDepthCamera.hh
@@ -128,10 +128,6 @@ namespace ignition
       public: virtual void Destroy() override;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *Camera() const override;
 
       /// \brief Update a render target

--- a/ogre/include/ignition/rendering/ogre/OgreDepthCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreDepthCamera.hh
@@ -31,6 +31,7 @@
 #include "ignition/rendering/base/BaseDepthCamera.hh"
 #include "ignition/rendering/ogre/OgreConversions.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
+#include "ignition/rendering/ogre/OgreObjectInterface.hh"
 #include "ignition/rendering/ogre/OgreRenderTarget.hh"
 #include "ignition/rendering/ogre/OgreRenderTypes.hh"
 #include "ignition/rendering/ogre/OgreScene.hh"
@@ -63,7 +64,8 @@ namespace ignition
     **/
     /// \brief Depth camera used to render depth data into an image buffer
     class IGNITION_RENDERING_OGRE_VISIBLE OgreDepthCamera :
-      public BaseDepthCamera<OgreSensor>
+      public virtual BaseDepthCamera<OgreSensor>,
+      public virtual OgreObjectInterface
     {
       /// \brief Constructor
       protected: OgreDepthCamera();
@@ -124,6 +126,13 @@ namespace ignition
 
       // Documentation inherited
       public: virtual void Destroy() override;
+
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *Camera() const override;
 
       /// \brief Update a render target
       /// \param[in] _target Render target to update

--- a/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE2_OGREOBJECTINTERFACE_HH_
+#define IGNITION_RENDERING_OGRE2_OGREOBJECTINTERFACE_HH_
+
+#include <memory>
+
+#include "ignition/rendering/ogre/OgreIncludes.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Mixin class to provide direct access to Ogre objects.
+    class OgreObjectInterface
+    {
+      public: virtual ~OgreObjectInterface() = default;
+
+      /// \brief Access to an Ogre::MovableObject.
+      //
+      /// \param[in] _typename Name of the object type to retrieve.
+      /// \return A pointer to an Ogre::MovableObject. Has default nullptr.
+      public: virtual Ogre::MovableObject *OgreMovableObject(const char* _typename) const = 0;
+
+      /// \brief Access the Ogre::Camera object.
+      //
+      /// \return A pointer to an Ogre::Camera. Has default nullptr.
+      public: virtual Ogre::Camera *Camera() const = 0;
+    };
+    }
+  }
+}
+#endif

--- a/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
@@ -14,11 +14,10 @@
  * limitations under the License.
  *
  */
-#ifndef IGNITION_RENDERING_OGRE2_OGREOBJECTINTERFACE_HH_
-#define IGNITION_RENDERING_OGRE2_OGREOBJECTINTERFACE_HH_
+#ifndef IGNITION_RENDERING_OGRE_OGREOBJECTINTERFACE_HH_
+#define IGNITION_RENDERING_OGRE_OGREOBJECTINTERFACE_HH_
 
-#include <memory>
-
+#include "ignition/rendering/ogre/Export.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
 
 namespace ignition
@@ -28,16 +27,16 @@ namespace ignition
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
 
     /// \brief Mixin class to provide direct access to Ogre objects.
-    class OgreObjectInterface
+    class IGNITION_RENDERING_OGRE_VISIBLE OgreObjectInterface
     {
-      public: virtual ~OgreObjectInterface() = default;
+      public: virtual ~OgreObjectInterface();
 
       /// \brief Access to an Ogre::MovableObject.
       //
       /// \param[in] _typename Name of the object type to retrieve.
       /// \return A pointer to an Ogre::MovableObject. Has default nullptr.
       public: virtual Ogre::MovableObject *OgreMovableObject(
-          const char* _typename) const = 0;
+          const char* _typename) const;
 
       /// \brief Access the Ogre::Camera object.
       //

--- a/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
@@ -17,8 +17,9 @@
 #ifndef IGNITION_RENDERING_OGRE_OGREOBJECTINTERFACE_HH_
 #define IGNITION_RENDERING_OGRE_OGREOBJECTINTERFACE_HH_
 
-#include "ignition/rendering/ogre/Export.hh"
+#include "ignition/rendering/config.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
+#include "ignition/rendering/ogre/Export.hh"
 
 namespace ignition
 {

--- a/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreObjectInterface.hh
@@ -36,7 +36,8 @@ namespace ignition
       //
       /// \param[in] _typename Name of the object type to retrieve.
       /// \return A pointer to an Ogre::MovableObject. Has default nullptr.
-      public: virtual Ogre::MovableObject *OgreMovableObject(const char* _typename) const = 0;
+      public: virtual Ogre::MovableObject *OgreMovableObject(
+          const char* _typename) const = 0;
 
       /// \brief Access the Ogre::Camera object.
       //

--- a/ogre/include/ignition/rendering/ogre/OgreRenderTypes.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderTypes.hh
@@ -50,6 +50,7 @@ namespace ignition
     class OgreMeshFactory;
     class OgreNode;
     class OgreObject;
+    class OgreObjectInterface;
     class OgreParticleEmitter;
     class OgrePointLight;
     class OgreRayQuery;
@@ -104,6 +105,7 @@ namespace ignition
     typedef shared_ptr<OgreNode>                 OgreNodePtr;
     typedef shared_ptr<OgreNodeStore>            OgreNodeStorePtr;
     typedef shared_ptr<OgreObject>               OgreObjectPtr;
+    typedef shared_ptr<OgreObjectInterface>      OgreObjectInterfacePtr;
     typedef shared_ptr<OgreParticleEmitter>      OgreParticleEmitterPtr;
     typedef shared_ptr<OgrePointLight>           OgrePointLightPtr;
     typedef shared_ptr<OgreRayQuery>             OgreRayQueryPtr;

--- a/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
@@ -97,10 +97,6 @@ namespace ignition
       public: virtual void Destroy() override;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *Camera() const override;
 
       /// \brief Get a pointer to the render target.

--- a/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
@@ -112,6 +112,7 @@ namespace ignition
       private: std::unique_ptr<OgreThermalCameraPrivate> dataPtr;
 
       private: friend class OgreScene;
+      private: friend class OgreRayQuery;
     };
     }
   }

--- a/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
@@ -117,7 +117,6 @@ namespace ignition
       private: std::unique_ptr<OgreThermalCameraPrivate> dataPtr;
 
       private: friend class OgreScene;
-      private: friend class OgreRayQuery;
     };
     }
   }

--- a/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
@@ -32,6 +32,7 @@
 #include "ignition/rendering/ogre/Export.hh"
 #include "ignition/rendering/ogre/OgreConversions.hh"
 #include "ignition/rendering/ogre/OgreIncludes.hh"
+#include "ignition/rendering/ogre/OgreObjectInterface.hh"
 #include "ignition/rendering/ogre/OgreRenderTarget.hh"
 #include "ignition/rendering/ogre/OgreRenderTypes.hh"
 #include "ignition/rendering/ogre/OgreScene.hh"
@@ -61,7 +62,8 @@ namespace ignition
     **/
     /// \brief Depth camera used to render thermal data into an image buffer
     class IGNITION_RENDERING_OGRE_VISIBLE OgreThermalCamera :
-      public BaseThermalCamera<OgreSensor>
+      public virtual BaseThermalCamera<OgreSensor>,
+      public virtual OgreObjectInterface
     {
       /// \brief Constructor
       protected: OgreThermalCamera();
@@ -93,6 +95,13 @@ namespace ignition
 
       // Documentation inherited
       public: virtual void Destroy() override;
+
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *Camera() const override;
 
       /// \brief Get a pointer to the render target.
       /// \return Pointer to the render target

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -341,7 +341,7 @@ void OgreCamera::SetVisibilityMask(uint32_t _mask)
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-OgreCamera::OgreMovableObject(const char* _typename) const
+OgreCamera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -340,13 +340,6 @@ void OgreCamera::SetVisibilityMask(uint32_t _mask)
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-OgreCamera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *OgreCamera::Camera() const
 {
   return this->ogreCamera;

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -39,12 +39,6 @@ OgreCamera::~OgreCamera()
 }
 
 //////////////////////////////////////////////////
-Ogre::Camera *OgreCamera::Camera() const
-{
-  return this->ogreCamera;
-}
-
-//////////////////////////////////////////////////
 void OgreCamera::Destroy()
 {
   if (!this->ogreCamera)
@@ -343,4 +337,17 @@ void OgreCamera::SetVisibilityMask(uint32_t _mask)
 {
   BaseCamera::SetVisibilityMask(_mask);
   this->renderTexture->SetVisibilityMask(_mask);
+}
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+OgreCamera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *OgreCamera::Camera() const
+{
+  return this->ogreCamera;
 }

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -582,3 +582,16 @@ double OgreDepthCamera::FarClipPlane() const
   else
     return 0;
 }
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+OgreDepthCamera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *OgreDepthCamera::Camera() const
+{
+  return this->ogreCamera;
+}

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -584,13 +584,6 @@ double OgreDepthCamera::FarClipPlane() const
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-OgreDepthCamera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *OgreDepthCamera::Camera() const
 {
   return this->ogreCamera;

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -585,7 +585,7 @@ double OgreDepthCamera::FarClipPlane() const
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-OgreDepthCamera::OgreMovableObject(const char* _typename) const
+OgreDepthCamera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre/src/OgreObjectInterface.cc
+++ b/ogre/src/OgreObjectInterface.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "ignition/rendering/ogre/OgreObjectInterface.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+OgreObjectInterface::~OgreObjectInterface() = default;
+
+//////////////////////////////////////////////////
+Ogre::MovableObject *OgreObjectInterface::OgreMovableObject(
+    const char* _typename) const
+{
+  return nullptr;
+}

--- a/ogre/src/OgreObjectInterface.cc
+++ b/ogre/src/OgreObjectInterface.cc
@@ -25,7 +25,7 @@ OgreObjectInterface::~OgreObjectInterface() = default;
 
 //////////////////////////////////////////////////
 Ogre::MovableObject *OgreObjectInterface::OgreMovableObject(
-    const char* _typename) const
+    const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre/src/OgreRayQuery.cc
+++ b/ogre/src/OgreRayQuery.cc
@@ -22,8 +22,10 @@
 #include "ignition/rendering/ogre/OgreIncludes.hh"
 #include "ignition/rendering/ogre/OgreCamera.hh"
 #include "ignition/rendering/ogre/OgreConversions.hh"
+#include "ignition/rendering/ogre/OgreDepthCamera.hh"
 #include "ignition/rendering/ogre/OgreRayQuery.hh"
 #include "ignition/rendering/ogre/OgreScene.hh"
+#include "ignition/rendering/ogre/OgreThermalCamera.hh"
 
 class ignition::rendering::OgreRayQueryPrivate
 {
@@ -51,9 +53,28 @@ void OgreRayQuery::SetFromCamera(const CameraPtr &_camera,
 {
   // convert to nomalized screen pos for ogre
   math::Vector2d screenPos((_coord.X() + 1.0) / 2.0, (_coord.Y() - 1.0) / -2.0);
-  OgreCameraPtr camera = std::dynamic_pointer_cast<OgreCamera>(_camera);
-  Ogre::Ray ray =
+
+  Ogre::Ray ray;
+  
+  if (OgreCameraPtr camera = std::dynamic_pointer_cast<OgreCamera>(_camera))
+  {
+    ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+  }
+  else if (OgreDepthCameraPtr camera = std::dynamic_pointer_cast<OgreDepthCamera>(_camera))
+  {
+    ray =
+      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+  }
+  else if (OgreThermalCameraPtr camera = std::dynamic_pointer_cast<OgreThermalCamera>(_camera))
+  {
+    ray =
+      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+  }
+  else
+  {
+    ignwarn << "Camera does not support ray query\n";
+  }
 
   this->origin = OgreConversions::Convert(ray.getOrigin());
   this->direction = OgreConversions::Convert(ray.getDirection());

--- a/ogre/src/OgreRayQuery.cc
+++ b/ogre/src/OgreRayQuery.cc
@@ -55,18 +55,20 @@ void OgreRayQuery::SetFromCamera(const CameraPtr &_camera,
   math::Vector2d screenPos((_coord.X() + 1.0) / 2.0, (_coord.Y() - 1.0) / -2.0);
 
   Ogre::Ray ray;
-  
+
   if (OgreCameraPtr camera = std::dynamic_pointer_cast<OgreCamera>(_camera))
   {
     ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
   }
-  else if (OgreDepthCameraPtr camera = std::dynamic_pointer_cast<OgreDepthCamera>(_camera))
+  else if (OgreDepthCameraPtr camera =
+    std::dynamic_pointer_cast<OgreDepthCamera>(_camera))
   {
     ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
   }
-  else if (OgreThermalCameraPtr camera = std::dynamic_pointer_cast<OgreThermalCamera>(_camera))
+  else if (OgreThermalCameraPtr camera =
+    std::dynamic_pointer_cast<OgreThermalCamera>(_camera))
   {
     ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());

--- a/ogre/src/OgreRayQuery.cc
+++ b/ogre/src/OgreRayQuery.cc
@@ -23,6 +23,7 @@
 #include "ignition/rendering/ogre/OgreCamera.hh"
 #include "ignition/rendering/ogre/OgreConversions.hh"
 #include "ignition/rendering/ogre/OgreDepthCamera.hh"
+#include "ignition/rendering/ogre/OgreObjectInterface.hh"
 #include "ignition/rendering/ogre/OgreRayQuery.hh"
 #include "ignition/rendering/ogre/OgreScene.hh"
 #include "ignition/rendering/ogre/OgreThermalCamera.hh"
@@ -54,29 +55,16 @@ void OgreRayQuery::SetFromCamera(const CameraPtr &_camera,
   // convert to nomalized screen pos for ogre
   math::Vector2d screenPos((_coord.X() + 1.0) / 2.0, (_coord.Y() - 1.0) / -2.0);
 
-  Ogre::Ray ray;
-
-  if (OgreCameraPtr camera = std::dynamic_pointer_cast<OgreCamera>(_camera))
-  {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-  }
-  else if (OgreDepthCameraPtr camera =
-    std::dynamic_pointer_cast<OgreDepthCamera>(_camera))
-  {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-  }
-  else if (OgreThermalCameraPtr camera =
-    std::dynamic_pointer_cast<OgreThermalCamera>(_camera))
-  {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-  }
-  else
+  OgreObjectInterfacePtr ogreObjectInterface =
+      std::dynamic_pointer_cast<OgreObjectInterface>(_camera);
+  if (!ogreObjectInterface)
   {
     ignwarn << "Camera does not support ray query\n";
+    return;
   }
+
+  Ogre::Ray ray = ogreObjectInterface->Camera()->getCameraToViewportRay(
+      screenPos.X(), screenPos.Y());
 
   this->origin = OgreConversions::Convert(ray.getOrigin());
   this->direction = OgreConversions::Convert(ray.getDirection());

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -571,13 +571,6 @@ RenderTargetPtr OgreThermalCamera::RenderTarget() const
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-OgreThermalCamera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *OgreThermalCamera::Camera() const
 {
   return this->ogreCamera;

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -572,7 +572,7 @@ RenderTargetPtr OgreThermalCamera::RenderTarget() const
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-OgreThermalCamera::OgreMovableObject(const char* _typename) const
+OgreThermalCamera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -569,3 +569,16 @@ RenderTargetPtr OgreThermalCamera::RenderTarget() const
 {
   return this->dataPtr->thermalTexture;
 }
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+OgreThermalCamera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *OgreThermalCamera::Camera() const
+{
+  return this->ogreCamera;
+}

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
@@ -22,6 +22,7 @@
 #include "ignition/rendering/base/BaseCamera.hh"
 #include "ignition/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "ignition/rendering/ogre2/Ogre2Includes.hh"
+#include "ignition/rendering/ogre2/Ogre2ObjectInterface.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
 namespace Ogre
@@ -41,7 +42,8 @@ namespace ignition
 
     /// \brief Ogre2.x implementation of the camera class
     class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2Camera :
-      public BaseCamera<Ogre2Sensor>
+      public virtual BaseCamera<Ogre2Sensor>,
+      public virtual Ogre2ObjectInterface
     {
       /// \brief Constructor
       protected: Ogre2Camera();
@@ -124,14 +126,19 @@ namespace ignition
       // Documentation inherited.
       public: virtual void Destroy() override;
 
-      public: Ogre::Camera *OgreCamera() const;
-
       // Documentation inherited.
       public: virtual void SetVisibilityMask(uint32_t _mask) override;
 
       /// \brief Get the selection buffer object
       /// \return the selection buffer object
       public: Ogre2SelectionBuffer *SelectionBuffer() const;
+
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *OgreCamera() const override;
 
       // Documentation inherited.
       protected: virtual RenderTargetPtr RenderTarget() const override;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
@@ -134,10 +134,6 @@ namespace ignition
       public: Ogre2SelectionBuffer *SelectionBuffer() const;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *OgreCamera() const override;
 
       // Documentation inherited.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
@@ -162,10 +162,6 @@ namespace ignition
 
       /// \brief Make scene our friend so it can create a camera
       private: friend class Ogre2Scene;
-
-      /// \brief Make ray query our friend so it can use the internal ogre
-      /// camera to execute queries
-      private: friend class Ogre2RayQuery;
     };
     }
   }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "ignition/rendering/base/BaseDepthCamera.hh"
+#include "ignition/rendering/ogre2/Ogre2ObjectInterface.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
 #include "ignition/common/Event.hh"
@@ -52,7 +53,8 @@ namespace ignition
 
     /// \brief Depth camera used to render depth data into an image buffer
     class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2DepthCamera :
-      public BaseDepthCamera<Ogre2Sensor>
+      public virtual BaseDepthCamera<Ogre2Sensor>,
+      public virtual Ogre2ObjectInterface
     {
       /// \brief Constructor
       protected: Ogre2DepthCamera();
@@ -127,6 +129,13 @@ namespace ignition
 
       // Documentation inherited.
       public: void AddRenderPass(const RenderPassPtr &_pass) override;
+
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *OgreCamera() const override;
 
       /// \brief Get a pointer to the render target.
       /// \return Pointer to the render target

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
@@ -131,10 +131,6 @@ namespace ignition
       public: void AddRenderPass(const RenderPassPtr &_pass) override;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *OgreCamera() const override;
 
       /// \brief Get a pointer to the render target.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DepthCamera.hh
@@ -155,7 +155,12 @@ namespace ignition
       /// \brief Pointer to private data.
       private: std::unique_ptr<Ogre2DepthCameraPrivate> dataPtr;
 
+      /// \brief Make scene our friend so it can create a camera
       private: friend class Ogre2Scene;
+
+      /// \brief Make ray query our friend so it can use the internal ogre
+      /// camera to execute queries
+      private: friend class Ogre2RayQuery;
     };
     }
   }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE2_OGRE2OBJECTINTERFACE_HH_
+#define IGNITION_RENDERING_OGRE2_OGRE2OBJECTINTERFACE_HH_
+
+#include <memory>
+
+#include "ignition/rendering/ogre2/Ogre2Includes.hh"
+
+namespace ignition
+{
+  namespace rendering
+  {
+    inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Mixin class to provide direct access to Ogre objects.
+    class Ogre2ObjectInterface
+    {
+      public: virtual ~Ogre2ObjectInterface() = default;
+
+      /// \brief Access to an Ogre::MovableObject.
+      //
+      /// \param[in] _typename Name of the object type to retrieve.
+      /// \return A pointer to an Ogre::MovableObject. Has default nullptr.
+      public: virtual Ogre::MovableObject *OgreMovableObject(const char* _typename) const = 0;
+
+      /// \brief Access the Ogre::Camera object.
+      //
+      /// \return A pointer to an Ogre::Camera. Has default nullptr.
+      public: virtual Ogre::Camera *OgreCamera() const = 0;
+    };
+    }
+  }
+}
+#endif

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
@@ -17,8 +17,7 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2OBJECTINTERFACE_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2OBJECTINTERFACE_HH_
 
-#include <memory>
-
+#include "ignition/rendering/ogre2/Export.hh"
 #include "ignition/rendering/ogre2/Ogre2Includes.hh"
 
 namespace ignition
@@ -28,16 +27,16 @@ namespace ignition
     inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
 
     /// \brief Mixin class to provide direct access to Ogre objects.
-    class Ogre2ObjectInterface
+    class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2ObjectInterface
     {
-      public: virtual ~Ogre2ObjectInterface() = default;
+      public: virtual ~Ogre2ObjectInterface();
 
       /// \brief Access to an Ogre::MovableObject.
       //
       /// \param[in] _typename Name of the object type to retrieve.
       /// \return A pointer to an Ogre::MovableObject. Has default nullptr.
       public: virtual Ogre::MovableObject *OgreMovableObject(
-          const char* _typename) const = 0;
+          const char* _typename) const;
 
       /// \brief Access the Ogre::Camera object.
       //

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
@@ -36,7 +36,8 @@ namespace ignition
       //
       /// \param[in] _typename Name of the object type to retrieve.
       /// \return A pointer to an Ogre::MovableObject. Has default nullptr.
-      public: virtual Ogre::MovableObject *OgreMovableObject(const char* _typename) const = 0;
+      public: virtual Ogre::MovableObject *OgreMovableObject(
+          const char* _typename) const = 0;
 
       /// \brief Access the Ogre::Camera object.
       //

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ObjectInterface.hh
@@ -17,8 +17,9 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2OBJECTINTERFACE_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2OBJECTINTERFACE_HH_
 
-#include "ignition/rendering/ogre2/Export.hh"
+#include "ignition/rendering/config.hh"
 #include "ignition/rendering/ogre2/Ogre2Includes.hh"
+#include "ignition/rendering/ogre2/Export.hh"
 
 namespace ignition
 {

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderTypes.hh
@@ -51,6 +51,7 @@ namespace ignition
     class Ogre2MeshFactory;
     class Ogre2Node;
     class Ogre2Object;
+    class Ogre2ObjectInterface;
     class Ogre2ParticleEmitter;
     class Ogre2PointLight;
     class Ogre2RayQuery;
@@ -101,6 +102,7 @@ namespace ignition
     typedef shared_ptr<Ogre2MeshFactory>          Ogre2MeshFactoryPtr;
     typedef shared_ptr<Ogre2Node>                 Ogre2NodePtr;
     typedef shared_ptr<Ogre2Object>               Ogre2ObjectPtr;
+    typedef shared_ptr<Ogre2ObjectInterface>      Ogre2ObjectInterfacePtr;
     typedef shared_ptr<Ogre2ParticleEmitter>      Ogre2ParticleEmitterPtr;
     typedef shared_ptr<Ogre2PointLight>           Ogre2PointLightPtr;
     typedef shared_ptr<Ogre2RayQuery>             Ogre2RayQueryPtr;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
@@ -32,6 +32,7 @@
 
 #include "ignition/rendering/base/BaseSegmentationCamera.hh"
 #include "ignition/rendering/ogre2/Ogre2Includes.hh"
+#include "ignition/rendering/ogre2/Ogre2ObjectInterface.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
 namespace ignition
@@ -46,7 +47,8 @@ namespace ignition
     /// \brief Segmentation camera used to label each pixel with a label id.
     /// Supports Semantic / Panoptic Segmentation
     class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationCamera :
-      public BaseSegmentationCamera<Ogre2Sensor>
+      public virtual BaseSegmentationCamera<Ogre2Sensor>,
+      public virtual Ogre2ObjectInterface
     {
       /// \brief Constructor
       protected: Ogre2SegmentationCamera();
@@ -85,6 +87,13 @@ namespace ignition
       // Documentation inherited
       public: void LabelMapFromColoredBuffer(
                   uint8_t * _labelBuffer) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *OgreCamera() const override;
 
       /// \brief Create the camera.
       protected: void CreateCamera();

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
@@ -89,10 +89,6 @@ namespace ignition
                   uint8_t * _labelBuffer) const override;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *OgreCamera() const override;
 
       /// \brief Create the camera.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
@@ -104,6 +104,10 @@ namespace ignition
 
       /// \brief Make scene our friend so it can create a camera
       private: friend class Ogre2Scene;
+
+      /// \brief Make ray query our friend so it can use the internal ogre
+      /// camera to execute queries
+      private: friend class Ogre2RayQuery;
     };
     }
   }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2SegmentationCamera.hh
@@ -109,10 +109,6 @@ namespace ignition
 
       /// \brief Make scene our friend so it can create a camera
       private: friend class Ogre2Scene;
-
-      /// \brief Make ray query our friend so it can use the internal ogre
-      /// camera to execute queries
-      private: friend class Ogre2RayQuery;
     };
     }
   }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
@@ -103,7 +103,12 @@ namespace ignition
       /// \brief Pointer to private data.
       private: std::unique_ptr<Ogre2ThermalCameraPrivate> dataPtr;
 
+      /// \brief Make scene our friend so it can create a camera
       private: friend class Ogre2Scene;
+
+      /// \brief Make ray query our friend so it can use the internal ogre
+      /// camera to execute queries
+      private: friend class Ogre2RayQuery;
     };
     }
   }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
@@ -86,10 +86,6 @@ namespace ignition
       public: virtual void Render() override;
 
       // Documentation inherited.
-      public: virtual Ogre::MovableObject* OgreMovableObject(
-          const char* _typename) const override;
-
-      // Documentation inherited.
       public: virtual Ogre::Camera *OgreCamera() const override;
 
       /// \brief Get a pointer to the render target.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
@@ -110,10 +110,6 @@ namespace ignition
 
       /// \brief Make scene our friend so it can create a camera
       private: friend class Ogre2Scene;
-
-      /// \brief Make ray query our friend so it can use the internal ogre
-      /// camera to execute queries
-      private: friend class Ogre2RayQuery;
     };
     }
   }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2ThermalCamera.hh
@@ -29,6 +29,7 @@
 
 #include "ignition/rendering/base/BaseThermalCamera.hh"
 #include "ignition/rendering/ogre2/Export.hh"
+#include "ignition/rendering/ogre2/Ogre2ObjectInterface.hh"
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 
 #include "ignition/common/Event.hh"
@@ -53,7 +54,8 @@ namespace ignition
 
     /// \brief Thermal camera used to render thermal data into an image buffer
     class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2ThermalCamera :
-      public BaseThermalCamera<Ogre2Sensor>
+      public virtual BaseThermalCamera<Ogre2Sensor>,
+      public virtual Ogre2ObjectInterface
     {
       /// \brief Constructor
       protected: Ogre2ThermalCamera();
@@ -82,6 +84,13 @@ namespace ignition
 
       /// \brief Implementation of the render call
       public: virtual void Render() override;
+
+      // Documentation inherited.
+      public: virtual Ogre::MovableObject* OgreMovableObject(
+          const char* _typename) const override;
+
+      // Documentation inherited.
+      public: virtual Ogre::Camera *OgreCamera() const override;
 
       /// \brief Get a pointer to the render target.
       /// \return Pointer to the render target

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -372,7 +372,7 @@ void Ogre2Camera::SetVisibilityMask(uint32_t _mask)
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-Ogre2Camera::OgreMovableObject(const char* _typename) const
+Ogre2Camera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -371,13 +371,6 @@ void Ogre2Camera::SetVisibilityMask(uint32_t _mask)
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-Ogre2Camera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *Ogre2Camera::OgreCamera() const
 {
   return this->ogreCamera;

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -363,15 +363,22 @@ void Ogre2Camera::SetFarClipPlane(const double _far)
 }
 
 //////////////////////////////////////////////////
-Ogre::Camera *Ogre2Camera::OgreCamera() const
-{
-  return ogreCamera;
-}
-
-//////////////////////////////////////////////////
 void Ogre2Camera::SetVisibilityMask(uint32_t _mask)
 {
   BaseSensor::SetVisibilityMask(_mask);
   if (this->renderTexture)
     this->renderTexture->SetVisibilityMask(_mask);
+}
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+Ogre2Camera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *Ogre2Camera::OgreCamera() const
+{
+  return this->ogreCamera;
 }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -1271,13 +1271,6 @@ void Ogre2DepthCamera::AddRenderPass(const RenderPassPtr &_pass)
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-Ogre2DepthCamera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *Ogre2DepthCamera::OgreCamera() const
 {
   return this->ogreCamera;

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -1269,3 +1269,16 @@ void Ogre2DepthCamera::AddRenderPass(const RenderPassPtr &_pass)
   this->dataPtr->renderPasses.push_back(depthNoisePass);
   this->dataPtr->renderPassDirty = true;
 }
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+Ogre2DepthCamera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *Ogre2DepthCamera::OgreCamera() const
+{
+  return this->ogreCamera;
+}

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -1272,7 +1272,7 @@ void Ogre2DepthCamera::AddRenderPass(const RenderPassPtr &_pass)
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-Ogre2DepthCamera::OgreMovableObject(const char* _typename) const
+Ogre2DepthCamera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre2/src/Ogre2ObjectInterface.cc
+++ b/ogre2/src/Ogre2ObjectInterface.cc
@@ -25,7 +25,7 @@ Ogre2ObjectInterface::~Ogre2ObjectInterface() = default;
 
 //////////////////////////////////////////////////
 Ogre::MovableObject *Ogre2ObjectInterface::OgreMovableObject(
-    const char* _typename) const
+    const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre2/src/Ogre2ObjectInterface.cc
+++ b/ogre2/src/Ogre2ObjectInterface.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include "ignition/rendering/ogre/Ogre2ObjectInterface.hh"
+#include "ignition/rendering/ogre2/Ogre2ObjectInterface.hh"
 
 using namespace ignition;
 using namespace rendering;

--- a/ogre2/src/Ogre2ObjectInterface.cc
+++ b/ogre2/src/Ogre2ObjectInterface.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "ignition/rendering/ogre/Ogre2ObjectInterface.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+Ogre2ObjectInterface::~Ogre2ObjectInterface() = default;
+
+//////////////////////////////////////////////////
+Ogre::MovableObject *Ogre2ObjectInterface::OgreMovableObject(
+    const char* _typename) const
+{
+  return nullptr;
+}

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -22,9 +22,12 @@
 
 #include "ignition/rendering/ogre2/Ogre2Camera.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
+#include "ignition/rendering/ogre2/Ogre2DepthCamera.hh"
 #include "ignition/rendering/ogre2/Ogre2RayQuery.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
+#include "ignition/rendering/ogre2/Ogre2SegmentationCamera.hh"
 #include "ignition/rendering/ogre2/Ogre2SelectionBuffer.hh"
+#include "ignition/rendering/ogre2/Ogre2ThermalCamera.hh"
 
 #ifdef _MSC_VER
   #pragma warning(push, 0)
@@ -75,19 +78,46 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
 {
   // convert to nomalized screen pos for ogre
   math::Vector2d screenPos((_coord.X() + 1.0) / 2.0, (_coord.Y() - 1.0) / -2.0);
-  Ogre2CameraPtr camera = std::dynamic_pointer_cast<Ogre2Camera>(_camera);
-  Ogre::Ray ray =
+
+  Ogre::Ray ray;  
+
+  if (Ogre2CameraPtr camera = std::dynamic_pointer_cast<Ogre2Camera>(_camera))
+  {
+    ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+    
+    this->dataPtr->camera = camera;
+  }
+  else if (Ogre2DepthCameraPtr camera = 
+      std::dynamic_pointer_cast<Ogre2DepthCamera>(_camera))
+  {
+    ray =
+      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+  }
+  else if (Ogre2SegmentationCameraPtr camera =
+      std::dynamic_pointer_cast<Ogre2SegmentationCamera>(_camera))
+  {
+    ray =
+      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+  }
+  else if (Ogre2ThermalCameraPtr camera =
+      std::dynamic_pointer_cast<Ogre2ThermalCamera>(_camera))
+  {
+    ray =
+      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
+  }
+  else
+  {
+    ignwarn << "Camera does not support ray query\n";
+  }
 
   this->origin = Ogre2Conversions::Convert(ray.getOrigin());
   this->direction = Ogre2Conversions::Convert(ray.getDirection());
 
-  this->dataPtr->camera = camera;
-
   this->dataPtr->imgPos.X() = static_cast<int>(
-      screenPos.X() * this->dataPtr->camera->ImageWidth());
+      screenPos.X() * _camera->ImageWidth());
   this->dataPtr->imgPos.Y() = static_cast<int>(
-      screenPos.Y() * this->dataPtr->camera->ImageHeight());
+      screenPos.Y() * _camera->ImageHeight());
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -23,6 +23,7 @@
 #include "ignition/rendering/ogre2/Ogre2Camera.hh"
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2DepthCamera.hh"
+#include "ignition/rendering/ogre2/Ogre2ObjectInterface.hh"
 #include "ignition/rendering/ogre2/Ogre2RayQuery.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2SegmentationCamera.hh"
@@ -79,37 +80,23 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
   // convert to nomalized screen pos for ogre
   math::Vector2d screenPos((_coord.X() + 1.0) / 2.0, (_coord.Y() - 1.0) / -2.0);
 
-  Ogre::Ray ray;
-
-  if (Ogre2CameraPtr camera = std::dynamic_pointer_cast<Ogre2Camera>(_camera))
+  Ogre2CameraPtr camera = std::dynamic_pointer_cast<Ogre2Camera>(_camera);
+  if (camera)
   {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-
     this->dataPtr->camera = camera;
   }
-  else if (Ogre2DepthCameraPtr camera =
-      std::dynamic_pointer_cast<Ogre2DepthCamera>(_camera))
-  {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-  }
-  else if (Ogre2SegmentationCameraPtr camera =
-      std::dynamic_pointer_cast<Ogre2SegmentationCamera>(_camera))
-  {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-  }
-  else if (Ogre2ThermalCameraPtr camera =
-      std::dynamic_pointer_cast<Ogre2ThermalCamera>(_camera))
-  {
-    ray =
-      camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-  }
-  else
+
+  Ogre2ObjectInterfacePtr ogre2ObjectInterface =
+      std::dynamic_pointer_cast<Ogre2ObjectInterface>(_camera);
+  if (!ogre2ObjectInterface)
   {
     ignwarn << "Camera does not support ray query\n";
+    return;
   }
+
+  Ogre::Ray ray = ogre2ObjectInterface->OgreCamera()->getCameraToViewportRay(
+      screenPos.X(), screenPos.Y());
+  
 
   this->origin = Ogre2Conversions::Convert(ray.getOrigin());
   this->direction = Ogre2Conversions::Convert(ray.getDirection());

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -79,16 +79,16 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
   // convert to nomalized screen pos for ogre
   math::Vector2d screenPos((_coord.X() + 1.0) / 2.0, (_coord.Y() - 1.0) / -2.0);
 
-  Ogre::Ray ray;  
+  Ogre::Ray ray;
 
   if (Ogre2CameraPtr camera = std::dynamic_pointer_cast<Ogre2Camera>(_camera))
   {
     ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
-    
+
     this->dataPtr->camera = camera;
   }
-  else if (Ogre2DepthCameraPtr camera = 
+  else if (Ogre2DepthCameraPtr camera =
       std::dynamic_pointer_cast<Ogre2DepthCamera>(_camera))
   {
     ray =

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -96,7 +96,6 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
 
   Ogre::Ray ray = ogre2ObjectInterface->OgreCamera()->getCameraToViewportRay(
       screenPos.X(), screenPos.Y());
-  
 
   this->origin = Ogre2Conversions::Convert(ray.getOrigin());
   this->direction = Ogre2Conversions::Convert(ray.getDirection());

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -417,7 +417,7 @@ void Ogre2SegmentationCamera::LabelMapFromColoredBuffer(
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-Ogre2SegmentationCamera::OgreMovableObject(const char* _typename) const
+Ogre2SegmentationCamera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -416,13 +416,6 @@ void Ogre2SegmentationCamera::LabelMapFromColoredBuffer(
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-Ogre2SegmentationCamera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *Ogre2SegmentationCamera::OgreCamera() const
 {
   return this->ogreCamera;

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -414,3 +414,16 @@ void Ogre2SegmentationCamera::LabelMapFromColoredBuffer(
     }
   }
 }
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+Ogre2SegmentationCamera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *Ogre2SegmentationCamera::OgreCamera() const
+{
+  return this->ogreCamera;
+}

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -951,13 +951,6 @@ RenderTargetPtr Ogre2ThermalCamera::RenderTarget() const
 }
 
 //////////////////////////////////////////////////
-Ogre::MovableObject*
-Ogre2ThermalCamera::OgreMovableObject(const char* /*_typename*/) const
-{
-  return nullptr;
-}
-
-//////////////////////////////////////////////////
 Ogre::Camera *Ogre2ThermalCamera::OgreCamera() const
 {
   return this->ogreCamera;

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -952,7 +952,7 @@ RenderTargetPtr Ogre2ThermalCamera::RenderTarget() const
 
 //////////////////////////////////////////////////
 Ogre::MovableObject*
-Ogre2ThermalCamera::OgreMovableObject(const char* _typename) const
+Ogre2ThermalCamera::OgreMovableObject(const char* /*_typename*/) const
 {
   return nullptr;
 }

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -949,3 +949,16 @@ RenderTargetPtr Ogre2ThermalCamera::RenderTarget() const
 {
   return this->dataPtr->thermalTexture;
 }
+
+//////////////////////////////////////////////////
+Ogre::MovableObject*
+Ogre2ThermalCamera::OgreMovableObject(const char* _typename) const
+{
+  return nullptr;
+}
+
+//////////////////////////////////////////////////
+Ogre::Camera *Ogre2ThermalCamera::OgreCamera() const
+{
+  return this->ogreCamera;
+}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #414

## Summary

This PR enables depth, segmentation and thermal cameras to set a ray query for the `ogre` and `ogre2` render engines.

The approach Introduces mix-in classes to provide access to underlying Ogre objects in the `OgreCamera` / `Ogre2Camera` and related camera classes.

Update the mouse handling in the `segmentation_camera` and `thermal_camera examples`.

![ogre_ray-query_thermal-camera](https://user-images.githubusercontent.com/24916364/139835717-a255b6bd-8e53-48dc-8376-9a3bc2de1b5c.gif)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**