### PR TITLE
Update Metal depth camera and selection buffer shaders to match #446

### DIFF
--- a/ogre2/src/media/materials/programs/Metal/depth_camera_final_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_final_fs.metal
@@ -49,9 +49,10 @@ fragment float4 main_metal
   // values close to 0 get rounded to 0)
   //
   // See https://github.com/ignitionrobotics/ign-rendering/issues/332
-  // float4 p = texelFetch(inputTexture, int2(inPs.uv0 * params.texResolution.xy), 0);
-  // TODO - establish Metal equivalent - use standard sampler as interim approx.
-  float4 p = inputTexture.sample(inputSampler, inPs.uv0);
+  // Either: Metal equivalent of texelFetch
+  float4 p = inputTexture.read(uint2(inPs.uv0 * params.texResolution.xy), 0);
+  // Or: Use standard sampler
+  // float4 p = inputTexture.sample(inputSampler, inPs.uv0);
 
   float3 point = p.xyz;
 

--- a/ogre2/src/media/materials/programs/Metal/selection_buffer_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/selection_buffer_fs.metal
@@ -29,6 +29,7 @@ struct Params
   float2  projectionParams;
   float   far;
   float   inf;
+  float4  colorTexResolution;
 };
 
 float packFloat(float4 color)
@@ -66,7 +67,11 @@ fragment float4 main_metal
     point = float3(p.inf);
 
   // color
-  float4 color = colorTexture.sample(colorSampler, inPs.uv0);
+  // Either: Metal equivalent of texelFetch
+  float4 color = colorTexture.read(
+      uint2(inPs.uv0 * p.colorTexResolution.xy), 0);
+  // Or: Use standard sampler
+  // float4 color = colorTexture.sample(colorSampler, inPs.uv0);
 
   float rgba = packFloat(color);
 


### PR DESCRIPTION
# 🦟 Bug fix

Apply #446 to Metal shaders

## Summary

This PR applies #446 to Metal shaders and updates them to use the Metal equivalent of OpenGL's `texelFetch` (which is `texture.read()`). Previously the depth camera and selection buffer Metal shaders were using a standard texture sampler accepting normalised coordinates and ignored the texture resolution uniform parameter.

## Testing

Currently there are no automated tests for the Metal shaders. Tested manually using the `ogre2demo` and `mouse_picking` examples and also `ign gazebo` (by cherry-picking this change into `main` to build the gui and gazebo libraries). 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**