### PR TITLE
Add test case for zero retro value

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -907,16 +907,6 @@ void Ogre2GpuRays::Setup1stPass()
       passScene->setAllLoadActions(Ogre::LoadAction::Clear);
       passScene->setAllClearColours(Ogre::ColourValue(0, 0, 0));
       // set camera custom visibility mask when rendering laser retro
-      // todo(anyone) currently in this color + depth pass, lidar sees all
-      // objects, including ones without laser_retro set. So the lidar outputs
-      // data containing depth data + some non-zero retro value for all
-      // objects. If we want to output a retro value of zero for objects
-      // without laser_retro, one possible approach could be to separate out
-      // the color and depth pass:
-      // 1: color pass that see only objects with laser_retro by using custom
-      //    visibility mask
-      // 2: depth pass that see all objects
-      // Then assemble these data in the final quad pass.
       passScene->mVisibilityMask = IGN_VISIBILITY_ALL &
           ~Ogre2ParticleEmitter::kParticleVisibilityFlags;
     }

--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -451,6 +451,13 @@ void GpuRaysTest::LaserVertical(const std::string &_renderEngine)
         ignition::math::INF_F);
     EXPECT_FLOAT_EQ(scan[(i * hRayCount + (hRayCount - 1)) * channels],
         ignition::math::INF_F);
+
+    // laser retro is currently only supported in ogre2
+    if (_renderEngine == "ogre2")
+    {
+      // object does not have retro value set so it should be 0
+      EXPECT_FLOAT_EQ(scan[i * hRayCount * channels + 1], 0.0);
+    }
   }
 
   // Move box out of range


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary
 
A follow up to #522. Retro values for objects that do not have anything set should now return zero. Added a check and remove todo comment.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
