### PR TITLE
Performance optimization by avoiding unnecessary passes

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -670,11 +670,6 @@ void Ogre2DepthCamera::CreateDepthTexture()
     particleTexDef->preferDepthTexture = false;
     particleTexDef->fsaa = "0";
 
-    Ogre::RenderTargetViewDef *rtvParticleTexture =
-      baseNodeDef->addRenderTextureView("particleTexture");
-    rtvParticleTexture->setForTextureDefinition(
-      "particleTexture", particleTexDef);
-
     Ogre::TextureDefinitionBase::TextureDefinition *particleDepthTexDef =
         baseNodeDef->addTextureDefinition("particleDepthTexture");
     particleDepthTexDef->textureType = Ogre::TextureTypes::Type2D;
@@ -690,12 +685,15 @@ void Ogre2DepthCamera::CreateDepthTexture()
     particleDepthTexDef->fsaa = "0";
     particleDepthTexDef->textureFlags &= ~Ogre::TextureFlags::Uav;
 
-    Ogre::RenderTargetViewDef *rtvparticleDepthTex =
-      baseNodeDef->addRenderTextureView("particleDepthTexture");
-    rtvparticleDepthTex->setForTextureDefinition(
-      "particleDepthTexture", particleDepthTexDef);
+    // Auto setup the RTV then manually override the depth buffer so
+    // it uses the one we created (and thus we can sample from it later)
+    Ogre::RenderTargetViewDef *rtvParticleTexture =
+      baseNodeDef->addRenderTextureView("particleTexture");
+    rtvParticleTexture->setForTextureDefinition("particleTexture",
+                                                particleTexDef);
+    rtvParticleTexture->depthAttachment.textureName = "particleDepthTexture";
 
-    baseNodeDef->setNumTargetPass(5);
+    baseNodeDef->setNumTargetPass(4);
     Ogre::CompositorTargetDef *colorTargetDef =
         baseNodeDef->addTargetPass("colorTexture");
 
@@ -780,23 +778,6 @@ void Ogre2DepthCamera::CreateDepthTexture()
           particleTargetDef->addPass(Ogre::PASS_SCENE));
       passScene->setAllLoadActions(Ogre::LoadAction::Clear);
       passScene->setAllClearColours(Ogre::ColourValue::Black);
-      passScene->mVisibilityMask =
-          Ogre2ParticleEmitter::kParticleVisibilityFlags;
-    }
-
-    Ogre::CompositorTargetDef *particleDepthTargetDef =
-        baseNodeDef->addTargetPass("particleDepthTexture");
-    particleDepthTargetDef->setNumPasses(1);
-    {
-      // scene pass
-      Ogre::CompositorPassSceneDef *passScene =
-          static_cast<Ogre::CompositorPassSceneDef *>(
-          particleDepthTargetDef->addPass(Ogre::PASS_SCENE));
-      passScene->setAllLoadActions(Ogre::LoadAction::Clear);
-      passScene->setAllClearColours(Ogre::ColourValue(
-        this->FarClipPlane(),
-        this->FarClipPlane(),
-        this->FarClipPlane()));
       passScene->mVisibilityMask =
           Ogre2ParticleEmitter::kParticleVisibilityFlags;
     }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -542,9 +542,15 @@ void Ogre2DepthCamera::CreateDepthTexture()
     //   texture colorTexture target_width target_height PF_R8G8B8
     //       depth_texture depth_format PF_D32_FLOAT
     //   texture depthTexture target_width target_height PF_D32_FLOAT
-    //   texture particleTexture target_width target_height PF_L8
+    //   texture particleTexture target_width target_height PFG_R8_UNORM
     //   // particleDepthTexture shares same depth buffer as particleTexture
