### PR TITLE
Remove unused time var in material scripts

### DIFF
--- a/ogre2/src/media/materials/scripts/depth_camera.material
+++ b/ogre2/src/media/materials/scripts/depth_camera.material
@@ -30,8 +30,6 @@ fragment_program DepthCameraFS glsl
 
   default_params
   {
-    param_named_auto time time
-
     param_named depthTexture int 0
     param_named colorTexture int 1
     param_named particleTexture int 2

--- a/ogre2/src/media/materials/scripts/gpu_rays.material
+++ b/ogre2/src/media/materials/scripts/gpu_rays.material
@@ -30,7 +30,6 @@ fragment_program GpuRaysScan1stFS glsl
 
   default_params
   {
-    param_named_auto time time
     param_named depthTexture int 0
     param_named colorTexture int 1
     param_named particleDepthTexture int 2


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>
# 🦟 Bug fix

## Summary

The `time` param declared in the ogre2 material scripts are no longer used in the shaders.

Here are the corresponding shaders. You can see that there are no uniforms called `time`:

[gpu_ray_1st_pass_fs.glsl](https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering4/ogre2/src/media/materials/programs/gpu_rays_1st_pass_fs.glsl) - `time` removed in #388
[depth_camera_fs.glsl](https://github.com/ignitionrobotics/ign-rendering/blob/ign-rendering4/ogre2/src/media/materials/programs/depth_camera_fs.glsl) - `time` was probably never used.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
