### PR TITLE
More nullptr checking on visuals and base axis

### DIFF
--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -167,7 +167,8 @@ namespace ignition
       {
         auto arrow = std::dynamic_pointer_cast<rendering::ArrowVisual>(
               this->ChildByIndex(i));
-        arrow->SetVisible(_visible);
+        if (arrow != nullptr)
+          arrow->SetVisible(_visible);
       }
     }
     }

--- a/ogre/src/OgreVisual.cc
+++ b/ogre/src/OgreVisual.cc
@@ -51,6 +51,9 @@ void OgreVisual::SetWireframe(bool _show)
   if (this->dataPtr->wireframe == _show)
     return;
 
+  if (!this->ogreNode)
+    return;
+
   this->dataPtr->wireframe = _show;
   for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
       i++)
@@ -100,6 +103,9 @@ bool OgreVisual::Wireframe() const
 //////////////////////////////////////////////////
 void OgreVisual::SetVisible(bool _visible)
 {
+  if (!this->ogreNode)
+    return;
+
   this->ogreNode->setVisible(_visible);
 }
 
@@ -124,6 +130,19 @@ GeometryStorePtr OgreVisual::Geometries() const
 //////////////////////////////////////////////////
 bool OgreVisual::AttachGeometry(GeometryPtr _geometry)
 {
+  if (!_geometry)
+  {
+    ignerr << "Cannot attach null geometry." << std::endl;
+
+    return false;
+  }
+
+  if (!this->ogreNode)
+  {
+    ignerr << "Cannot attach geometry, null Ogre node." << std::endl;
+    return false;
+  }
+
   OgreGeometryPtr derived =
       std::dynamic_pointer_cast<OgreGeometry>(_geometry);
 
@@ -137,16 +156,20 @@ bool OgreVisual::AttachGeometry(GeometryPtr _geometry)
 
   // Some geometries, like heightmaps, may not have an OgreObject
   Ogre::MovableObject *ogreObj = derived->OgreObject();
-  if (ogreObj)
+  if (!ogreObj)
   {
-    // set user data for mouse queries
-    ogreObj->getUserObjectBindings().setUserAny(
-        Ogre::Any(this->Id()));
-    ogreObj->setVisibilityFlags(this->visibilityFlags);
-    this->ogreNode->attachObject(ogreObj);
+    ignerr << "Cannot attach a null geometry object" << std::endl;
+    return false;
   }
 
+  // set user data for mouse queries
+  ogreObj->getUserObjectBindings().setUserAny(
+      Ogre::Any(this->Id()));
+  ogreObj->setVisibilityFlags(this->visibilityFlags);
+
   derived->SetParent(this->SharedThis());
+  this->ogreNode->attachObject(ogreObj);
+
   return true;
 }
 
