### PR TITLE
Rename Ogre2IgnHlmsCustomizations to Ogre2IgnHlmsSphericalClipMinDistance

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -53,7 +53,7 @@ namespace ignition
     //
     // forward declaration
     class Ogre2RenderEnginePrivate;
-    class Ogre2IgnHlmsCustomizations;
+    class Ogre2IgnHlmsSphericalClipMinDistance;
 
     /// \brief Plugin for loading ogre render engine
     class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2RenderEnginePlugin :
@@ -175,9 +175,13 @@ namespace ignition
       /// \return a list of FSAA levels
       public: std::vector<unsigned int> FSAALevels() const;
 
+      /// \brief Deprecated. Use SphericalClipMinDistance instead
+      public: Ogre2IgnHlmsSphericalClipMinDistance &IGN_DEPRECATED(7)
+          HlmsCustomizations();
+
       /// \brief Retrieves Hlms customizations for tweaking them
       /// \return Ogre HLMS customizations
-      public: Ogre2IgnHlmsCustomizations &HlmsCustomizations();
+      public: Ogre2IgnHlmsSphericalClipMinDistance &SphericalClipMinDistance();
 
       /// \internal
       /// \brief Get a pointer to the Ogre overlay system.

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -176,7 +176,7 @@ namespace ignition
       public: std::vector<unsigned int> FSAALevels() const;
 
       /// \brief Deprecated. Use SphericalClipMinDistance instead
-      public: Ogre2IgnHlmsSphericalClipMinDistance &IGN_DEPRECATED(7)
+      public: Ogre2IgnHlmsSphericalClipMinDistance IGN_DEPRECATED(7) &
           HlmsCustomizations();
 
       /// \brief Retrieves Hlms customizations for tweaking them

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -33,7 +33,7 @@
 #include "ignition/rendering/ogre2/Ogre2Sensor.hh"
 #include "ignition/rendering/ogre2/Ogre2Visual.hh"
 
-#include "Ogre2IgnHlmsCustomizations.hh"
+#include "Ogre2IgnHlmsSphericalClipMinDistance.hh"
 #include "Ogre2ParticleNoiseListener.hh"
 
 #ifdef _MSC_VER
