### PR TITLE
Support using custom shader materials and updating uniform variables (ogre2)

### DIFF
--- a/examples/custom_shaders_uniforms/GlutWindow.cc
+++ b/examples/custom_shaders_uniforms/GlutWindow.cc
@@ -111,6 +111,8 @@ void updateCameras()
 //! [update uniforms]
 void updateUniforms()
 {
+  if (!g_shaderParams)
+    return;
   (*g_shaderParams)["u_seed"].UpdateBuffer(g_seed);
   (*g_shaderParams)["u_resolution"].UpdateBuffer(g_resolution);
   (*g_shaderParams)["u_color"].UpdateBuffer(g_color);
@@ -200,6 +202,8 @@ void initUniforms()
   ir::VisualPtr sphere =
       std::dynamic_pointer_cast<ir::Visual>(node->ChildByName("box"));
   ir::MaterialPtr shader = sphere->Material();
+  if (!shader)
+    return;
   g_shaderParams = shader->FragmentShaderParams();
 
   (*g_shaderParams)["u_seed"].InitializeBuffer(1);

--- a/examples/custom_shaders_uniforms/Main.cc
+++ b/examples/custom_shaders_uniforms/Main.cc
@@ -68,7 +68,7 @@ void buildScene(ScenePtr _scene, const std::string &_engineName)
   light0->SetSpecularColor(0.5, 0.5, 0.5);
   root->AddChild(light0);
 
-  t std::string vertexShaderFile;
+  std::string vertexShaderFile;
   std::string fragmentShaderFile;
   if (_engineName == "ogre2")
   {

--- a/examples/custom_shaders_uniforms/Main.cc
+++ b/examples/custom_shaders_uniforms/Main.cc
@@ -175,7 +175,7 @@ int main(int _argc, char** _argv)
       {
         // \todo(anyone) uncomment once metal shaders are available
         // params["metal"] = "1";
-        ignerr << "Metal shaders are not implemented yet. Using GSLS" << std::endl;
+        ignerr << "Metal shaders are not implemented yet. Using GLSL" << std::endl;
       }
 
       CameraPtr camera = createCamera(engineName, params);

--- a/examples/custom_shaders_uniforms/media/fragment_shader.glsl
+++ b/examples/custom_shaders_uniforms/media/fragment_shader.glsl
@@ -1,6 +1,23 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #define M_PI 3.1415926535897932384626433832795
 
-varying vec3 interpolatedPosition;
+varying vec4 interpolatedPosition;
 
 uniform int u_seed;
 uniform vec2 u_resolution;
@@ -14,9 +31,9 @@ float random(vec2 uv, float seed) {
 void main()
 {
   vec3 a = vec3(u_adjustments[0][0], u_adjustments[1][0], u_adjustments[2][0]);
-  vec2 b = vec2(distance(interpolatedPosition, a)) * u_adjustments[3][0];
+  vec2 b = vec2(distance(vec3(interpolatedPosition.xyw), a)) * u_adjustments[3][0];
   vec2 normalizedFragCoord = b / u_resolution;
 
-  vec3 color = vec3(random(normalizedFragCoord, u_seed));
+  vec3 color = vec3(random(normalizedFragCoord, float(u_seed)));
   gl_FragColor = vec4(color * u_color, 1.0);
 }

--- a/examples/custom_shaders_uniforms/media/fragment_shader_330.glsl
+++ b/examples/custom_shaders_uniforms/media/fragment_shader_330.glsl
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#version 330
+
+#define M_PI 3.1415926535897932384626433832795
+
+uniform int u_seed;
+uniform vec2 u_resolution;
+uniform vec3 u_color;
+uniform mat4 u_adjustments;
+
+in vec4 interpolatedPosition;
+
+out vec4 fragColor;
+
+float random(vec2 uv, float seed) {
+  return fract(sin(mod(dot(uv, vec2(12.9898, 78.233)) + 1113.1 * seed, M_PI)) * 43758.5453);;
+}
+
+void main()
+{
+  vec3 a = vec3(u_adjustments[0][0], u_adjustments[1][0], u_adjustments[2][0]);
+  vec2 b = vec2(distance(vec3(interpolatedPosition.xyw), a)) * u_adjustments[3][0];
+  vec2 normalizedFragCoord = b / u_resolution;
+
+  vec3 color = vec3(random(normalizedFragCoord, float(u_seed)));
+  fragColor = vec4(color * u_color, 1.0);
+}

--- a/examples/custom_shaders_uniforms/media/vertex_shader.glsl
+++ b/examples/custom_shaders_uniforms/media/vertex_shader.glsl
@@ -1,7 +1,24 @@
-varying vec3 interpolatedPosition;
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+varying vec4 interpolatedPosition;
 
 void main()
 {
   gl_Position = ftransform();
-  interpolatedPosition = gl_Position.xyz;
+  interpolatedPosition = gl_Position;
 }

--- a/examples/custom_shaders_uniforms/media/vertex_shader_330.glsl
+++ b/examples/custom_shaders_uniforms/media/vertex_shader_330.glsl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#version 330
+
+in vec4 vertex;
+uniform mat4 worldViewProj;
+
+out gl_PerVertex
+{
+  vec4 gl_Position;
+};
+
+out vec4 interpolatedPosition;
+
+void main()
+{
+  gl_Position = worldViewProj * vertex;
+  interpolatedPosition = gl_Position;
+}
+

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
@@ -241,6 +241,32 @@ namespace ignition
       // Documentation inherited
       public: virtual void SetDepthWriteEnabled(bool _enabled) override;
 
+      // Documentation inherited.
+      // \sa Material::SetVertexShader(const std::string &)
+      public: virtual void SetVertexShader(const std::string &_path) override;
+
+      // Documentation inherited.
+      // \sa Material::VertexShader() const
+      public: virtual std::string VertexShader() const override;
+
+      // Documentation inherited.
+      // \sa Material::VertexShaderParams()
+      public: virtual ShaderParamsPtr VertexShaderParams() override;
+
+      // Documentation inherited.
+      // \sa Material::SetFragmentShader(const std::string &)
+      public: virtual void SetFragmentShader(const std::string &_path)
+                  override;
+
+      // Documentation inherited.
+      // \sa Material::FragmentShader() const
+      public: virtual std::string FragmentShader() const override;
+
+      // Documentation inherited.
+      // \sa Material::FragmentShaderParams()
+      public: virtual ShaderParamsPtr FragmentShaderParams() override;
+
+
       /// \brief Set the texture map for this material
       /// \param[in] _texture Name of the texture.
       /// \param[in] _type Type of texture, i.e. diffuse, normal, roughness,

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Material.hh
@@ -27,6 +27,7 @@
   #pragma warning(push, 0)
 #endif
 #include <Hlms/Pbs/OgreHlmsPbsPrerequisites.h>
+#include <OgreGpuProgramParams.h>
 #include <OgreMaterial.h>
 #ifdef _MSC_VER
   #pragma warning(pop)
@@ -266,7 +267,6 @@ namespace ignition
       // \sa Material::FragmentShaderParams()
       public: virtual ShaderParamsPtr FragmentShaderParams() override;
 
-
       /// \brief Set the texture map for this material
       /// \param[in] _texture Name of the texture.
       /// \param[in] _type Type of texture, i.e. diffuse, normal, roughness,
@@ -284,6 +284,15 @@ namespace ignition
 
       // Documentation inherited.
       protected: virtual void Init() override;
+
+      /// \brief bind shader parameters that have changed
+      protected: void UpdateShaderParams();
+
+      /// \brief Transfer params from ign-rendering type to ogre type
+      /// \param[in] _params ignition rendering params
+      /// \param[out] _ogreParams ogre type for holding params
+      protected: void UpdateShaderParams(ConstShaderParamsPtr _params,
+          Ogre::GpuProgramParametersSharedPtr _ogreParams);
 
       /// \brief  Ogre material. Mainly used for render targets.
       protected: Ogre::MaterialPtr ogreMaterial;

--- a/ogre2/src/Ogre2Mesh.cc
+++ b/ogre2/src/Ogre2Mesh.cc
@@ -346,8 +346,17 @@ void Ogre2SubMesh::SetMaterialImpl(MaterialPtr _material)
     return;
   }
 
-  this->ogreSubItem->setDatablock(
-      static_cast<Ogre::HlmsPbsDatablock *>(derived->Datablock()));
+  // low level material with custom shaders
+  if (!derived->FragmentShader().empty() && !derived->VertexShader().empty())
+  {
+    this->ogreSubItem->setMaterial(derived->Material());
+  }
+  // Pbs Hlms material
+  else
+  {
+    this->ogreSubItem->setDatablock(
+        static_cast<Ogre::HlmsPbsDatablock *>(derived->Datablock()));
+  }
 
   // set cast shadows
   this->ogreSubItem->getParent()->setCastShadows(_material->CastShadows());

--- a/src/ShaderParam.cc
+++ b/src/ShaderParam.cc
@@ -37,7 +37,7 @@ class ignition::rendering::ShaderParamPrivate
   public: std::shared_ptr<void> buffer;
 
   /// \brief Count of elements in buffer of parameter held
-  public: uint32_t count;
+  public: uint32_t count = 0u;
 };
 
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Implemented code to supported loading custom shader material and updating their uniform variables.

Extended the `custom_shaders_uniforms` to run with ogre2 render engine. Note I made a slight tweak to the shader code in the demo to make the ogre 1.x and ogre 2.x behavior more consistent. When running with `ogre2`, the clip space z pos returned by `gl_Position.z` is different from `ogre` so it was rendering slightly different visual effect.

To test:

build and run the [custom_shaders_uniforms](https://github.com/ignitionrobotics/ign-rendering/tree/dc4e4c1f480e109bd9b15920300d2c9e49796f36/examples/custom_shaders_uniforms) demo:

```
./custom_shaders_uniforms ogre2
```

![custom_shader_uniforms_ogre2](https://user-images.githubusercontent.com/4000684/147301438-55d3f000-9d24-456a-b37a-7504dc450671.png)