@@ -154,7 +177,10 @@ bool OgreVisual::AttachGeometry(GeometryPtr _geometry)
 bool OgreVisual::DetachGeometry(GeometryPtr _geometry)
 {
   if (!this->ogreNode)
-    return true;
+  {
+    ignerr << "Cannot detach geometry, null Ogre node." << std::endl;
+    return false;
+  }
 
   OgreGeometryPtr derived =
       std::dynamic_pointer_cast<OgreGeometry>(_geometry);
@@ -200,6 +226,9 @@ void OgreVisual::BoundsHelper(ignition::math::AxisAlignedBox &_box,
 void OgreVisual::BoundsHelper(ignition::math::AxisAlignedBox &_box,
     bool _local, const ignition::math::Pose3d &_pose) const
 {
+  if (!this->ogreNode)
+    return;
+
   this->ogreNode->_updateBounds();
   this->ogreNode->_update(false, true);
 
@@ -228,6 +257,7 @@ void OgreVisual::BoundsHelper(ignition::math::AxisAlignedBox &_box,
         Ogre::Vector3 ogreMin = bb.getMinimum();
         Ogre::Vector3 ogreMax = bb.getMaximum();
 
+        // Get ogre bounding boxes and size to object's scale
         min = scale * ignition::math::Vector3d(ogreMin.x, ogreMin.y, ogreMin.z);
         max = scale * ignition::math::Vector3d(ogreMax.x, ogreMax.y, ogreMax.z);
         box.Min() = min,
@@ -240,9 +270,8 @@ void OgreVisual::BoundsHelper(ignition::math::AxisAlignedBox &_box,
         if (_local)
         {
           ignition::math::Pose3d worldPose = this->WorldPose();
-          ignition::math::Quaternion parentRot = _pose.Rot();
           ignition::math::Vector3d parentPos = _pose.Pos();
-          ignition::math::Quaternion parentRotInv = parentRot.Inverse();
+          ignition::math::Quaternion parentRotInv = _pose.Rot().Inverse();
           ignition::math::Pose3d localTransform =
             ignition::math::Pose3d(
                 (parentRotInv * (worldPose.Pos() - parentPos)),

--- a/ogre/src/OgreVisual.cc
+++ b/ogre/src/OgreVisual.cc
@@ -156,20 +156,16 @@ bool OgreVisual::AttachGeometry(GeometryPtr _geometry)
 
   // Some geometries, like heightmaps, may not have an OgreObject
   Ogre::MovableObject *ogreObj = derived->OgreObject();
-  if (!ogreObj)
+  if (ogreObj)
   {
-    ignerr << "Cannot attach a null geometry object" << std::endl;
-    return false;
+    // set user data for mouse queries
+    ogreObj->getUserObjectBindings().setUserAny(
+        Ogre::Any(this->Id()));
+    ogreObj->setVisibilityFlags(this->visibilityFlags);
+    this->ogreNode->attachObject(ogreObj);
   }
 
-  // set user data for mouse queries
-  ogreObj->getUserObjectBindings().setUserAny(
-      Ogre::Any(this->Id()));
-  ogreObj->setVisibilityFlags(this->visibilityFlags);
-
   derived->SetParent(this->SharedThis());
-  this->ogreNode->attachObject(ogreObj);
-
   return true;
 }
 

--- a/ogre2/src/Ogre2Visual.cc
+++ b/ogre2/src/Ogre2Visual.cc
@@ -61,6 +61,9 @@ void Ogre2Visual::SetWireframe(bool _show)
   if (this->dataPtr->wireframe == _show)
     return;
 
+  if (!this->ogreNode)
+    return;
+
   this->dataPtr->wireframe = _show;
   for (unsigned int i = 0; i < this->ogreNode->numAttachedObjects();
       i++)
@@ -96,6 +99,9 @@ bool Ogre2Visual::Wireframe() const
 //////////////////////////////////////////////////
 void Ogre2Visual::SetVisible(bool _visible)
 {
+  if (!this->ogreNode)
+    return;
+
   this->ogreNode->setVisible(_visible);
 }
 
@@ -130,6 +136,12 @@ bool Ogre2Visual::AttachGeometry(GeometryPtr _geometry)
     return false;
   }
 
+  if (!this->ogreNode)
+  {
+    ignerr << "Cannot attach geometry, null Ogre node." << std::endl;
+    return false;
+  }
+
   Ogre2GeometryPtr derived =
       std::dynamic_pointer_cast<Ogre2Geometry>(_geometry);
 
@@ -141,6 +153,7 @@ bool Ogre2Visual::AttachGeometry(GeometryPtr _geometry)
     return false;
   }
 
+  // Some geometries, like heightmaps, may not have an OgreObject
   Ogre::MovableObject *ogreObj = derived->OgreObject();
   if (!ogreObj)
   {
@@ -164,6 +177,12 @@ bool Ogre2Visual::AttachGeometry(GeometryPtr _geometry)
 //////////////////////////////////////////////////
 bool Ogre2Visual::DetachGeometry(GeometryPtr _geometry)
 {
+  if (!this->ogreNode)
+  {
+    ignerr << "Cannot detach geometry, null Ogre node." << std::endl;
+    return false;
+  }
+
   Ogre2GeometryPtr derived =
       std::dynamic_pointer_cast<Ogre2Geometry>(_geometry);
 
@@ -175,7 +194,8 @@ bool Ogre2Visual::DetachGeometry(GeometryPtr _geometry)
     return false;
   }
 
-  this->ogreNode->detachObject(derived->OgreObject());
+  if (nullptr != derived->OgreObject())
+    this->ogreNode->detachObject(derived->OgreObject());
   derived->SetParent(nullptr);
   return true;
 }
@@ -207,6 +227,9 @@ void Ogre2Visual::BoundsHelper(ignition::math::AxisAlignedBox &_box,
 void Ogre2Visual::BoundsHelper(ignition::math::AxisAlignedBox &_box,
     bool _local, const ignition::math::Pose3d &_pose) const
 {
+  if (!this->ogreNode)
+    return;
+
   ignition::math::Vector3d scale = this->WorldScale();
 
   for (size_t i = 0; i < this->ogreNode->numAttachedObjects(); i++)

--- a/ogre2/src/Ogre2Visual.cc
+++ b/ogre2/src/Ogre2Visual.cc
@@ -153,7 +153,6 @@ bool Ogre2Visual::AttachGeometry(GeometryPtr _geometry)
     return false;
   }
 
-  // Some geometries, like heightmaps, may not have an OgreObject
   Ogre::MovableObject *ogreObj = derived->OgreObject();
   if (!ogreObj)
   {


### PR DESCRIPTION
# 🦟 Bug fix

Needed by https://github.com/ignitionrobotics/ign-gazebo/pull/1105/

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

A couple of these nullptr checks were needed by https://github.com/ignitionrobotics/ign-gazebo/pull/1105/. While at it, I also went over `Ogre2Visual` and `OgreVisual`, added more nullptr checks, and reduced the diff between them.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
