### PR TITLE
Silence CMake policy CMP0072

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ ign_find_package(FreeImage VERSION 3.9
 
 #--------------------------------------
 # Find OpenGL
+# See CMP0072 for more details (cmake --help-policy CMP0072)
+if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
+  set(OpenGL_GL_PREFERENCE "GLVND")
+endif()
+
 ign_find_package(OpenGL
   REQUIRED_BY ogre ogre2
   PKGCONFIG gl)


### PR DESCRIPTION
# 🦟 Bug fix

* Fixes #360

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Calling `cmake_policy` is complicated in this situation because the `find_package` call is made in a different scope, within `ign_find_package`. Setting the variable directly does the trick though. See https://github.com/ignitionrobotics/ign-rendering/issues/360#issuecomment-1006278927.

This doesn't solve the problem for downstream projects though. I didn't find a way of passing variables to [ignition-component-config.cmake.in](https://github.com/ignitionrobotics/ign-cmake/blob/ign-cmake2/cmake/ignition-component-config.cmake.in).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
