### PR TITLE
Require geospatial component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(IGN_MATH_VER ${ignition-math7_VERSION_MAJOR})
 #--------------------------------------
 # Find ignition-common
 ign_find_package(ignition-common5 REQUIRED
-  COMPONENTS graphics events)
+  COMPONENTS graphics events geospatial)
 set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
 
 #--------------------------------------


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Adds the new `geospatial` component (https://github.com/ignitionrobotics/ign-common/pull/267) as it is needed by heightmaps. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
