### PR TITLE
Enable selection buffer based ray query (ogre2)

### DIFF
--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -95,11 +95,6 @@ RayQueryResult Ogre2RayQuery::ClosestPoint()
 {
   RayQueryResult result;
 
-  // ray query using selection buffer does not seem to work on some machines
-  // using cpu based ray-triangle intersection method
-  // \todo remove this line if selection buffer is working again
-  return this->ClosestPointByIntersection();
-
 #ifdef __APPLE__
   return this->ClosestPointByIntersection();
 #else

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -121,6 +121,16 @@ void UtilTest::ClickToScene(const std::string &_renderEngine)
   root->AddChild(camera);
   camera->Update();
 
+  // \todo(anyone)
+  // the centerClick var above is set to a screen pos of (width/2, height/2).
+  // This is off-by-1. The actual center pos should be at
+  // (width/2 - 1, height/2 - 1) so the result.X() and result.Y() is a bit off
+  // from the expected position. However, fixing the centerClick above caused
+  // the screenToPlane tests to fail so only modifying the pos here, and the
+  // cause of test failure need to be investigated.
+  if (_renderEngine == "ogre2")
+    centerClick = ignition::math::Vector2i(halfWidth-1, halfHeight-1);
+
   // API without RayQueryResult and default max distance
   result = screenToScene(centerClick, camera, rayQuery, rayResult);
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

https://github.com/ignitionrobotics/ign-rendering/pull/446 made a few fixes to selection buffer for mouse picking and got the tests to pass but it didn't remove [the code](https://github.com/ignitionrobotics/ign-rendering/pull/447) that disabled this feature. So currently mouse pickin is still based on the triangle intersection based method.

This PR enables ray queries using selection buffer in ogre2 again. I brought [this commit](https://github.com/ignitionrobotics/ign-rendering/commit/bfb22fb1f9bee5643c4407ae05ec24857c200bbf#) back to fix the Utils test.

## To test:

run the fortress demo world and mouse orbit control should be smoother.

```
ign gazebo -v 4 -r "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Fortress demo"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

