### PR TITLE
Check for OpenGL backend before calling GL APIs

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -979,8 +979,9 @@ void Ogre2DepthCamera::Render()
   auto engine = Ogre2RenderEngine::Instance();
   std::string renderSystemName =
       engine->OgreRoot()->getRenderSystem()->getFriendlyName();
+  bool useGL = renderSystemName.find("OpenGL") != std::string::npos;
 #ifndef _WIN32
-  if (renderSystemName.find("OpenGL") != std::string::npos)
+  if (useGL)
     glEnable(GL_DEPTH_CLAMP);
 #endif
 
@@ -999,7 +1000,7 @@ void Ogre2DepthCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
 #ifndef _WIN32
-  if (renderSystemName.find("OpenGL") != std::string::npos)
+  if (useGL)
     glDisable(GL_DEPTH_CLAMP);
 #endif
 }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -976,8 +976,12 @@ void Ogre2DepthCamera::Render()
 {
   // GL_DEPTH_CLAMP was disabled in later version of ogre2.2
   // however our shaders rely on clamped values so enable it for this sensor
+  auto engine = Ogre2RenderEngine::Instance();
+  std::string renderSystemName =
+      engine->OgreRoot()->getRenderSystem()->getFriendlyName();
 #ifndef _WIN32
-  glEnable(GL_DEPTH_CLAMP);
+  if (renderSystemName.find("OpenGL") != std::string::npos)
+    glEnable(GL_DEPTH_CLAMP);
 #endif
 
   this->scene->StartRendering(this->ogreCamera);
@@ -995,7 +999,8 @@ void Ogre2DepthCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
 #ifndef _WIN32
-  glDisable(GL_DEPTH_CLAMP);
+  if (renderSystemName.find("OpenGL") != std::string::npos)
+    glDisable(GL_DEPTH_CLAMP);
 #endif
 }
 

--- a/ogre2/src/Ogre2LidarVisual.cc
+++ b/ogre2/src/Ogre2LidarVisual.cc
@@ -30,6 +30,7 @@
 #include "ignition/rendering/ogre2/Ogre2Conversions.hh"
 #include "ignition/rendering/ogre2/Ogre2DynamicRenderable.hh"
 #include "ignition/rendering/ogre2/Ogre2LidarVisual.hh"
+#include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2Marker.hh"
 #include "ignition/rendering/ogre2/Ogre2Geometry.hh"
@@ -39,6 +40,7 @@
 #endif
 #include <OgreItem.h>
 #include <OgreMaterialManager.h>
+#include <OgreRoot.h>
 #include <OgreSceneNode.h>
 #include <OgreTechnique.h>
 #ifdef _MSC_VER
@@ -153,13 +155,19 @@ void Ogre2LidarVisual::Init()
 void Ogre2LidarVisual::Create()
 {
   // enable GL_PROGRAM_POINT_SIZE so we can set gl_PointSize in vertex shader
+  auto engine = Ogre2RenderEngine::Instance();
+  std::string renderSystemName =
+      engine->OgreRoot()->getRenderSystem()->getFriendlyName();
+  if (renderSystemName.find("OpenGL") != std::string::npos)
+  {
 #ifdef __APPLE__
-  glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
+    glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
 #else
 #ifndef _WIN32
-  glEnable(GL_PROGRAM_POINT_SIZE);
+    glEnable(GL_PROGRAM_POINT_SIZE);
 #endif
 #endif
+  }
   this->dataPtr->pointsMat =
       Ogre::MaterialManager::getSingleton().getByName(
       "PointCloudPoint");

--- a/ogre2/src/Ogre2Marker.cc
+++ b/ogre2/src/Ogre2Marker.cc
@@ -36,6 +36,7 @@
 #include "ignition/rendering/ogre2/Ogre2Marker.hh"
 #include "ignition/rendering/ogre2/Ogre2Material.hh"
 #include "ignition/rendering/ogre2/Ogre2Mesh.hh"
+#include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 #include "ignition/rendering/ogre2/Ogre2Scene.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
 
@@ -44,6 +45,7 @@
 #endif
 #include <OgreItem.h>
 #include <OgreMaterialManager.h>
+#include <OgreRoot.h>
 #include <OgreTechnique.h>
 #ifdef _MSC_VER
   #pragma warning(pop)
@@ -94,6 +96,11 @@ void Ogre2Marker::PreRender()
     {
       // enable GL_PROGRAM_POINT_SIZE so we can set gl_PointSize in vertex
       // shader
+      auto engine = Ogre2RenderEngine::Instance();
+      std::string renderSystemName =
+          engine->OgreRoot()->getRenderSystem()->getFriendlyName();
+      if (renderSystemName.find("OpenGL") != std::string::npos)
+      {
       #ifdef __APPLE__
         glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
       #else
@@ -101,6 +108,7 @@ void Ogre2Marker::PreRender()
         glEnable(GL_PROGRAM_POINT_SIZE);
       #endif
       #endif
+      }
       Ogre::MaterialPtr pointsMat =
           Ogre::MaterialManager::getSingleton().getByName(
           "PointCloudPoint");

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -839,8 +839,9 @@ void Ogre2ThermalCamera::Render()
   auto engine = Ogre2RenderEngine::Instance();
   std::string renderSystemName =
       engine->OgreRoot()->getRenderSystem()->getFriendlyName();
+  bool useGL = renderSystemName.find("OpenGL") != std::string::npos;
 #ifndef _WIN32
-  if (renderSystemName.find("OpenGL") != std::string::npos)
+  if (useGL)
     glEnable(GL_DEPTH_CLAMP);
 #endif
 
@@ -859,7 +860,7 @@ void Ogre2ThermalCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
 #ifndef _WIN32
-  if (renderSystemName.find("OpenGL") != std::string::npos)
+  if (useGL)
     glDisable(GL_DEPTH_CLAMP);
 #endif
 }

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -836,8 +836,12 @@ void Ogre2ThermalCamera::Render()
 {
   // GL_DEPTH_CLAMP is disabled in later version of ogre2.2
   // however our shaders rely on clamped values so enable it for this sensor
+  auto engine = Ogre2RenderEngine::Instance();
+  std::string renderSystemName =
+      engine->OgreRoot()->getRenderSystem()->getFriendlyName();
 #ifndef _WIN32
-  glEnable(GL_DEPTH_CLAMP);
+  if (renderSystemName.find("OpenGL") != std::string::npos)
+    glEnable(GL_DEPTH_CLAMP);
 #endif
 
   // update the compositors
@@ -855,7 +859,8 @@ void Ogre2ThermalCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
 #ifndef _WIN32
-  glDisable(GL_DEPTH_CLAMP);
+  if (renderSystemName.find("OpenGL") != std::string::npos)
+    glDisable(GL_DEPTH_CLAMP);
 #endif
 }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

fixes issue found in this comment: https://github.com/ignitionrobotics/ign-gui/pull/323#issuecomment-989142005

## Summary

Now that here is support for more than just OpenGL graphics API, we should check that the OpenGL render system is actually in use before making GL calls.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

