### PR TITLE
Fix crash when hovering the cursor in heightmap.sdf

### DIFF
--- a/ogre2/src/media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
+++ b/ogre2/src/media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
@@ -34,7 +34,7 @@
     outVs.terrainShadow = mix( terraShadowData.x, 1.0, clamp( terraHeightWeight, 0.0, 1.0 ) );
 @end
 
-@property( hlms_lights_directional )
+@property( hlms_lights_directional && hlms_num_shadow_map_lights )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @else
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end

--- a/ogre2/src/media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
+++ b/ogre2/src/media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
@@ -36,7 +36,7 @@
     outVs.terrainShadow = lerp( terraShadowData.x, 1.0, saturate( terraHeightWeight ) );
 @end
 
-@property( hlms_lights_directional )
+@property( hlms_lights_directional && hlms_num_shadow_map_lights )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @else
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end

--- a/ogre2/src/media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
+++ b/ogre2/src/media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
@@ -36,7 +36,7 @@
     outVs.terrainShadow = lerp( terraShadowData.x, 1.0, saturate( terraHeightWeight ) );
 @end
 
-@property( hlms_lights_directional )
+@property( hlms_lights_directional && hlms_num_shadow_map_lights )
     @piece( custom_ps_preLights )fShadow *= inPs.terrainShadow;@end
 @else
     @piece( custom_ps_preLights )float fShadow = inPs.terrainShadow;@end


### PR DESCRIPTION
## Summary

Hovering the cursor while in the ign gui when heightmap.sdf is opened
would cause a shader compiler error.

The triggering condition was having a directional light without shadow
nodes.

This error is from upstream
https://github.com/OGRECave/ogre-next/commit/e40bc539092ec64fc75153a50033dbb8a7da2857

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

No ticket was assigned for this bug

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