@@ -218,7 +218,7 @@ void Ogre2LaserRetroMaterialSwitcher::cameraPreRenderScene(
 {
   {
     auto engine = Ogre2RenderEngine::Instance();
-    Ogre2IgnHlmsCustomizations &hlmsCustomizations =
+    Ogre2IgnHlmsSphericalClipMinDistance &hlmsCustomizations =
         engine->HlmsCustomizations();
     Ogre::Pass *pass =
         this->laserRetroSourceMaterial->getBestTechnique()->getPass(0u);
@@ -1245,7 +1245,7 @@ void Ogre2GpuRays::Render()
   // These customization can be used to implement multi-tiered
   // "near plane distances" as proposed in:
   // https://github.com/ignitionrobotics/ign-rendering/issues/395
-  Ogre2IgnHlmsCustomizations &hlmsCustomizations =
+  Ogre2IgnHlmsSphericalClipMinDistance &hlmsCustomizations =
       engine->HlmsCustomizations();
 
   hlmsCustomizations.minDistanceClip =

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -219,7 +219,7 @@ void Ogre2LaserRetroMaterialSwitcher::cameraPreRenderScene(
   {
     auto engine = Ogre2RenderEngine::Instance();
     Ogre2IgnHlmsSphericalClipMinDistance &hlmsCustomizations =
-        engine->HlmsCustomizations();
+        engine->SphericalClipMinDistance();
     Ogre::Pass *pass =
         this->laserRetroSourceMaterial->getBestTechnique()->getPass(0u);
     pass->getVertexProgramParameters()->setNamedConstant(
@@ -1246,7 +1246,7 @@ void Ogre2GpuRays::Render()
   // "near plane distances" as proposed in:
   // https://github.com/ignitionrobotics/ign-rendering/issues/395
   Ogre2IgnHlmsSphericalClipMinDistance &hlmsCustomizations =
-      engine->HlmsCustomizations();
+      engine->SphericalClipMinDistance();
 
   hlmsCustomizations.minDistanceClip =
       static_cast<float>(this->NearClipPlane());

--- a/ogre2/src/Ogre2IgnHlmsPbsPrivate.cc
+++ b/ogre2/src/Ogre2IgnHlmsPbsPrivate.cc
@@ -47,7 +47,7 @@ namespace Ogre
 
   Ogre2IgnHlmsPbs::Ogre2IgnHlmsPbs(
     Archive *dataFolder, ArchiveVec *libraryFolders,
-    Ogre2IgnHlmsCustomizations *_sphericalClipMinDistance,
+    Ogre2IgnHlmsSphericalClipMinDistance *_sphericalClipMinDistance,
     Ogre::HlmsPbsTerraShadows *terraShadows) :
     HlmsPbs(dataFolder, libraryFolders)
   {

--- a/ogre2/src/Ogre2IgnHlmsPbsPrivate.hh
+++ b/ogre2/src/Ogre2IgnHlmsPbsPrivate.hh
@@ -20,7 +20,7 @@
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/ogre2/Export.hh"
 
-#include "Ogre2IgnHlmsCustomizations.hh"
+#include "Ogre2IgnHlmsSphericalClipMinDistance.hh"
 #include "Ogre2IgnHlmsSharedPrivate.hh"
 
 #ifdef _MSC_VER
@@ -66,7 +66,8 @@ namespace Ogre
     /// \brief Constructor. Asks for modular listeners so we can add
     /// them in the proper order
     public: Ogre2IgnHlmsPbs(Archive *dataFolder, ArchiveVec *libraryFolders,
-                            ignition::rendering::Ogre2IgnHlmsCustomizations
+                            ignition::rendering::
+                            Ogre2IgnHlmsSphericalClipMinDistance
                             *_sphericalClipMinDistance,
                             Ogre::HlmsPbsTerraShadows *terraShadows);
 

--- a/ogre2/src/Ogre2IgnHlmsSphericalClipMinDistance.cc
+++ b/ogre2/src/Ogre2IgnHlmsSphericalClipMinDistance.cc
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
-#include "Ogre2IgnHlmsCustomizations.hh"
+#include "Ogre2IgnHlmsSphericalClipMinDistance.hh"
 
 #include "ignition/rendering/ogre2/Ogre2RenderEngine.hh"
 
 #ifdef _MSC_VER
-  #pragma warning(push, 0)
+#  pragma warning(push, 0)
 #endif
 #include <OgreCamera.h>
 #include <OgreHlms.h>
@@ -28,18 +28,17 @@
 #include <OgreSceneManager.h>
 #include <OgreViewport.h>
 #ifdef _MSC_VER
-  #pragma warning(pop)
+#  pragma warning(pop)
 #endif
 
 using namespace ignition;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-void Ogre2IgnHlmsCustomizations::preparePassHash(
-    const Ogre::CompositorShadowNode */*_shadowNode*/,
-    bool _casterPass, bool /*_dualParaboloid*/,
-    Ogre::SceneManager */*_sceneManager*/,
-    Ogre::Hlms *_hlms)
+void Ogre2IgnHlmsSphericalClipMinDistance::preparePassHash(
+  const Ogre::CompositorShadowNode * /*_shadowNode*/, bool _casterPass,
+  bool /*_dualParaboloid*/, Ogre::SceneManager * /*_sceneManager*/,
+  Ogre::Hlms *_hlms)
 {
   this->needsWorldPos = false;
   if (!_casterPass && this->MinDistanceClipEnabled())
@@ -62,10 +61,9 @@ void Ogre2IgnHlmsCustomizations::preparePassHash(
 }
 
 //////////////////////////////////////////////////
-Ogre::uint32 Ogre2IgnHlmsCustomizations::getPassBufferSize(
-    const Ogre::CompositorShadowNode */*_shadowNode*/,
-    bool _casterPass, bool /*_dualParaboloid*/,
-    Ogre::SceneManager */*_sceneManager*/) const
+Ogre::uint32 Ogre2IgnHlmsSphericalClipMinDistance::getPassBufferSize(
+  const Ogre::CompositorShadowNode * /*_shadowNode*/, bool _casterPass,
+  bool /*_dualParaboloid*/, Ogre::SceneManager * /*_sceneManager*/) const
 {
   if (_casterPass || !this->MinDistanceClipEnabled())
     return 0u;
@@ -78,16 +76,15 @@ Ogre::uint32 Ogre2IgnHlmsCustomizations::getPassBufferSize(
 }
 
 //////////////////////////////////////////////////
-float* Ogre2IgnHlmsCustomizations::preparePassBuffer(
-    const Ogre::CompositorShadowNode */*_shadowNode*/,
-    bool _casterPass, bool /*_dualParaboloid*/,
-    Ogre::SceneManager *_sceneManager,
-    float *_passBufferPtr)
+float *Ogre2IgnHlmsSphericalClipMinDistance::preparePassBuffer(
+  const Ogre::CompositorShadowNode * /*_shadowNode*/, bool _casterPass,
+  bool /*_dualParaboloid*/, Ogre::SceneManager *_sceneManager,
+  float *_passBufferPtr)
 {
   if (!_casterPass && this->MinDistanceClipEnabled())
   {
     const Ogre::Camera *camera =
-        _sceneManager->getCamerasInProgress().renderingCamera;
+      _sceneManager->getCamerasInProgress().renderingCamera;
     const Ogre::Vector3 &camPos = camera->getDerivedPosition();
 
     // float4 ignMinClipDistance_ignCameraPos
@@ -105,19 +102,18 @@ float* Ogre2IgnHlmsCustomizations::preparePassBuffer(
       auto engine = Ogre2RenderEngine::Instance();
       auto ogreRoot = engine->OgreRoot();
       Ogre::RenderPassDescriptor *renderPassDesc =
-          ogreRoot->getRenderSystem()->getCurrentPassDescriptor();
-      Ogre::Matrix4 projectionMatrix =
-          camera->getProjectionMatrixWithRSDepth();
+        ogreRoot->getRenderSystem()->getCurrentPassDescriptor();
+      Ogre::Matrix4 projectionMatrix = camera->getProjectionMatrixWithRSDepth();
       if (renderPassDesc->requiresTextureFlipping())
       {
-          projectionMatrix[1][0]  = -projectionMatrix[1][0];
-          projectionMatrix[1][1]  = -projectionMatrix[1][1];
-          projectionMatrix[1][2]  = -projectionMatrix[1][2];
-          projectionMatrix[1][3]  = -projectionMatrix[1][3];
+        projectionMatrix[1][0] = -projectionMatrix[1][0];
+        projectionMatrix[1][1] = -projectionMatrix[1][1];
+        projectionMatrix[1][2] = -projectionMatrix[1][2];
+        projectionMatrix[1][3] = -projectionMatrix[1][3];
       }
 
-      Ogre::Matrix4 invViewProj = (projectionMatrix *
-                                   camera->getViewMatrix(true)).inverse();
+      Ogre::Matrix4 invViewProj =
+        (projectionMatrix * camera->getViewMatrix(true)).inverse();
       for (size_t i = 0; i < 16u; ++i)
       {
         *_passBufferPtr++ = static_cast<float>(invViewProj[0][i]);

--- a/ogre2/src/Ogre2IgnHlmsSphericalClipMinDistance.hh
+++ b/ogre2/src/Ogre2IgnHlmsSphericalClipMinDistance.hh
@@ -46,11 +46,10 @@ namespace ignition
     /// \internal
     /// \remark Public variables take effect immediately (i.e. for the
     /// next render)
-    class IGNITION_RENDERING_OGRE2_HIDDEN Ogre2IgnHlmsCustomizations final :
-        public Ogre::HlmsListener
+    class IGNITION_RENDERING_OGRE2_HIDDEN Ogre2IgnHlmsSphericalClipMinDistance
+      final : public Ogre::HlmsListener
     {
-    public:
-      virtual ~Ogre2IgnHlmsCustomizations() = default;
+      public: virtual ~Ogre2IgnHlmsSphericalClipMinDistance() = default;
 
       /// \brief
       /// \return Returns true if spherical clipping customizations should
@@ -72,7 +71,8 @@ namespace ignition
       /// \brief Tells Ogre the buffer data sent to GPU should be a little
       /// bigger to fit our data we need to send
       ///
-      /// This data is sent in Ogre2IgnHlmsCustomizations::preparePassBuffer
+      /// This data is sent in
+      /// Ogre2IgnHlmsSphericalClipMinDistance::preparePassBuffer
       /// \param _casterPass
       /// \param _hlms
       private: virtual Ogre::uint32 getPassBufferSize(
@@ -81,8 +81,8 @@ namespace ignition
             Ogre::SceneManager *_sceneManager) const override;
 
       /// \brief Sends our custom data to GPU buffers that our
-      /// pieces activated in Ogre2IgnHlmsCustomizations::preparePassHash
-      /// will need.
+      /// pieces activated in
+      /// Ogre2IgnHlmsSphericalClipMinDistance::preparePassHash will need.
       ///
       /// Bytes written must not exceed what we informed in getPassBufferSize
       /// \param _casterPass

--- a/ogre2/src/Ogre2IgnHlmsUnlitPrivate.cc
+++ b/ogre2/src/Ogre2IgnHlmsUnlitPrivate.cc
@@ -45,7 +45,7 @@ namespace Ogre
 
   Ogre2IgnHlmsUnlit::Ogre2IgnHlmsUnlit(
     Archive *dataFolder, ArchiveVec *libraryFolders,
-    Ogre2IgnHlmsCustomizations *_sphericalClipMinDistance) :
+    Ogre2IgnHlmsSphericalClipMinDistance *_sphericalClipMinDistance) :
     HlmsUnlit(dataFolder, libraryFolders)
   {
     this->customizations.push_back(_sphericalClipMinDistance);

--- a/ogre2/src/Ogre2IgnHlmsUnlitPrivate.hh
+++ b/ogre2/src/Ogre2IgnHlmsUnlitPrivate.hh
@@ -20,7 +20,7 @@
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/ogre2/Export.hh"
 
-#include "Ogre2IgnHlmsCustomizations.hh"
+#include "Ogre2IgnHlmsSphericalClipMinDistance.hh"
 #include "Ogre2IgnHlmsSharedPrivate.hh"
 
 #ifdef _MSC_VER
@@ -64,7 +64,8 @@ namespace Ogre
     /// \brief Constructor. Asks for modular listeners so we can add
     /// them in the proper order
     public: Ogre2IgnHlmsUnlit(Archive *dataFolder, ArchiveVec *libraryFolders,
-                              ignition::rendering::Ogre2IgnHlmsCustomizations
+                              ignition::rendering::
+                              Ogre2IgnHlmsSphericalClipMinDistance
                               *_sphericalClipMinDistance);
 
     /// \brief Destructor. Virtual to silence warnings

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -48,7 +48,7 @@
 #include "Terra/Hlms/OgreHlmsTerra.h"
 #include "Terra/Hlms/PbsListener/OgreHlmsPbsTerraShadows.h"
 #include "Terra/TerraWorkspaceListener.h"
-#include "Ogre2IgnHlmsCustomizations.hh"
+#include "Ogre2IgnHlmsSphericalClipMinDistance.hh"
 
 class IGNITION_RENDERING_OGRE2_HIDDEN
     ignition::rendering::Ogre2RenderEnginePrivate
@@ -64,7 +64,8 @@ class IGNITION_RENDERING_OGRE2_HIDDEN
   public: std::vector<unsigned int> fsaaLevels;
 
   /// \brief Controls Hlms customizations for both PBS and Unlit
-  public: ignition::rendering::Ogre2IgnHlmsCustomizations hlmsCustomizations;
+  public: ignition::rendering::Ogre2IgnHlmsSphericalClipMinDistance
+  sphericalClipMinDistance;
 
   /// \brief Pbs listener that adds terra shadows
   public: std::unique_ptr<Ogre::HlmsPbsTerraShadows> hlmsPbsTerraShadows;
@@ -754,8 +755,9 @@ void Ogre2RenderEngine::RegisterHlms()
     archiveUnlitLibraryFolders.push_back(customizationsArchiveLibrary);
 
     // Create and register the unlit Hlms
-    hlmsUnlit = OGRE_NEW Ogre::Ogre2IgnHlmsUnlit(archiveUnlit,
-        &archiveUnlitLibraryFolders, &this->dataPtr->hlmsCustomizations);
+    hlmsUnlit = OGRE_NEW Ogre::Ogre2IgnHlmsUnlit(
+      archiveUnlit, &archiveUnlitLibraryFolders,
+      &this->dataPtr->sphericalClipMinDistance);
     Ogre::Root::getSingleton().getHlmsManager()->registerHlms(hlmsUnlit);
 
     // disable writting debug output to disk
@@ -795,9 +797,10 @@ void Ogre2RenderEngine::RegisterHlms()
     }
 
     // Create and register
-    hlmsPbs = OGRE_NEW Ogre::Ogre2IgnHlmsPbs(
-      archivePbs, &archivePbsLibraryFolders, &this->dataPtr->hlmsCustomizations,
-      this->dataPtr->hlmsPbsTerraShadows.get());
+    hlmsPbs =
+      OGRE_NEW Ogre::Ogre2IgnHlmsPbs(archivePbs, &archivePbsLibraryFolders,
+                                     &this->dataPtr->sphericalClipMinDistance,
+                                     this->dataPtr->hlmsPbsTerraShadows.get());
     Ogre::Root::getSingleton().getHlmsManager()->registerHlms(hlmsPbs);
 
     // disable writting debug output to disk
@@ -1012,9 +1015,16 @@ std::vector<unsigned int> Ogre2RenderEngine::FSAALevels() const
 }
 
 /////////////////////////////////////////////////
-Ogre2IgnHlmsCustomizations& Ogre2RenderEngine::HlmsCustomizations()
+Ogre2IgnHlmsSphericalClipMinDistance& Ogre2RenderEngine::HlmsCustomizations()
 {
-  return this->dataPtr->hlmsCustomizations;
+  return this->dataPtr->sphericalClipMinDistance;
+}
+
+/////////////////////////////////////////////////
+Ogre2IgnHlmsSphericalClipMinDistance& Ogre2RenderEngine::
+SphericalClipMinDistance()
+{
+  return this->dataPtr->sphericalClipMinDistance;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

This is part of ticket #502

In order to split the amount of changes into maneagable, reviewable changes; the changes are being submitted in 3 PRs.

This is the 2nd PR.

It simply renames Ogre2IgnHlmsCustomizations to Ogre2IgnHlmsSphericalClipMinDistance.

The reason behind this is that customizations are now being managed by Ogre2IgnHlmsPbs & Ogre2IgnHlmsUnlit.

Since Ogre2IgnHlmsCustomizations is doing just one job but has a generic name, it would tend to confusion as to what it does and its role.

The class isn't exposed to the user; however `Ogre2RenderEngine::HlmsCustomizations` did expose a forward declared pointer to the user; which is why the function still exists but has been marked as deprecated.

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

Affects #502 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
