### PR TITLE
Fix color of last / extra marker points

### DIFF
--- a/ogre2/src/Ogre2DynamicRenderable.cc
+++ b/ogre2/src/Ogre2DynamicRenderable.cc
@@ -311,8 +311,7 @@ void Ogre2DynamicRenderable::UpdateBuffer()
 
   // fill the rest of the buffer with the position of the last vertex to avoid
   // the geometry connecting back to 0, 0, 0
-  if (vertexCount > 0 && vertexCount < this->dataPtr->vertexBufferCapacity &&
-      this->dataPtr->operationType != Ogre::OperationType::OT_POINT_LIST)
+  if (vertexCount > 0 && vertexCount < this->dataPtr->vertexBufferCapacity)
   {
     math::Vector3d lastVertex = this->dataPtr->vertices[vertexCount-1];
     for (unsigned int i = vertexCount; i < this->dataPtr->vertexBufferCapacity;
@@ -723,9 +722,8 @@ void Ogre2DynamicRenderable::GenerateNormals(Ogre::OperationType _opType,
 void Ogre2DynamicRenderable::GenerateColors(Ogre::OperationType _opType,
   const std::vector<math::Vector3d> &_vertices, float *_vbuffer)
 {
-  unsigned int vertexCount = _vertices.size();
   // Skip if colors haven't been setup per-vertex correctly.
-  if (vertexCount != this->dataPtr->colors.size())
+  if (_vertices.size() != this->dataPtr->colors.size())
     return;
 
   // Each vertex occupies 6 elements in the vbuffer float array. Normally,
@@ -741,9 +739,10 @@ void Ogre2DynamicRenderable::GenerateColors(Ogre::OperationType _opType,
   {
     case Ogre::OperationType::OT_POINT_LIST:
     {
-      for (unsigned int i = 0; i < vertexCount; ++i)
+      for (unsigned int i = 0; i < this->dataPtr->vertexBufferCapacity; ++i)
       {
-        auto color = this->dataPtr->colors[i];
+        math::Color color = i < this->dataPtr->colors.size() ?
+            this->dataPtr->colors[i] : this->dataPtr->colors.back();
 
         unsigned int idx = i * 6;
         _vbuffer[idx+3] = color.R();


### PR DESCRIPTION
# 🦟 Bug fix

* Follow up to #494 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

On #494 I had skipped filling the rest of the buffer for points because that was adding multiple points to the end of the cloud with the color blue. What I didn't notice is that I swapped the "last blue points" for "extra black point at the origin" :upside_down_face: 

* "last blue points" issue: the end of the vertex buffer is filled with points that have a Z normal (0,0,1 : blue) and coincide with the last point
* "extra black point at the origin": if the vertex buffer isn't filled completely with points, it's filled with zeroes (origin position, black color)

The  solution here is to first fill the buffer with blue normals, then override that with the color of the last point. I did this to match the implementation for other markers and reduce the amount of code changes, but some drawbacks to this approach are:

* We have multiple overlapping points in one place, which could be a bit wasteful depending on the size of the buffer. Ideally it would be good to shrink the buffer, but I don't know if that's possible.
* We're assigning the colors to the buffer twice, but we should be able to do it only once
* I think other markers may be suffering from the same problem, but ending up with Z normals instead of blue colors. That's because `GenerateNormals` is not using the whole `vertexBufferCapacity`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests - I don't know how to
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
