### PR TITLE
Per-point colors in point clouds

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2DynamicRenderable.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2DynamicRenderable.hh
@@ -137,6 +137,14 @@ namespace ignition
       private: void GenerateNormals(Ogre::OperationType _opType,
           const std::vector<math::Vector3d> &_vertices, float *_vbuffer);
 
+      /// \brief Helper function to generate colors per-vertex. Only applies
+      /// to points. The colors fill the normal slots on the vertex buffer.
+      /// \param[in] _opType Ogre render operation type
+      /// \param[in] _vertices a list of vertices
+      /// \param[in,out] _vbuffer vertex buffer to be filled
+      private: void GenerateColors(Ogre::OperationType _opType,
+          const std::vector<math::Vector3d> &_vertices, float *_vbuffer);
+
       /// \brief Destroy the vertex buffer
       private: void DestroyBuffer();
 

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -278,7 +278,6 @@ VisualPtr Ogre2Camera::VisualAt(const ignition::math::Vector2i &_mousePos)
   ignition::math::Vector2i mousePos(
       static_cast<int>(std::rint(ratio * _mousePos.X())),
       static_cast<int>(std::rint(ratio * _mousePos.Y())));
-
   Ogre::Item *ogreItem = this->selectionBuffer->OnSelectionClick(
       mousePos.X(), mousePos.Y());
 

--- a/ogre2/src/Ogre2LidarVisual.cc
+++ b/ogre2/src/Ogre2LidarVisual.cc
@@ -347,6 +347,8 @@ void Ogre2LidarVisual::Update()
       this->dataPtr->deadZoneRayFans[j]->SetPoint(0, this->offset.Pos());
     }
 
+    auto pointMat = this->Scene()->Material("Lidar/BlueRay");
+
     unsigned count = this->horizontalCount;
     // Process each ray in current scan
     for (unsigned int i = 0; i < count; ++i)
@@ -441,14 +443,16 @@ void Ogre2LidarVisual::Update()
         {
           if (this->displayNonHitting || !inf)
           {
-            this->dataPtr->points[j]->AddPoint(inf ? noHitPt: pt);
+            this->dataPtr->points[j]->AddPoint(inf ? noHitPt : pt,
+                pointMat->Diffuse());
           }
         }
         else
         {
           if (this->displayNonHitting || !inf)
           {
-            this->dataPtr->points[j]->SetPoint(i, inf ? noHitPt: pt);
+            this->dataPtr->points[j]->SetPoint(i, inf ? noHitPt : pt);
+            this->dataPtr->points[j]->SetColor(i, pointMat->Diffuse());
           }
         }
       }
@@ -483,12 +487,6 @@ void Ogre2LidarVisual::Update()
     auto pass = this->dataPtr->pointsMat->getTechnique(0)->getPass(0);
     auto vertParams = pass->getVertexProgramParameters();
     vertParams->setNamedConstant("size", static_cast<Ogre::Real>(this->size));
-
-    // support setting color only from diffuse for now
-    MaterialPtr mat = this->Scene()->Material("Lidar/BlueRay");
-    auto fragParams = pass->getFragmentProgramParameters();
-    fragParams->setNamedConstant("color",
-        Ogre2Conversions::Convert(mat->Diffuse()));
   }
 
   // The newly created dynamic lines are having default visibility as true.

--- a/ogre2/src/Ogre2Marker.cc
+++ b/ogre2/src/Ogre2Marker.cc
@@ -112,14 +112,6 @@ void Ogre2Marker::PreRender()
     auto pass = item->getSubItem(0)->getMaterial()->getTechnique(0)->getPass(0);
     auto vertParams = pass->getVertexProgramParameters();
     vertParams->setNamedConstant("size", static_cast<Ogre::Real>(this->size));
