### PR TITLE
Bind shader uniforms to constants from ogre

### DIFF
--- a/examples/custom_shaders_uniforms/GlutWindow.cc
+++ b/examples/custom_shaders_uniforms/GlutWindow.cc
@@ -214,6 +214,11 @@ void initUniforms()
   auto engine = g_camera->Scene()->Engine();
   if (engine->Name() == "ogre2")
   {
+    // worldviewproj_matrix is a constant defined by ogre.
+    // Here we add a line to add this constant to the params.
+    // The specified value is ignored as it will be auto bound to the
+    // correct type and value. See available constants:
+    // https://github.com/OGRECave/ogre-next/blob/v2-2/OgreMain/src/OgreGpuProgramParams.cpp
     auto params = shader->VertexShaderParams();
     (*params)["worldviewproj_matrix"] = 1;
   }

--- a/examples/custom_shaders_uniforms/GlutWindow.cc
+++ b/examples/custom_shaders_uniforms/GlutWindow.cc
@@ -210,6 +210,13 @@ void initUniforms()
   (*g_shaderParams)["u_resolution"].InitializeBuffer(2);
   (*g_shaderParams)["u_color"].InitializeBuffer(3);
   (*g_shaderParams)["u_adjustments"].InitializeBuffer(16);
+
+  auto engine = g_camera->Scene()->Engine();
+  if (engine->Name() == "ogre2")
+  {
+    auto params = shader->VertexShaderParams();
+    (*params)["worldviewproj_matrix"] = 1;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/examples/custom_shaders_uniforms/media/vertex_shader_330.glsl
+++ b/examples/custom_shaders_uniforms/media/vertex_shader_330.glsl
@@ -18,7 +18,7 @@
 #version 330
 
 in vec4 vertex;
-uniform mat4 worldViewProj;
+uniform mat4 worldviewproj_matrix;
 
 out gl_PerVertex
 {
@@ -29,7 +29,7 @@ out vec4 interpolatedPosition;
 
 void main()
 {
-  gl_Position = worldViewProj * vertex;
+  gl_Position = worldviewproj_matrix * vertex;
   interpolatedPosition = gl_Position;
 }
 

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -638,6 +638,14 @@ void Ogre2Material::UpdateShaderParams(ConstShaderParamsPtr _params,
 {
   for (const auto name_param : *_params)
   {
+    auto *constantDef =
+        Ogre::GpuProgramParameters::getAutoConstantDefinition(name_param.first);
+    if (constantDef)
+    {
+      _ogreParams->setNamedAutoConstant(name_param.first, constantDef->acType);
+      continue;
+    }
+
     if (ShaderParam::PARAM_FLOAT == name_param.second.Type())
     {
       float value;
@@ -1012,8 +1020,6 @@ void Ogre2Material::SetVertexShader(const std::string &_path)
 
   Ogre::GpuProgramParametersSharedPtr params =
       vertexShader->getDefaultParameters();
-  params->setNamedAutoConstant("worldViewProj",
-      Ogre::GpuProgramParameters::ACT_WORLDVIEWPROJ_MATRIX);
 
   vertexShader->load();
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Ogre provides a few constants that are useful when writing shaders:
https://github.com/OGRECave/ogre-next/blob/v2-2/OgreMain/src/OgreGpuProgramParams.cpp#L43-L196

 This PR binds these constants to named uniforms so that they can be accessed by the shaders. I also removed the hardcoded uniform that I introduced in #520. 

Updated the `custom_shader_uniforms` demo to show how to bind a uniform to one of these constants.

To test, run the `custom_shader_uniforms` example to make sure nothing is broken.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

