### PR TITLE
[Metal] Fix depth camera sensor 

### DIFF
--- a/ogre2/src/media/materials/scripts/depth_camera.material
+++ b/ogre2/src/media/materials/scripts/depth_camera.material
@@ -135,6 +135,13 @@ fragment_program DepthCameraFinalFS_Metal metal
 {
   source depth_camera_final_fs.metal
   shader_reflection_pair_hint DepthCameraFinalVS_Metal
+
+  default_params
+  {
+    param_named inputTexture int 0
+
+    param_named_auto texResolution texture_size 0
+  }
 }
 
 // Unified shaders

--- a/ogre2/src/media/materials/scripts/selection_buffer.material
+++ b/ogre2/src/media/materials/scripts/selection_buffer.material
@@ -53,6 +53,13 @@ fragment_program selection_buffer_fs_Metal metal
 {
   source selection_buffer_fs.metal
   shader_reflection_pair_hint selection_buffer_vs_Metal
+  default_params
+  {
+    param_named colorTexture int 0
+    param_named depthTexture int 1
+
+    param_named_auto colorTexResolution texture_size 0
+  }
 }
 
 // Unified shaders


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to #498

## Summary

This fix adds default parameters to the Metal fragment shader definitions in the depth camera and selection buffer materials.

A depth camera would not render correctly (black screen) on macOS using Metal shaders. This can be reproduced either using the `depth_camera` example or by including a depth_camera sensor in a SDF model and displaying the image in Gazebo.

After the PR the `depth_camera` example and Image display are working correctly.

![depth_camera_issue_fix](https://user-images.githubusercontent.com/24916364/149614414-b76bf6f0-b022-4760-8a41-8f157cceb1c8.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.