### PR TITLE
Partial fix for emissive map

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -541,7 +541,8 @@ void Ogre2Material::ClearLightMap()
   this->lightMapUvSet = 0u;
 
   // in ogre 2.2, we swtiched to use the emissive map slot for light map
-  this->ogreDatablock->setTexture(Ogre::PBSM_EMISSIVE, this->lightMapName);
+  if (this->ogreDatablock->getUseEmissiveAsLightmap())
+    this->ogreDatablock->setTexture(Ogre::PBSM_EMISSIVE, this->lightMapName);
   this->ogreDatablock->setUseEmissiveAsLightmap(false);
 }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Partial fix for #499 

## Summary

When porting to ogre 2.2, lightmap and emissive map share the same texture slot. The fix adds a check to make sure we don't accidentally clear the emissive map when clearing out the lightmap texture.

There is still an issue of using grayscale emissive maps, in ogre2.2 it's being treated as RGB and so it's rendered red. This needs to be fixed next.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

