### PR TITLE
Fix Ogre2ThermalCamera using garbage depth data

### DIFF
--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -659,6 +659,12 @@ void Ogre2ThermalCamera::CreateThermalTexture()
   //   in 0 rt_input
   //   texture depthTexture target_width target_height PFG_D32_FLOAT
   //   texture colorTexture target_width target_height PFG_RGBA8_UNORM
+  //
+  //   rtv colorTexture
+  //   {
+  //     depth depthTexture
+  //   }
+  //
   //   target colorTexture
   //   {
   //     pass clear
@@ -712,10 +718,6 @@ void Ogre2ThermalCamera::CreateThermalTexture()
     thermalTexDef->depthBufferId = Ogre::DepthBuffer::POOL_DEFAULT;
     thermalTexDef->depthBufferFormat = Ogre::PFG_UNKNOWN;
 
-    Ogre::RenderTargetViewDef *rtv =
-      nodeDef->addRenderTextureView("depthTexture");
-    rtv->setForTextureDefinition("depthTexture", thermalTexDef);
-
     Ogre::TextureDefinitionBase::TextureDefinition *colorTexDef =
         nodeDef->addTextureDefinition("colorTexture");
     colorTexDef->textureType = Ogre::TextureTypes::Type2D;
@@ -731,9 +733,10 @@ void Ogre2ThermalCamera::CreateThermalTexture()
     colorTexDef->depthBufferFormat = Ogre::PFG_D32_FLOAT;
     colorTexDef->preferDepthTexture = true;
 
-    Ogre::RenderTargetViewDef *rtv2 =
+    Ogre::RenderTargetViewDef *rtv =
       nodeDef->addRenderTextureView("colorTexture");
-    rtv2->setForTextureDefinition("colorTexture", colorTexDef);
+    rtv->setForTextureDefinition("colorTexture", colorTexDef);
+    rtv->depthAttachment.textureName = "depthTexture";
 
     nodeDef->setNumTargetPass(2);
     Ogre::CompositorTargetDef *colorTargetDef =


### PR DESCRIPTION
## Summary

The depth buffer is created but never filled with anything.
As a result it contains uninitialized values (likely 0.0f but it's not
guaranteed)

This bug seems to have been introduced when ported to Ogre 2.2

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

No ticket created for this

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