-
-    // support setting color only from diffuse for now
-    if (this->dataPtr->material)
-    {
-      auto fragParams = pass->getFragmentProgramParameters();
-      fragParams->setNamedConstant("color",
-          Ogre2Conversions::Convert(this->dataPtr->material->Diffuse()));
-    }
   }
 
   this->dataPtr->dynamicRenderable->Update();

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -144,6 +144,10 @@ RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
 //////////////////////////////////////////////////
 RayQueryResult Ogre2RayQuery::ClosestPointBySelectionBuffer()
 {
+  // update selection buffer dimension in case window is resized
+  this->dataPtr->camera->SelectionBuffer()->SetDimensions(
+    this->dataPtr->camera->ImageWidth(), this->dataPtr->camera->ImageHeight());
+
   RayQueryResult result;
   Ogre::Item *ogreItem = nullptr;
   math::Vector3d point;

--- a/ogre2/src/media/materials/programs/GLSL/point_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/point_fs.glsl
@@ -18,13 +18,11 @@
 #version 330
 
 uniform vec4 color;
+in vec3 ptColor;
 
 out vec4 fragColor;
 
 void main()
 {
-  // todo(anyone) update Ogre2DynamicRenderable to support vertex coloring
-  // so we can set color using the line below
-  // fragColor = gl_Color;
-  fragColor = color;
+  fragColor = vec4(ptColor.x, ptColor.y, ptColor.z, 1);
 }

--- a/ogre2/src/media/materials/programs/GLSL/point_vs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/point_vs.glsl
@@ -18,8 +18,10 @@
 #version 330
 
 in vec4 vertex;
+in vec3 normal;
 uniform mat4 worldViewProj;
 uniform float size;
+out vec3 ptColor;
 
 out gl_PerVertex
 {
@@ -31,4 +33,6 @@ void main()
   // Calculate output position
   gl_Position = worldViewProj * vertex;
   gl_PointSize = size;
+  // We're abusing the normal variable to hold per-point colors
+  ptColor = normal;
 }

--- a/ogre2/src/media/materials/programs/GLSL/selection_buffer_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/selection_buffer_fs.glsl
@@ -25,6 +25,7 @@ in block
 
 uniform sampler2D colorTexture;
 uniform sampler2D depthTexture;
+uniform vec4 colorTexResolution;
 
 out vec4 fragColor;
 
@@ -58,7 +59,8 @@ void main()
     point = vec3(inf);
 
   // color
-  vec4 color = texture(colorTexture, inPs.uv0);
+  vec4 color = texelFetch(colorTexture,
+      ivec2(inPs.uv0 * colorTexResolution.xy), 0);
 
   float rgba = packFloat(color);
 

--- a/ogre2/src/media/materials/scripts/selection_buffer.material
+++ b/ogre2/src/media/materials/scripts/selection_buffer.material
@@ -33,6 +33,8 @@ fragment_program selection_buffer_fs_GLSL glsl
   {
     param_named colorTexture int 0
     param_named depthTexture int 1
+
+    param_named_auto colorTexResolution texture_size 0
   }
 }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -104,7 +104,10 @@ float screenScalingFactor()
 {
   // todo(anyone) set device pixel ratio for high dpi displays on Windows
   float ratio = 1.0;
-#ifdef __linux__
+
+  // the scaling factor seems to cause issues with mouse picking.
+  // see https://github.com/ignitionrobotics/ign-gazebo/issues/147
+#if 0
   auto closeDisplay = [](Display * display)
   {
     if (display)

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -121,15 +121,6 @@ void UtilTest::ClickToScene(const std::string &_renderEngine)
   root->AddChild(camera);
   camera->Update();
 
-  if (_renderEngine == "ogre2")
-  {
-    // tests using selection buffer fail on CI, see issue #170
-    // https://github.com/ignitionrobotics/ign-rendering/issues/170
-    igndbg << "Selection buffer based screenToScene test is disabled in "
-           << _renderEngine << "." << std::endl;
-    return;
-  }
-
   // API without RayQueryResult and default max distance
   result = screenToScene(centerClick, camera, rayQuery, rayResult);
 

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -187,14 +187,6 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
             << _renderEngine << std::endl;
     return;
   }
-  else if (_renderEngine == "ogre2")
-  {
-    // VisualAt tests fail on CI, see issue #170
-    // https://github.com/ignitionrobotics/ign-rendering/issues/170
-    igndbg << "VisualAt test is disabled in " << _renderEngine << "."
-           << std::endl;
-    return;
-  }
 
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
@@ -282,6 +274,27 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
     else
     {
       EXPECT_EQ(nullptr, vis);
+    }
+  }
+
+  // change camera size
+  camera->SetImageWidth(1200);
+  camera->SetImageHeight(800);
+
+  // render a few frames
+  for (auto i = 0; i < 30; ++i)
+  {
+    camera->Update();
+  }
+
+  // test that VisualAt still works after resize
+  {
+    unsigned int x = 300u;
+    auto vis = camera->VisualAt(math::Vector2i(x, camera->ImageHeight() / 2));
+    EXPECT_NE(nullptr, vis) << "X: " << x;
+    if (vis)
+    {
+      EXPECT_EQ("sphere", vis->Name());
     }
   }
 

--- a/test/integration/scene.cc
+++ b/test/integration/scene.cc
@@ -154,14 +154,6 @@ void SceneTest::VisualAt(const std::string &_renderEngine)
             << _renderEngine << std::endl;
     return;
   }
-  else if (_renderEngine == "ogre2")
-  {
-    // VisualAt tests fail on CI, see issue #170
-    // https://github.com/ignitionrobotics/ign-rendering/issues/170
-    igndbg << "VisualAt test is disabled in " << _renderEngine << "."
-           << std::endl;
-    return;
-  }
 
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);


### PR DESCRIPTION
# 🎉 New feature

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1156
* Needed by https://github.com/ignitionrobotics/ign-gui/pull/318

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

We have been populating the `colors` vector in `Ogre2DynamicRenderable`, but not using the colors for anything.

For most dynamic renderables, we fill the vertex buffer with position and normal. But points don't have normals, so we've been leaving half the buffer empty. The implementation on this PR takes advantage of those empty slots to place per-point colors (only RGB, no A).

Thanks @WilliamLewww for helping me out with this!

## Test it
<!--Explain how reviewers can test this new feature manually.-->

The marker example on https://github.com/ignitionrobotics/ign-gui/pull/318 uses this:

![pts_color](https://user-images.githubusercontent.com/5751272/144187977-a2698f43-38fd-45fd-ac8b-b08985334d97.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
