### PR TITLE
Fix sky background in RGBD camera

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -695,9 +695,9 @@ void Ogre2DepthCamera::CreateDepthTexture()
         baseNodeDef->addTargetPass("colorTexture");
 
     if (validBackground)
-      colorTargetDef->setNumPasses(2);
+      colorTargetDef->setNumPasses(3);
     else
-      colorTargetDef->setNumPasses(1);
+      colorTargetDef->setNumPasses(2);
     {
       // scene pass - opaque
       {

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -479,6 +479,11 @@ void Ogre2DepthCamera::CreateDepthTexture()
   bool validBackground = backgroundMaterial &&
       !backgroundMaterial->EnvironmentMap().empty();
 
+  // let depth camera shader know if there is background material
+  // This is needed for manual clipping of color pixel values.
+  psParams->setNamedConstant("hasBackground",
+      static_cast<int>(validBackground));
+
   if (validBackground)
   {
     Ogre::MaterialManager &matManager = Ogre::MaterialManager::getSingleton();

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -185,9 +185,9 @@ void Ogre2RenderTarget::BuildCompositor()
         nodeDef->addTargetPass("rtv");
 
     if (validBackground)
-      rt0TargetDef->setNumPasses(2);
+      rt0TargetDef->setNumPasses(3);
     else
-      rt0TargetDef->setNumPasses(1);
+      rt0TargetDef->setNumPasses(2);
     {
       // scene pass - opaque
       {

--- a/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
@@ -150,14 +150,6 @@ void main()
     {
       point.x = max;
     }
-    // clamp to background color only if it is not a particle pixel
-    // this is because point.x may have been set to background depth value
-    // due to the scatter effect. We should still render particles in the color
-    // image
-    if (particle.x < 1e-6)
-    {
-      color = vec4(backgroundColor, 1.0);
-    }
   }
   else if (point.x < near + tolerance)
   {
@@ -168,12 +160,6 @@ void main()
     else
     {
       point.x = min;
-    }
-
-    // clamp to background color only if it is not a particle pixel
-    if (particle.x < 1e-6)
-    {
-      color = vec4(backgroundColor, 1.0);
     }
   }
 

--- a/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
@@ -36,6 +36,7 @@ uniform float far;
 uniform float min;
 uniform float max;
 uniform vec3 backgroundColor;
+uniform int hasBackground;
 
 uniform float particleStddev;
 uniform float particleScatterRatio;
@@ -150,6 +151,15 @@ void main()
     {
       point.x = max;
     }
+    // clamp to background color only if it is not a particle pixel
+    // this is because point.x may have been set to background depth value
+    // due to the scatter effect. We should still render particles in the color
+    // image
+    // todo(iche033) handle case when background is a cubemap
+    if (hasBackground == 0 && particle.x < 1e-6)
+    {
+      color = vec4(backgroundColor, 1.0);
+    }
   }
   else if (point.x < near + tolerance)
   {
@@ -160,6 +170,13 @@ void main()
     else
     {
       point.x = min;
+    }
+
+    // clamp to background color only if it is not a particle pixel
+    // todo(iche033) handle case when background is a cubemap
+    if (hasBackground == 0 && particle.x < 1e-6)
+    {
+      color = vec4(backgroundColor, 1.0);
     }
   }
 

--- a/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
@@ -161,14 +161,6 @@ fragment float4 main_metal
     {
       point.x = p.max;
     }
-    // clamp to background color only if it is not a particle pixel
-    // this is because point.x may have been set to background depth value
-    // due to the scatter effect. We should still render particles in the color
-    // image
-    if (particle.x < 1e-6)
-    {
-      color = float4(p.backgroundColor, 1.0);
-    }
   }
   else if (point.x < p.near + tolerance)
   {
@@ -179,12 +171,6 @@ fragment float4 main_metal
     else
     {
       point.x = p.min;
-    }
-
-    // clamp to background color only if it is not a particle pixel
-    if (particle.x < 1e-6)
-    {
-      color = float4(p.backgroundColor, 1.0);
     }
   }
 

--- a/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
- 
+
 // For details and documentation see: depth_camera_fs.glsl
 
 #include <metal_stdlib>
@@ -34,6 +34,7 @@ struct Params
   float min;
   float max;
   float3 backgroundColor;
+  int hasBackground;
 
   float particleStddev;
   float particleScatterRatio;
@@ -161,6 +162,15 @@ fragment float4 main_metal
     {
       point.x = p.max;
     }
+    // clamp to background color only if it is not a particle pixel
+    // this is because point.x may have been set to background depth value
+    // due to the scatter effect. We should still render particles in the color
+    // image
+    // todo(iche033) handle case when background is a cubemap
+    if (hasBackground == 0 && particle.x < 1e-6)
+    {
+      color = float4(p.backgroundColor, 1.0);
+    }
   }
   else if (point.x < p.near + tolerance)
   {
@@ -171,6 +181,13 @@ fragment float4 main_metal
     else
     {
       point.x = p.min;
+    }
+
+    // clamp to background color only if it is not a particle pixel
+    // todo(iche033) handle case when background is a cubemap
+    if (hasBackground == 0 && particle.x < 1e-6)
+    {
+      color = float4(p.backgroundColor, 1.0);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix



## Summary

Updated shaders so that it does not incorrectly assume that the background is just a plain color.

Added a todo note about doing coming up with a better way of doing manual clipping of color values.

To test:

You can test with this world: [sensor_particles.sdf](https://gist.github.com/iche033/26888ed86b27f824e5979c385ea393f1) world file.

```
ign gazebo -v 4 sensor_particles.sdf
```

You should see that the RGBD camera now shows the sky background in the `RGBD: image` Image Display plugin.
![rgbd_sky](https://user-images.githubusercontent.com/4000684/146624924-63177a18-8a2f-4528-8f66-c7e61efb3462.png)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

