### PR TITLE
RenderOrder is in different scale in Reverse Z

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -281,7 +281,22 @@ void Ogre2Material::SetRenderOrder(const float _renderOrder)
   this->renderOrder = _renderOrder;
   Ogre::HlmsMacroblock macroblock(
       *this->ogreDatablock->getMacroblock());
-  macroblock.mDepthBiasConstant = _renderOrder;
+
+  Ogre::Root *root = Ogre2RenderEngine::Instance()->OgreRoot();
+  Ogre::RenderSystem *renderSystem = root->getRenderSystem();
+
+  if (renderSystem->isReverseDepth())
+  {
+    // Reverse depth needs 100x scale AND ends up being superior
+    // See https://github.com/ignitionrobotics/ign-rendering/
+    // issues/427#issuecomment-991800352
+    // and see https://www.youtube.com/watch?v=s2XdH3fYUac
+    macroblock.mDepthBiasConstant = _renderOrder * 100.0f;
+  }
+  else
+  {
+    macroblock.mDepthBiasConstant = _renderOrder;
+  }
   this->ogreDatablock->setMacroblock(macroblock);
 }
 


### PR DESCRIPTION
I could not find info online about this problem, so i had to write a
test myself.

The obvious solution is to multiply the depth bias by 100 or so; but I
was wondering what would be the side effects on other geometry.

I.e. what would happen to geometry that is meant to be in front of the
plane? We know a depth bias of 300 works at close range at reverse Z
(where at normal Z a depth bias of 3 was enough), but would the plane
get on top of everything as you move the camera away?

So I made a test: https://www.youtube.com/watch?v=s2XdH3fYUac

We can safely multiply by something like 100 or so, and we will get
better results with reverse Z than we could with normal Z + the usual
depth bias constant scale.

With Normal Z, wven with a depth bias of 3 will eventually be on top of
everything, but with Reverse Z + depth bias of 300, that never happens.

Apparently multiplying the constant bias by 100.0f *is* the right thing
to do.

Fixes #427

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

Fixes #427 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