-    //   texture particleDepthTexture target_width target_height PF_D32_FLOAT
+    //   texture particleDepthTexture target_width target_height PFG_D32_FLOAT
+    //
+    //   rtv particleTexture
+    //   {
+    //     depth particleDepthTexture
+    //   }
+    //
     //   target colorTexture
     //   {
     //     pass clear
@@ -567,16 +573,6 @@ void Ogre2DepthCamera::CreateDepthTexture()
     //     }
     //   }
     //   target particleTexture
-    //   {
-    //     pass clear
-    //     {
-    //     }
-    //     pass render_scene
-    //     {
-    //       visibility_mask 0x00100000
-    //     }
-    //   }
-    //   target particleDepthTexture
     //   {
     //     pass clear
     //     {

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -301,10 +301,6 @@ void Ogre2SelectionBuffer::CreateRTTBuffer()
   depthTexDef->depthBufferFormat = Ogre::PFG_UNKNOWN;
   depthTexDef->fsaa = "0";
 
-  Ogre::RenderTargetViewDef *rtvDepth =
-      nodeDef->addRenderTextureView("depthTexture");
-  rtvDepth->setForTextureDefinition("depthTexture", depthTexDef);
-
   Ogre::TextureDefinitionBase::TextureDefinition *colorTexDef =
       nodeDef->addTextureDefinition("colorTexture");
   colorTexDef->textureType = Ogre::TextureTypes::Type2D;
@@ -321,15 +317,18 @@ void Ogre2SelectionBuffer::CreateRTTBuffer()
   colorTexDef->preferDepthTexture = true;
   colorTexDef->fsaa = "0";
 
+  // Auto setup the RTV then manually override the depth buffer so
+  // it uses the one we created (and thus we can sample from it later)
   Ogre::RenderTargetViewDef *rtvColor =
     nodeDef->addRenderTextureView("colorTexture");
   rtvColor->setForTextureDefinition("colorTexture", colorTexDef);
+  rtvColor->depthAttachment.textureName = "depthTexture";
 
   // Input texture
   nodeDef->addTextureSourceName("rt", 0,
       Ogre::TextureDefinitionBase::TEXTURE_INPUT);
 
-  nodeDef->setNumTargetPass(3);
+  nodeDef->setNumTargetPass(2);
   Ogre::CompositorTargetDef *colorTargetDef =
       nodeDef->addTargetPass("colorTexture");
   colorTargetDef->setNumPasses(1);
@@ -338,19 +337,6 @@ void Ogre2SelectionBuffer::CreateRTTBuffer()
     Ogre::CompositorPassSceneDef *passScene =
         static_cast<Ogre::CompositorPassSceneDef *>(
         colorTargetDef->addPass(Ogre::PASS_SCENE));
-    passScene->setAllLoadActions(Ogre::LoadAction::Clear);
-    passScene->setAllClearColours(Ogre::ColourValue::Black);
-    passScene->mVisibilityMask = IGN_VISIBILITY_SELECTABLE;
-  }
-
-  Ogre::CompositorTargetDef *depthTargetDef =
-      nodeDef->addTargetPass("depthTexture");
-  depthTargetDef->setNumPasses(1);
-  {
-    // scene pass
-    Ogre::CompositorPassSceneDef *passScene =
-        static_cast<Ogre::CompositorPassSceneDef *>(
-        depthTargetDef->addPass(Ogre::PASS_SCENE));
     passScene->setAllLoadActions(Ogre::LoadAction::Clear);
     passScene->setAllClearColours(Ogre::ColourValue::Black);
     passScene->mVisibilityMask = IGN_VISIBILITY_SELECTABLE;


### PR DESCRIPTION
# 🦟 Bug fix

No ticket created

## Summary

Ignition is pointlessly performing two passes when one is enough, as the
depth buffer data is already filled.

In the case of `Ogre2DepthCamera` we cannot do the same with
colorTexture & depthTexture though; because the way they are filled is different (colorTexture contains particles
and potentially other stuff that might write to depth; depthTexture doesn't)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
