### PR TITLE
Fix warnings on Windows

### DIFF
--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -810,7 +810,7 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseCamera<T>::RenderTextureMetalId(void */*_textureIdPtr*/) const
+    void BaseCamera<T>::RenderTextureMetalId(void *) const
     {
       ignerr << "RenderTextureMetalId is not supported by current render"
           << " engine" << std::endl;

--- a/include/ignition/rendering/base/BaseRenderTarget.hh
+++ b/include/ignition/rendering/base/BaseRenderTarget.hh
@@ -296,7 +296,7 @@ namespace ignition
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseRenderTexture<T>::MetalId(void */*_textureIdPtr*/) const
+    void BaseRenderTexture<T>::MetalId(void *) const
     {
     }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

This should fix a couple of Windows build warnings found by CI:

```
'*/' found outside of comment (compiling source file C:\Jenkins\workspace\ign_rendering-pr-win\ws\ign-rendering\ogre\src\OgreCamera.cc)
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
