### PR TITLE
Implement Hlms custom pieces swap for Objects & Terrain

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2IgnOgreRenderingMode.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2IgnOgreRenderingMode.hh
@@ -38,10 +38,14 @@ namespace ignition
         /// Used by e.g. Segmentation camera mode
         IORM_SOLID_COLOR,
 
-        /// \brief Render a solid color explicit per object.
-        /// But Unlit won't do that.
+        /// \brief Like IORM_SOLID_COLOR, but if CustomParameter 2u
+        /// is present, raw diffuse texture will be multiplied against
+        /// the solid colour.
+        ///
+        /// Also Unlit will behave as if IORM_NORMAL
+        ///
         /// Used by thermal camera
-        IORM_SOLID_COLOR_NOT_UNLIT,
+        IORM_SOLID_THERMAL_COLOR_TEXTURED,
 
         /// \brief Total number of rendering modes
         IORM_COUNT,

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2IgnOgreRenderingMode.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2IgnOgreRenderingMode.hh
@@ -38,6 +38,11 @@ namespace ignition
         /// Used by e.g. Segmentation camera mode
         IORM_SOLID_COLOR,
 
+        /// \brief Render a solid color explicit per object.
+        /// But Unlit won't do that.
+        /// Used by thermal camera
+        IORM_SOLID_COLOR_NOT_UNLIT,
+
         /// \brief Total number of rendering modes
         IORM_COUNT,
       };

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
@@ -84,6 +84,12 @@ namespace ignition
       private: std::unordered_map<Ogre::HlmsDatablock *,
           const Ogre::HlmsBlendblock *> datablockMap;
 
+      /// \brief A map of ogre sub item pointer to their original low level
+      /// material.
+      /// Most objects don't use one so it should be almost always empty.
+      private:
+        std::vector<std::pair<Ogre::SubItem *, Ogre::MaterialPtr>> materialMap;
+
       /// \brief Increment unique color value that will be assigned to the
       /// next renderable
       private: void NextColor();

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
@@ -20,6 +20,9 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include <ignition/math/Color.hh>
 #include "ignition/rendering/config.hh"

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2MaterialSwitcher.hh
@@ -80,17 +80,9 @@ namespace ignition
       /// renderable name
       private: std::map<unsigned int, std::string> colorDict;
 
-      /// \brief A map of ogre sub item pointer to their original hlms material
-      private: std::map<Ogre::SubItem *, Ogre::HlmsDatablock *> datablockMap;
-
-      /// \brief Ogre v1 material consisting of a shader that changes the
-      /// appearance of item to use a unique color for mouse picking
-      private: Ogre::MaterialPtr plainMaterial;
-
-      /// \brief Ogre v1 material consisting of a shader that changes the
-      /// appearance of item to use a unique color for mouse picking. In
-      /// addition, the depth check and depth write properties disabled.
-      private: Ogre::MaterialPtr plainOverlayMaterial;
+      /// \brief A map of ogre datablock pointer to their original blendblocks
+      private: std::unordered_map<Ogre::HlmsDatablock *,
+          const Ogre::HlmsBlendblock *> datablockMap;
 
       /// \brief Increment unique color value that will be assigned to the
       /// next renderable

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -78,8 +78,8 @@ class IGNITION_RENDERING_OGRE2_HIDDEN
   private: virtual void passPreExecute(
       Ogre::CompositorPass *_pass) override;
 
-    /// \brief Callback when each pass is finisned executing.
-    /// \param[in] _pass Ogre pass which has already executed
+  /// \brief Callback when each pass is finisned executing.
+  /// \param[in] _pass Ogre pass which has already executed
   private: virtual void passPosExecute(
       Ogre::CompositorPass *_pass) override;
 

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -273,7 +273,8 @@ void Ogre2LaserRetroMaterialSwitcher::cameraPreRenderScene(
       retroValue = std::max(retroValue, 0.0f);
     }
 
-    for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
+    const size_t numSubItems = item->getNumSubItems();
+    for (size_t i = 0; i < numSubItems; ++i)
     {
       Ogre::SubItem *subItem = item->getSubItem(i);
 
@@ -325,6 +326,29 @@ void Ogre2LaserRetroMaterialSwitcher::cameraPostRenderScene(
     hlmsManager->destroyBlendblock(blendblock);
   }
   this->datablockMap.clear();
+
+  // Remove the custom parameter. Why? If there are multiple cameras that
+  // use IORM_SOLID_COLOR (or any other mode), we want them to throw if
+  // that code forgot to call setCustomParameter. We may miss those errors
+  // if that code forgets to call but it was already carrying the value
+  // we set here.
+  //
+  // This consumes more performance but it's the price to pay for
+  // safety.
+  auto itor = this->scene->OgreSceneManager()->getMovableObjectIterator(
+      Ogre::ItemFactory::FACTORY_TYPE_NAME);
+  while (itor.hasMoreElements())
+  {
+    Ogre::MovableObject *object = itor.peekNext();
+    Ogre::Item *item = static_cast<Ogre::Item *>(object);
+    const size_t numSubItems = item->getNumSubItems();
+    for (size_t i = 0; i < numSubItems; ++i)
+    {
+      Ogre::SubItem *subItem = item->getSubItem(i);
+      subItem->removeCustomParameter(1u);
+    }
+    itor.moveNext();
+  }
 
   engine->SetIgnOgreRenderingMode(IORM_NORMAL);
 }

--- a/ogre2/src/Ogre2IgnHlmsPbsPrivate.cc
+++ b/ogre2/src/Ogre2IgnHlmsPbsPrivate.cc
@@ -61,7 +61,9 @@ namespace Ogre
                                         SceneManager *_sceneManager,
                                         Hlms *_hlms)
   {
-    if (!_casterPass && this->ignOgreRenderingMode == IORM_SOLID_COLOR)
+    if (!_casterPass &&
+        (this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
+         this->ignOgreRenderingMode == IORM_SOLID_COLOR_NOT_UNLIT))
     {
       _hlms->_setProperty("ign_render_solid_color", 1);
     }
@@ -140,7 +142,9 @@ namespace Ogre
       listener->hlmsTypeChanged(_casterPass, _commandBuffer, _datablock);
     }
 
-    if (_casterPass || this->ignOgreRenderingMode != IORM_SOLID_COLOR)
+    if (_casterPass ||
+        (this->ignOgreRenderingMode != IORM_SOLID_COLOR &&
+         this->ignOgreRenderingMode != IORM_SOLID_COLOR_NOT_UNLIT))
     {
       return;
     }
@@ -156,7 +160,9 @@ namespace Ogre
     const uint32 instanceIdx = HlmsPbs::fillBuffersForV1(
       _cache, _queuedRenderable, _casterPass, _lastCacheHash, _commandBuffer);
 
-    if (this->ignOgreRenderingMode == IORM_SOLID_COLOR && !_casterPass)
+    if ((this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
+         this->ignOgreRenderingMode == IORM_SOLID_COLOR_NOT_UNLIT) &&
+        !_casterPass)
     {
       Vector4 customParam =
         _queuedRenderable.renderable->getCustomParameter(1u);
@@ -181,7 +187,9 @@ namespace Ogre
     const uint32 instanceIdx = HlmsPbs::fillBuffersForV2(
       _cache, _queuedRenderable, _casterPass, _lastCacheHash, _commandBuffer);
 
-    if (this->ignOgreRenderingMode == IORM_SOLID_COLOR && !_casterPass)
+    if ((this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
+         this->ignOgreRenderingMode == IORM_SOLID_COLOR_NOT_UNLIT) &&
+        !_casterPass)
     {
       Vector4 customParam;
       try

--- a/ogre2/src/Ogre2IgnHlmsPbsPrivate.cc
+++ b/ogre2/src/Ogre2IgnHlmsPbsPrivate.cc
@@ -63,9 +63,12 @@ namespace Ogre
   {
     if (!_casterPass &&
         (this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
-         this->ignOgreRenderingMode == IORM_SOLID_COLOR_NOT_UNLIT))
+         this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED))
     {
       _hlms->_setProperty("ign_render_solid_color", 1);
+
+      if (this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED)
+        _hlms->_setProperty("ign_render_solid_color_textured", 1);
     }
 
     // Allow additional listener-only customizations to inject their stuff
@@ -144,7 +147,7 @@ namespace Ogre
 
     if (_casterPass ||
         (this->ignOgreRenderingMode != IORM_SOLID_COLOR &&
-         this->ignOgreRenderingMode != IORM_SOLID_COLOR_NOT_UNLIT))
+         this->ignOgreRenderingMode != IORM_SOLID_THERMAL_COLOR_TEXTURED))
     {
       return;
     }
@@ -161,7 +164,7 @@ namespace Ogre
       _cache, _queuedRenderable, _casterPass, _lastCacheHash, _commandBuffer);
 
     if ((this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
-         this->ignOgreRenderingMode == IORM_SOLID_COLOR_NOT_UNLIT) &&
+         this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED) &&
         !_casterPass)
     {
       Vector4 customParam =
@@ -173,7 +176,22 @@ namespace Ogre
       dataPtr[0] = customParam.x;
       dataPtr[1] = customParam.y;
       dataPtr[2] = customParam.z;
-      dataPtr[3] = customParam.w;
+
+      if (this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED &&
+          _queuedRenderable.renderable->hasCustomParameter(2u))
+      {
+        IGN_ASSERT(customParam.w >= 0.0f,
+                   "customParam.w can't be negative for "
+                   "IORM_SOLID_THERMAL_COLOR_TEXTURED");
+
+        // Negate customParam.w to tell the shader we wish to multiply
+        // against the diffuse texture. We substract 0.5f to avoid -0.0 = 0.0
+        dataPtr[3] = -customParam.w - 0.5f;
+      }
+      else
+      {
+        dataPtr[3] = customParam.w;
+      }
     }
 
     return instanceIdx;
@@ -188,7 +206,7 @@ namespace Ogre
       _cache, _queuedRenderable, _casterPass, _lastCacheHash, _commandBuffer);
 
     if ((this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
-         this->ignOgreRenderingMode == IORM_SOLID_COLOR_NOT_UNLIT) &&
+         this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED) &&
         !_casterPass)
     {
       Vector4 customParam;
@@ -217,6 +235,22 @@ namespace Ogre
       dataPtr[1] = customParam.y;
       dataPtr[2] = customParam.z;
       dataPtr[3] = customParam.w;
+
+      if (this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED &&
+          _queuedRenderable.renderable->hasCustomParameter(2u))
+      {
+        IGN_ASSERT(customParam.w >= 0.0f,
+                   "customParam.w can't be negative for "
+                   "IORM_SOLID_THERMAL_COLOR_TEXTURED");
+
+        // Negate customParam.w to tell the shader we wish to multiply
+        // against the diffuse texture. We substract 0.5f to avoid -0.0 = 0.0
+        dataPtr[3] = -customParam.w - 0.5f;
+      }
+      else
+      {
+        dataPtr[3] = customParam.w;
+      }
     }
 
     return instanceIdx;

--- a/ogre2/src/Ogre2IgnHlmsTerraPrivate.cc
+++ b/ogre2/src/Ogre2IgnHlmsTerraPrivate.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ogre2/src/Ogre2IgnHlmsTerraPrivate.cc
+++ b/ogre2/src/Ogre2IgnHlmsTerraPrivate.cc
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "Ogre2IgnHlmsTerraPrivate.hh"
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
+#include <ignition/common/Util.hh>
+
+#ifdef _MSC_VER
+#  pragma warning(push, 0)
+#endif
+#include <CommandBuffer/OgreCbShaderBuffer.h>
+#include <CommandBuffer/OgreCommandBuffer.h>
+#include <OgreRenderQueue.h>
+#include <Vao/OgreConstBufferPacked.h>
+#include <Vao/OgreVaoManager.h>
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+using namespace ignition;
+using namespace rendering;
+
+namespace Ogre
+{
+  /// \brief The slot where to bind currPerObjectDataBuffer
+  /// HlmsPbs might consume slot 3, so we always use slot 4 for simplicity
+  /// \internal
+  static const uint16 kPerObjectDataBufferSlot = 4u;
+
+  Ogre2IgnHlmsTerra::Ogre2IgnHlmsTerra(
+    Archive *dataFolder, ArchiveVec *libraryFolders,
+    Ogre2IgnHlmsSphericalClipMinDistance *_sphericalClipMinDistance) :
+    HlmsTerra(dataFolder, libraryFolders)
+  {
+    this->customizations.push_back(_sphericalClipMinDistance);
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::preparePassHash(
+    const CompositorShadowNode *_shadowNode, bool _casterPass,
+    bool _dualParaboloid, SceneManager *_sceneManager, Hlms *_hlms)
+  {
+    if (!_casterPass &&
+        (this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
+         this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED))
+    {
+      _hlms->_setProperty("ign_render_solid_color", 1);
+
+      if (this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED)
+        _hlms->_setProperty("ign_render_solid_color_textured", 1);
+    }
+
+    // Allow additional listener-only customizations to inject their stuff
+    for (Ogre::HlmsListener *listener : this->customizations)
+    {
+      listener->preparePassHash(_shadowNode, _casterPass, _dualParaboloid,
+                                _sceneManager, _hlms);
+    }
+  }
+
+  /////////////////////////////////////////////////
+  uint32 Ogre2IgnHlmsTerra::getPassBufferSize(
+    const Ogre::CompositorShadowNode *_shadowNode, bool _casterPass,
+    bool _dualParaboloid, Ogre::SceneManager *_sceneManager) const
+  {
+    uint32 bufferSize = 0u;
+
+    // Allow additional listener-only customizations to inject their stuff
+    for (Ogre::HlmsListener *listener : this->customizations)
+    {
+      bufferSize += listener->getPassBufferSize(_shadowNode, _casterPass,
+                                                _dualParaboloid, _sceneManager);
+    }
+    return bufferSize;
+  }
+
+  /////////////////////////////////////////////////
+  float *Ogre2IgnHlmsTerra::preparePassBuffer(
+    const Ogre::CompositorShadowNode *_shadowNode, bool _casterPass,
+    bool _dualParaboloid, Ogre::SceneManager *_sceneManager,
+    float *_passBufferPtr)
+  {
+    // Allow additional listener-only customizations to inject their stuff
+    for (Ogre::HlmsListener *listener : this->customizations)
+    {
+      _passBufferPtr =
+        listener->preparePassBuffer(_shadowNode, _casterPass, _dualParaboloid,
+                                    _sceneManager, _passBufferPtr);
+    }
+    return _passBufferPtr;
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::shaderCacheEntryCreated(
+    const String &_shaderProfile, const HlmsCache *_hlmsCacheEntry,
+    const HlmsCache &_passCache, const HlmsPropertyVec &_properties,
+    const QueuedRenderable &_queuedRenderable)
+  {
+    // Allow additional listener-only customizations to inject their stuff
+    for (Ogre::HlmsListener *listener : this->customizations)
+    {
+      listener->shaderCacheEntryCreated(_shaderProfile, _hlmsCacheEntry,
+                                        _passCache, _properties,
+                                        _queuedRenderable);
+    }
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::notifyPropertiesMergedPreGenerationStep()
+  {
+    HlmsTerra::notifyPropertiesMergedPreGenerationStep();
+
+    setProperty("IgnPerObjectDataSlot", kPerObjectDataBufferSlot);
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::hlmsTypeChanged(bool _casterPass,
+                                          CommandBuffer *_commandBuffer,
+                                          const HlmsDatablock *_datablock)
+  {
+    // Allow additional listener-only customizations to inject their stuff
+    for (Ogre::HlmsListener *listener : this->customizations)
+    {
+      listener->hlmsTypeChanged(_casterPass, _commandBuffer, _datablock);
+    }
+
+    if (_casterPass ||
+        (this->ignOgreRenderingMode != IORM_SOLID_COLOR &&
+         this->ignOgreRenderingMode != IORM_SOLID_THERMAL_COLOR_TEXTURED))
+    {
+      return;
+    }
+
+    this->BindObjectDataBuffer(_commandBuffer, kPerObjectDataBufferSlot);
+  }
+
+  /////////////////////////////////////////////////
+  uint32 Ogre2IgnHlmsTerra::fillBuffersForV1(
+    const HlmsCache *_cache, const QueuedRenderable &_queuedRenderable,
+    bool _casterPass, uint32 _lastCacheHash, CommandBuffer *_commandBuffer)
+  {
+    const uint32 instanceIdx = HlmsTerra::fillBuffersForV1(
+      _cache, _queuedRenderable, _casterPass, _lastCacheHash, _commandBuffer);
+
+    if ((this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
+         this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED) &&
+        !_casterPass)
+    {
+      Vector4 customParam =
+        _queuedRenderable.renderable->getCustomParameter(1u);
+      float *dataPtr = this->MapObjectDataBufferFor(
+        instanceIdx, _commandBuffer, this->mVaoManager, this->mConstBuffers,
+        this->mCurrentConstBuffer, this->mStartMappedConstBuffer,
+        kPerObjectDataBufferSlot);
+      dataPtr[0] = customParam.x;
+      dataPtr[1] = customParam.y;
+      dataPtr[2] = customParam.z;
+
+      if (this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED &&
+          _queuedRenderable.renderable->hasCustomParameter(2u))
+      {
+        IGN_ASSERT(customParam.w >= 0.0f,
+                   "customParam.w can't be negative for "
+                   "IORM_SOLID_THERMAL_COLOR_TEXTURED");
+
+        // Negate customParam.w to tell the shader we wish to multiply
+        // against the diffuse texture. We substract 0.5f to avoid -0.0 = 0.0
+        dataPtr[3] = -customParam.w - 0.5f;
+      }
+      else
+      {
+        dataPtr[3] = customParam.w;
+      }
+    }
+
+    return instanceIdx;
+  }
+
+  /////////////////////////////////////////////////
+  uint32 Ogre2IgnHlmsTerra::fillBuffersForV2(
+    const HlmsCache *_cache, const QueuedRenderable &_queuedRenderable,
+    bool _casterPass, uint32 _lastCacheHash, CommandBuffer *_commandBuffer)
+  {
+    const uint32 instanceIdx = HlmsTerra::fillBuffersForV2(
+      _cache, _queuedRenderable, _casterPass, _lastCacheHash, _commandBuffer);
+
+    if ((this->ignOgreRenderingMode == IORM_SOLID_COLOR ||
+         this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED) &&
+        !_casterPass)
+    {
+      Vector4 customParam;
+      try
+      {
+        customParam = _queuedRenderable.renderable->getCustomParameter(1u);
+      }
+      catch (ItemIdentityException &)
+      {
+        // This error can trigger for two reasons:
+        //
+        //  1. We forgot to call setCustomParameter(1u, ...)
+        //  2. This object should not be rendered and we should've called
+        //     movableObject->setVisible(false) or use RenderQueue IDs
+        //     or visibility flags to prevent rendering it
+        ignerr << "A module is trying to render an object without "
+                  "specifying a parameter. Please report this bug at "
+                  "https://github.com/ignitionrobotics/ign-rendering/issues\n";
+        throw;
+      }
+      float *dataPtr = this->MapObjectDataBufferFor(
+        instanceIdx, _commandBuffer, this->mVaoManager, this->mConstBuffers,
+        this->mCurrentConstBuffer, this->mStartMappedConstBuffer,
+        kPerObjectDataBufferSlot);
+      dataPtr[0] = customParam.x;
+      dataPtr[1] = customParam.y;
+      dataPtr[2] = customParam.z;
+      dataPtr[3] = customParam.w;
+
+      if (this->ignOgreRenderingMode == IORM_SOLID_THERMAL_COLOR_TEXTURED &&
+          _queuedRenderable.renderable->hasCustomParameter(2u))
+      {
+        IGN_ASSERT(customParam.w >= 0.0f,
+                   "customParam.w can't be negative for "
+                   "IORM_SOLID_THERMAL_COLOR_TEXTURED");
+
+        // Negate customParam.w to tell the shader we wish to multiply
+        // against the diffuse texture. We substract 0.5f to avoid -0.0 = 0.0
+        dataPtr[3] = -customParam.w - 0.5f;
+      }
+      else
+      {
+        dataPtr[3] = customParam.w;
+      }
+    }
+
+    return instanceIdx;
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::preCommandBufferExecution(
+    CommandBuffer *_commandBuffer)
+  {
+    this->UnmapObjectDataBuffer();
+    HlmsTerra::preCommandBufferExecution(_commandBuffer);
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::frameEnded()
+  {
+    HlmsTerra::frameEnded();
+
+    this->currPerObjectDataBuffer = nullptr;
+    this->lastMainConstBuffer = nullptr;
+    this->currPerObjectDataPtr = nullptr;
+  }
+
+  /////////////////////////////////////////////////
+  void Ogre2IgnHlmsTerra::GetDefaultPaths(String &_outDataFolderPath,
+                                          StringVector &_outLibraryFoldersPaths)
+  {
+    HlmsTerra::getDefaultPaths(_outDataFolderPath, _outLibraryFoldersPaths);
+
+    _outLibraryFoldersPaths.push_back(
+      common::joinPaths("Hlms", "Ignition", "SolidColor"));
+    _outLibraryFoldersPaths.push_back(
+      common::joinPaths("Hlms", "Ignition", "SphericalClipMinDistance"));
+    _outLibraryFoldersPaths.push_back(
+      common::joinPaths("Hlms", "Ignition", "Pbs"));
+  }
+}  // namespace Ogre

--- a/ogre2/src/Ogre2IgnHlmsTerraPrivate.hh
+++ b/ogre2/src/Ogre2IgnHlmsTerraPrivate.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ogre2/src/Ogre2IgnHlmsTerraPrivate.hh
+++ b/ogre2/src/Ogre2IgnHlmsTerraPrivate.hh
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef IGNITION_RENDERING_OGRE2_OGRE2IGNHLMSTERRAPRIVATE_HH_
+#define IGNITION_RENDERING_OGRE2_OGRE2IGNHLMSTERRAPRIVATE_HH_
+
+#include "ignition/rendering/config.hh"
+#include "ignition/rendering/ogre2/Export.hh"
+
+#include "Ogre2IgnHlmsSharedPrivate.hh"
+#include "Ogre2IgnHlmsSphericalClipMinDistance.hh"
+#include "Terra/Hlms/OgreHlmsTerra.h"
+
+#ifdef _MSC_VER
+#  pragma warning(push, 0)
+#endif
+#include <OgreHlmsListener.h>
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+#include <vector>
+
+namespace Ogre
+{
+  /// \brief Controls custom shader snippets of Hlms:
+  ///
+  ///   - Toggles them on/off
+  ///   - Sends relevant data to the GPU buffers for shaders to use
+  ///
+  /// This listener requires Hlms to have been created with the piece data
+  /// files in ogre2/src/media/Hlms/Ignition registered
+  ///
+  /// We need to derive from HlmsTerra (rather than just using
+  /// HlmsListener) when we need to use code that sends data
+  /// *per object*
+  ///
+  /// For performance reasons Ogre does not allow passing per-object
+  /// data via listeners; so we override Hlms implementations.
+  ///
+  /// Use GetDefaultPaths to get them
+  ///
+  /// \internal
+  /// \remark Public variables take effect immediately (i.e. for the
+  /// next render)
+  class IGNITION_RENDERING_OGRE2_HIDDEN Ogre2IgnHlmsTerra final
+    : public HlmsTerra,
+      public HlmsListener,
+      public ignition::rendering::Ogre2IgnHlmsShared
+  {
+    /// \brief Constructor. Asks for modular listeners so we can add
+    /// them in the proper order
+    public: Ogre2IgnHlmsTerra(Archive *dataFolder, ArchiveVec *libraryFolders,
+                              ignition::rendering::
+                              Ogre2IgnHlmsSphericalClipMinDistance
+                              *_sphericalClipMinDistance);
+
+      /// \brief Destructor. Virtual to silence warnings
+    public: virtual ~Ogre2IgnHlmsTerra() override = default;
+
+    // Documentation inherited
+    public: using HlmsTerra::preparePassHash;
+
+    /// \brief Override HlmsListener to add customizations.
+    /// We can't override HlmsTerra because adding properties before
+    /// calling it will be cleared. And adding it afterwards is too late.
+    /// The listener gets called right in the middle
+    ///
+    /// \param[in] _shadowNode see base class
+    /// \param[in] _casterPass see base class
+    /// \param[in] _dualParaboloid see base class
+    /// \param[in] _sceneManager see base class
+    /// \param[in] _hlms see base class
+    public: virtual void preparePassHash(
+        const CompositorShadowNode *_shadowNode,
+        bool _casterPass,
+        bool _dualParaboloid,
+        SceneManager *_sceneManager,
+        Hlms *_hlms) override;
+
+    /// \brief Tells Ogre the buffer data sent to GPU should be a little
+    /// bigger to fit our data we need to send
+    /// \param[in] _shadowNode see base class
+    /// \param[in] _casterPass see base class
+    /// \param[in] _dualParaboloid see base class
+    /// \param[in] _sceneManager see base class
+    /// \return Size in bytes of how bigger the buffer should be
+    public: virtual uint32 getPassBufferSize(
+        const Ogre::CompositorShadowNode *_shadowNode,
+        bool _casterPass, bool _dualParaboloid,
+        Ogre::SceneManager *_sceneManager) const override;
+
+    /// \brief Sends our custom data to GPU buffers that our
+    /// pieces activated in preparePassHash will need.
+    ///
+    /// Bytes written must not exceed what we informed in getPassBufferSize
+    /// \param[in] _shadowNode see base class
+    /// \param[in] _casterPass see base class
+    /// \param[in] _dualParaboloid see base class
+    /// \param[in] _sceneManager see base class
+    /// \param[in] _passBufferPtr see base class
+    /// \return The pointer where Ogre should continue appending more data
+    private: virtual float* preparePassBuffer(
+        const Ogre::CompositorShadowNode *_shadowNode,
+        bool _casterPass, bool _dualParaboloid,
+        Ogre::SceneManager *_sceneManager,
+        float *_passBufferPtr) override;
+
+    /// \brief See HlmsListener::shaderCacheEntryCreated
+    public: virtual void shaderCacheEntryCreated(
+        const String &_shaderProfile, const HlmsCache *_hlmsCacheEntry,
+        const HlmsCache &_passCache, const HlmsPropertyVec &_properties,
+        const QueuedRenderable &_queuedRenderable) override;
+
+    /// \brief Override to calculate which slots are used
+    public: virtual void notifyPropertiesMergedPreGenerationStep() override;
+
+    /// \brief Override HlmsListener::hlmsTypeChanged so we can
+    /// bind buffers which carry per-object data when in IORM_SOLID_COLOR
+    /// \param[in] _casterPass true if this is a caster pass
+    /// \param[in] _commandBuffer command buffer so we can add commands
+    /// \param[in] _datablock material of the object that caused
+    /// Ogre2IgnHlmsTerra to be bound again
+    public: virtual void hlmsTypeChanged(
+        bool _casterPass,
+        CommandBuffer *_commandBuffer,
+        const HlmsDatablock *_datablock) override;
+
+    // Documentation inherited
+    public: virtual uint32 fillBuffersForV1(
+        const HlmsCache *_cache,
+        const QueuedRenderable &_queuedRenderable,
+        bool _casterPass, uint32 _lastCacheHash,
+        CommandBuffer *_commandBuffer ) override;
+
+    // Documentation inherited
+    public: virtual uint32 fillBuffersForV2(
+        const HlmsCache *_cache,
+        const QueuedRenderable &_queuedRenderable,
+        bool _casterPass, uint32 _lastCacheHash,
+        CommandBuffer *_commandBuffer ) override;
+
+    // Documentation inherited
+    public: virtual void preCommandBufferExecution(
+        CommandBuffer *_commandBuffer) override;
+
+    // Documentation inherited
+    public: virtual void frameEnded() override;
+
+    //// \brief Same as HlmsTerra::getDefaultPaths, but we also append
+    /// our own paths with customizations
+    /// \param[out] _outDataFolderPath Path (as a String) used for
+    /// creating the "dataFolder" Archive the constructor will need
+    /// \param[out] _outLibraryFoldersPaths
+    /// Vector of String used for creating the ArchiveVector "libraryFolders"
+    /// the constructor will need. Our own stuff is appended here
+    public: static void GetDefaultPaths(String &_outDataFolderPath,
+                                        StringVector &_outLibraryFoldersPaths);
+
+    /// \brief Contains additional customizations that are modular and
+    /// implemented as listener-only
+    private: std::vector<Ogre::HlmsListener*> customizations;
+  };
+}  // namespace Ogre
+
+#endif

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -83,7 +83,8 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
 
     this->colorDict[this->currentColor.AsRGBA()] = item->getName();
 
-    for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
+    const size_t numSubItems = item->getNumSubItems();
+    for (size_t i = 0; i < numSubItems; ++i)
     {
       Ogre::SubItem *subItem = item->getSubItem(i);
 
@@ -131,6 +132,29 @@ void Ogre2MaterialSwitcher::cameraPostRenderScene(
     hlmsManager->destroyBlendblock(blendblock);
   }
   this->datablockMap.clear();
+
+  // Remove the custom parameter. Why? If there are multiple cameras that
+  // use IORM_SOLID_COLOR (or any other mode), we want them to throw if
+  // that code forgot to call setCustomParameter. We may miss those errors
+  // if that code forgets to call but it was already carrying the value
+  // we set here.
+  //
+  // This consumes more performance but it's the price to pay for
+  // safety.
+  auto itor = this->scene->OgreSceneManager()->getMovableObjectIterator(
+      Ogre::ItemFactory::FACTORY_TYPE_NAME);
+  while (itor.hasMoreElements())
+  {
+    Ogre::MovableObject *object = itor.peekNext();
+    Ogre::Item *item = static_cast<Ogre::Item *>(object);
+    const size_t numSubItems = item->getNumSubItems();
+    for (size_t i = 0; i < numSubItems; ++i)
+    {
+      Ogre::SubItem *subItem = item->getSubItem(i);
+      subItem->removeCustomParameter(1u);
+    }
+    itor.moveNext();
+  }
 
   engine->SetIgnOgreRenderingMode(IORM_NORMAL);
 }

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -111,6 +111,9 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
     }
     itor.moveNext();
   }
+
+  // Remove the reference count on noBlend we created
+  hlmsManager->destroyBlendblock(noBlend);
 }
 
 /////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -80,6 +80,9 @@ class IGNITION_RENDERING_OGRE2_HIDDEN
 
   /// \brief Custom Unlit modifications
   public: Ogre::Ogre2IgnHlmsUnlit *ignHlmsUnlit{nullptr};
+
+  /// \brief Custom Terra modifications
+  public: Ogre::Ogre2IgnHlmsTerra *ignHlmsTerra{nullptr};
 };
 
 using namespace ignition;
@@ -817,13 +820,10 @@ void Ogre2RenderEngine::RegisterHlms()
     Ogre::Ogre2IgnHlmsTerra *hlmsTerra = 0;
     // Create & Register HlmsPbs
     // Do the same for HlmsPbs:
-    Ogre::Ogre2IgnHlmsTerra::getDefaultPaths(mainFolderPath,
+    Ogre::Ogre2IgnHlmsTerra::GetDefaultPaths(mainFolderPath,
                                              libraryFoldersPaths);
     Ogre::Archive *archiveTerra = archiveManager.load(
         rootHlmsFolder + mainFolderPath, "FileSystem", true);
-
-    // Add ignition's customizations
-    libraryFoldersPaths.push_back(common::joinPaths("Hlms", "Terra", "ign"));
 
     // Get the library archive(s)
     Ogre::ArchiveVec archiveTerraLibraryFolders;
@@ -846,9 +846,12 @@ void Ogre2RenderEngine::RegisterHlms()
 
     // disable writting debug output to disk
     hlmsTerra->setDebugOutputPath(false, false);
+    hlmsTerra->setListener(hlmsTerra);
 
     this->dataPtr->terraWorkspaceListener.reset(
       new Ogre::TerraWorkspaceListener(hlmsTerra));
+
+    this->dataPtr->ignHlmsTerra = hlmsTerra;
   }
 }
 
@@ -1043,6 +1046,8 @@ void Ogre2RenderEngine::SetIgnOgreRenderingMode(
   IgnOgreRenderingMode renderingMode)
 {
   this->dataPtr->ignHlmsPbs->ignOgreRenderingMode = renderingMode;
+  this->dataPtr->ignHlmsUnlit->ignOgreRenderingMode = renderingMode;
+  this->dataPtr->ignHlmsTerra->ignOgreRenderingMode = renderingMode;
 }
 
 /////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -43,6 +43,7 @@
 #include "ignition/rendering/ogre2/Ogre2Storage.hh"
 
 #include "Ogre2IgnHlmsPbsPrivate.hh"
+#include "Ogre2IgnHlmsTerraPrivate.hh"
 #include "Ogre2IgnHlmsUnlitPrivate.hh"
 
 #include "Terra/Hlms/OgreHlmsTerra.h"
@@ -777,6 +778,14 @@ void Ogre2RenderEngine::RegisterHlms()
 
     // Get the library archive(s)
     Ogre::ArchiveVec archivePbsLibraryFolders;
+
+    {
+      archivePbsLibraryFolders.push_back(archiveManager.load(
+        rootHlmsFolder + common::joinPaths("Hlms", "Terra", "GLSL",
+        "PbsTerraShadows"), "FileSystem", true ));
+      this->dataPtr->hlmsPbsTerraShadows.reset(new Ogre::HlmsPbsTerraShadows());
+    }
+
     libraryFolderPathIt = libraryFoldersPaths.begin();
     libraryFolderPathEn = libraryFoldersPaths.end();
     while (libraryFolderPathIt != libraryFolderPathEn)
@@ -789,12 +798,6 @@ void Ogre2RenderEngine::RegisterHlms()
     }
 
     archivePbsLibraryFolders.push_back(customizationsArchiveLibrary);
-    {
-      archivePbsLibraryFolders.push_back(archiveManager.load(
-        rootHlmsFolder + common::joinPaths("Hlms", "Terra", "GLSL",
-        "PbsTerraShadows"), "FileSystem", true ));
-      this->dataPtr->hlmsPbsTerraShadows.reset(new Ogre::HlmsPbsTerraShadows());
-    }
 
     // Create and register
     hlmsPbs =
@@ -811,10 +814,11 @@ void Ogre2RenderEngine::RegisterHlms()
   }
 
   {
-    Ogre::HlmsTerra *hlmsTerra = 0;
+    Ogre::Ogre2IgnHlmsTerra *hlmsTerra = 0;
     // Create & Register HlmsPbs
     // Do the same for HlmsPbs:
-    Ogre::HlmsTerra::getDefaultPaths(mainFolderPath, libraryFoldersPaths);
+    Ogre::Ogre2IgnHlmsTerra::getDefaultPaths(mainFolderPath,
+                                             libraryFoldersPaths);
     Ogre::Archive *archiveTerra = archiveManager.load(
         rootHlmsFolder + mainFolderPath, "FileSystem", true);
 
@@ -835,8 +839,9 @@ void Ogre2RenderEngine::RegisterHlms()
     }
 
     // Create and register
-    hlmsTerra = OGRE_NEW Ogre::HlmsTerra(archiveTerra,
-                                         &archiveTerraLibraryFolders);
+    hlmsTerra = OGRE_NEW Ogre::Ogre2IgnHlmsTerra(
+      archiveTerra, &archiveTerraLibraryFolders,
+      &this->dataPtr->sphericalClipMinDistance);
     Ogre::Root::getSingleton().getHlmsManager()->registerHlms(hlmsTerra);
 
     // disable writting debug output to disk

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -310,7 +310,7 @@ ignition::common::ConnectionPtr
 void Ogre2SegmentationCamera::Render()
 {
   // update the compositors
-  this->scene->StartRendering(nullptr);
+  this->scene->StartRendering(this->ogreCamera);
 
   this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
   this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -80,7 +80,7 @@ bool Ogre2SegmentationMaterialSwitcher::IsTakenColor(const math::Color &_color)
 }
 
 /////////////////////////////////////////////////
-Ogre::Vector4 Ogre2SegmentationMaterialSwitcher::GetColorForVisual(
+Ogre::Vector4 Ogre2SegmentationMaterialSwitcher::ColorForVisual(
   const VisualPtr &_visual, std::string &_prevParentName)
 {
   // get class user data
@@ -290,7 +290,7 @@ void Ogre2SegmentationMaterialSwitcher::cameraPreRenderScene(
       }
 
       const Ogre::Vector4 customParameter =
-        GetColorForVisual(visual, prevParentName);
+        ColorForVisual(visual, prevParentName);
 
       const size_t numSubItems = item->getNumSubItems();
       for (size_t i = 0; i < numSubItems; ++i)
@@ -342,7 +342,7 @@ void Ogre2SegmentationMaterialSwitcher::cameraPreRenderScene(
       // like we do with Items (it should be impossible?)
       VisualPtr visual = heightmap->Parent();
       const Ogre::Vector4 customParameter =
-        GetColorForVisual(visual, prevParentName);
+        ColorForVisual(visual, prevParentName);
       heightmap->Terra()->SetSolidColor(1u, customParameter);
     }
   }

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -74,8 +74,8 @@ class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationMaterialSwitcher :
   /// \param[in,out] _prevParentName A persistent string between call
   /// to ensure multilink visuals receive the same color
   /// \return The color to apply to the visual
-  private: Ogre::Vector4 GetColorForVisual(const VisualPtr &_visual,
-                                           std::string &_prevParentName);
+  private: Ogre::Vector4 ColorForVisual(const VisualPtr &_visual,
+                                        std::string &_prevParentName);
 
   /// \brief Convert label of semantic map to a unique color for colored map and
   /// add the color of the label to the taken colors if it doesn't exist

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -102,7 +102,7 @@ class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationMaterialSwitcher :
 
   /// \brief Keep track of num of instances of the same label
   /// Key: label id, value: num of instances
-  private: std::unordered_map<unsigned int, unsigned int> instancesCount;
+  private: std::unordered_map<int, unsigned int> instancesCount;
 
   /// \brief keep track of the random colors (store encoded id of r,g,b)
   private: std::unordered_set<int64_t> takenColors;

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -18,10 +18,12 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2SEGMENTATIONMATERIALSWITCHER_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2SEGMENTATIONMATERIALSWITCHER_HH_
 
-#include <string>
 #include <random>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include <ignition/math/Color.hh>
 

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -121,6 +121,12 @@ class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationMaterialSwitcher :
   private: std::unordered_map<Ogre::HlmsDatablock *,
       const Ogre::HlmsBlendblock *> datablockMap;
 
+  /// \brief A map of ogre sub item pointer to their original low level
+  /// material.
+  /// Most objects don't use one so it should be almost always empty.
+  private:
+    std::vector<std::pair<Ogre::SubItem *, Ogre::MaterialPtr>> materialMap;
+
   /// \brief Pseudo num generator to generate colors from label id
   private: std::default_random_engine generator;
 

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -67,6 +67,14 @@ class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationMaterialSwitcher :
   /// \return The map between color and label IDs
   public: const std::unordered_map<int64_t, int64_t> &ColorToLabel() const;
 
+  /// \brief Create a color to apply for the given visual
+  /// \param[in] _visual Visual will be applying the color to
+  /// \param[in,out] _prevParentName A persistent string between call
+  /// to ensure multilink visuals receive the same color
+  /// \return The color to apply to the visual
+  private: Ogre::Vector4 GetColorForVisual(const VisualPtr &_visual,
+                                           std::string &_prevParentName);
+
   /// \brief Convert label of semantic map to a unique color for colored map and
   /// add the color of the label to the taken colors if it doesn't exist
   /// \param[in] _label id of the semantic map or encoded id of panoptic map

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -312,7 +312,8 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
               << std::endl;
         }
 
-        for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
+        const size_t numSubItems = item->getNumSubItems();
+        for (size_t i = 0; i < numSubItems; ++i)
         {
           Ogre::SubItem *subItem = item->getSubItem(i);
 
@@ -398,7 +399,8 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
           this->heatSignatureMaterials[item->getId()] = heatSignatureMaterial;
         }
 
-        for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
+        const size_t numSubItems = item->getNumSubItems();
+        for (size_t i = 0; i < numSubItems; ++i)
         {
           Ogre::SubItem *subItem = item->getSubItem(i);
 
@@ -418,7 +420,8 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
         //
         // We will be converting rgb values to temperature values in shaders
         // thus we want them textured but without lighting
-        for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
+        const size_t numSubItems = item->getNumSubItems();
+        for (size_t i = 0; i < numSubItems; ++i)
         {
           Ogre::SubItem *subItem = item->getSubItem(i);
 
@@ -466,12 +469,38 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPostRenderScene(
   }
   this->datablockMap.clear();
 
+  // Remove the custom parameter. Why? If there are multiple cameras that
+  // use IORM_SOLID_COLOR (or any other mode), we want them to throw if
+  // that code forgot to call setCustomParameter. We may miss those errors
+  // if that code forgets to call but it was already carrying the value
+  // we set here.
+  //
+  // This consumes more performance but it's the price to pay for
+  // safety.
+  auto itor = this->scene->OgreSceneManager()->getMovableObjectIterator(
+      Ogre::ItemFactory::FACTORY_TYPE_NAME);
+  while (itor.hasMoreElements())
+  {
+    Ogre::MovableObject *object = itor.peekNext();
+    Ogre::Item *item = static_cast<Ogre::Item *>(object);
+    const size_t numSubItems = item->getNumSubItems();
+    for (size_t i = 0; i < numSubItems; ++i)
+    {
+      Ogre::SubItem *subItem = item->getSubItem(i);
+      subItem->removeCustomParameter(1u);
+      subItem->removeCustomParameter(2u);
+    }
+    itor.moveNext();
+  }
+
   // restore item to use pbs hlms material
   for (auto it : this->itemDatablockMap)
   {
     Ogre::SubItem *subItem = it.first;
     subItem->setDatablock(it.second);
   }
+
+  engine->SetIgnOgreRenderingMode(IORM_NORMAL);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -233,7 +233,7 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
     Ogre::Camera * /*_cam*/)
 {
   auto engine = Ogre2RenderEngine::Instance();
-  engine->SetIgnOgreRenderingMode(IORM_SOLID_COLOR);
+  engine->SetIgnOgreRenderingMode(IORM_SOLID_COLOR_NOT_UNLIT);
 
   Ogre::HlmsManager *hlmsManager = engine->OgreRoot()->getHlmsManager();
 
@@ -453,7 +453,7 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
           if(!ogreMat->HasTexture())
           {
             // Fast path: We can use the current PBS datablock
-            // while in IORM_SOLID_COLOR
+            // while in IORM_SOLID_COLOR_NOT_UNLIT
             math::Color color = ogreMat->Diffuse();
             for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
             {
@@ -468,7 +468,7 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
           }
           else
           {
-            // Slow path: IORM_SOLID_COLOR doesn't support a texture,
+            // Slow path: IORM_SOLID_COLOR_NOT_UNLIT doesn't support a texture,
             // so we use a temporary Unlit Datablock
             Ogre::HlmsUnlitDatablock *unlit = ogreMat->UnlitDatablock();
             for (unsigned int i = 0; i < item->getNumSubItems(); ++i)

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -233,7 +233,7 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
     Ogre::Camera * /*_cam*/)
 {
   auto engine = Ogre2RenderEngine::Instance();
-  engine->SetIgnOgreRenderingMode(IORM_SOLID_COLOR_NOT_UNLIT);
+  engine->SetIgnOgreRenderingMode(IORM_SOLID_THERMAL_COLOR_TEXTURED);
 
   Ogre::HlmsManager *hlmsManager = engine->OgreRoot()->getHlmsManager();
 
@@ -254,7 +254,6 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
     Ogre::MovableObject *object = itor.peekNext();
     Ogre::Item *item = static_cast<Ogre::Item *>(object);
 
-    bool backgroundObject = true;
     const std::string tempKey = "temperature";
     // get visual
     Ogre::Any userAny = item->getUserObjectBindings().getUserAny();
@@ -313,8 +312,6 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
               << std::endl;
         }
 
-        backgroundObject = false;
-
         for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
         {
           Ogre::SubItem *subItem = item->getSubItem(i);
@@ -350,8 +347,6 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
       // get heat signature and the corresponding min/max temperature values
       else if (auto heatSignature = std::get_if<std::string>(&tempAny))
       {
-        backgroundObject = false;
-
         // if this is the first time rendering the heat signature,
         // we need to make sure that the texture is loaded and applied to
         // the heat signature material before loading the material
@@ -413,72 +408,37 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
           subItem->setMaterial(this->heatSignatureMaterials[item->getId()]);
         }
       }
-    }
-
-    // Temperature object not set (or there was an error)
-    // We need to use the "background object" material which uses
-    // an Unlit material to output full RGB that is actually used
-    // by thermal_camera_fs.glsl
-    if (backgroundObject)
-    {
-      VisualPtr result;
-      try
+      else
       {
-        result = this->scene->VisualById(Ogre::any_cast<unsigned int>(userAny));
-      }
-      catch (Ogre::Exception &e)
-      {
-        ignerr << "Ogre Error:" << e.getFullDescription() << "\n";
-      }
-      Ogre2VisualPtr ogreVisual =
-        std::dynamic_pointer_cast<Ogre2Visual>(result);
-
-      Ogre::Aabb aabb = item->getWorldAabbUpdated();
-      Ogre::AxisAlignedBox box =
-        Ogre::AxisAlignedBox(aabb.getMinimum(), aabb.getMaximum());
-
-      // we will be converting rgb values to temperature values in shaders
-      // but we want to make sure the object rgb values are not affected by
-      // lighting, so disable lighting
-      // Also check if objects are within camera view
-      if (ogreVisual->GeometryCount() > 0u && this->ogreCamera->isVisible(box))
-      {
-        auto geom = ogreVisual->GeometryByIndex(0);
-        if (geom)
+        // Temperature object not set
+        // We consider this a "background object".
+        //
+        // It will be set to ambient temperature in thermal_camera_fs.glsl
+        // but its unlit, textured RGB color actually matters.
+        //
+        // We will be converting rgb values to temperature values in shaders
+        // thus we want them textured but without lighting
+        for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
         {
-          MaterialPtr mat = geom->Material();
-          Ogre2MaterialPtr ogreMat =
-            std::dynamic_pointer_cast<Ogre2Material>(mat);
+          Ogre::SubItem *subItem = item->getSubItem(i);
 
-          if(!ogreMat->HasTexture())
-          {
-            // Fast path: We can use the current PBS datablock
-            // while in IORM_SOLID_COLOR_NOT_UNLIT
-            math::Color color = ogreMat->Diffuse();
-            for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
-            {
-              Ogre::SubItem *subItem = item->getSubItem(i);
-              subItem->setCustomParameter(
-                1, Ogre::Vector4(color.R(), color.G(), color.B(), 1.0));
+          const Ogre::HlmsDatablock *datablock = subItem->getDatablock();
 
-              // We don't save to this->datablockMap because we're already
-              // honouring the original HlmsBlendblock. There's nothing
-              // to override.
-            }
-          }
-          else
-          {
-            // Slow path: IORM_SOLID_COLOR_NOT_UNLIT doesn't support a texture,
-            // so we use a temporary Unlit Datablock
-            Ogre::HlmsUnlitDatablock *unlit = ogreMat->UnlitDatablock();
-            for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
-            {
-              Ogre::SubItem *subItem = item->getSubItem(i);
-              Ogre::HlmsDatablock *datablock = subItem->getDatablock();
-              this->itemDatablockMap[subItem] = datablock;
-              subItem->setDatablock(unlit);
-            }
-          }
+          IGN_ASSERT(datablock->getCreator()->getType() == Ogre::HLMS_PBS ||
+                       datablock->getCreator()->getType() == Ogre::HLMS_UNLIT,
+                     "Item's datablock is expected to be PBS or Unlit");
+
+          const Ogre::ColourValue color = datablock->getDiffuseColour();
+          subItem->setCustomParameter(
+            1u, Ogre::Vector4(color.r, color.g, color.b, 1.0));
+
+          // Set 2 to signal we want it to multiply against
+          // the diffuse texture (if any). The actual value doesn't matter.
+          subItem->setCustomParameter(2u, Ogre::Vector4::ZERO);
+
+          // We don't save to this->datablockMap because we're already
+          // honouring the original HlmsBlendblock. There's nothing
+          // to override.
         }
       }
     }

--- a/ogre2/src/media/Hlms/Ignition/SolidColor/800.IgnSolidColor_piece_ps.any
+++ b/ogre2/src/media/Hlms/Ignition/SolidColor/800.IgnSolidColor_piece_ps.any
@@ -1,7 +1,29 @@
 @property( ign_render_solid_color )
 
 @piece( custom_ps_posExecution_solid_color )
-  outPs_colour0 = inPs.ignSolidColour;
+
+  @property( ign_render_solid_color_textured )
+    if( inPs.ignSolidColour.w >= 0.0f )
+    {
+      outPs_colour0 = inPs.ignSolidColour;
+    }
+    else
+    {
+      @property( diffuse_map )
+        float4 diffuse = SampleDiffuse( textureMaps@value( diffuse_map_idx ),
+                           samplerState@value(diffuse_map_sampler),
+                           UV_DIFFUSE( inPs.uv@value(uv_diffuse).xy ),
+                           texIndex_diffuseIdx );
+        outPs_colour0 = float4( inPs.ignSolidColour.xyz,
+                                -inPs.ignSolidColour.w - 0.5f ) * diffuse;
+      @else
+        outPs_colour0 = float4( inPs.ignSolidColour.xyz,
+                                -inPs.ignSolidColour.w - 0.5f );
+      @end
+    }
+  @else
+    outPs_colour0 = inPs.ignSolidColour;
+  @end
 @end
 
 @end

--- a/ogre2/src/media/Hlms/Terra/ign/100.ign_CustomVs_piece_vs.any
+++ b/ogre2/src/media/Hlms/Terra/ign/100.ign_CustomVs_piece_vs.any
@@ -1,4 +1,4 @@
 
-@piece( custom_vs_posExecution )
+@piece( custom_vs_posExecution_terra )
 	outVs.localHeight = worldPos.z - cellData.pos.y;
 @end

--- a/ogre2/src/media/Hlms/Terra/ign/500.ign_Structs_piece_all.any
+++ b/ogre2/src/media/Hlms/Terra/ign/500.ign_Structs_piece_all.any
@@ -6,6 +6,6 @@
 	float4 ignWeightsMaxHeight;
 @end
 
-@piece( custom_VStoPS )
+@piece( custom_VStoPS_terra )
 	INTERPOLANT( float localHeight, @counter(texcoord) );
 @end

--- a/ogre2/src/terrain/Terra/include/Terra/Hlms/OgreHlmsTerra.h
+++ b/ogre2/src/terrain/Terra/include/Terra/Hlms/OgreHlmsTerra.h
@@ -56,6 +56,7 @@ namespace Ogre
     */
     class HlmsTerra : public HlmsPbs
     {
+    protected:
         MovableObject const *mLastMovableObject;
         DescriptorSetSampler const *mTerraDescSetSampler;
 

--- a/ogre2/src/terrain/Terra/include/Terra/Terra.h
+++ b/ogre2/src/terrain/Terra/include/Terra/Terra.h
@@ -107,6 +107,13 @@ namespace Ogre
         CompositorManager2      *m_compositorManager;
         Camera const            *m_camera;
 
+        // IGN CUSTOMIZE BEGIN
+        /// See IORM_SOLID_COLOR and IORM_SOLID_THERMAL_COLOR_TEXTURED
+        Vector4 mSolidColor[2];
+        /// See IORM_SOLID_COLOR and IORM_SOLID_THERMAL_COLOR_TEXTURED
+        bool mSolidColorSet[2];
+        // IGN CUSTOMIZE END
+
         /// Converts value from Y-up to whatever the user up vector is (see m_zUp)
         inline Vector3 fromYUp( Vector3 value ) const;
         /// Same as fromYUp, but preserves original sign. Needed when value is a scale
@@ -169,6 +176,33 @@ namespace Ogre
         /// Note however, this may have a *tremendous* GPU performance impact.
         void setCustomSkirtMinHeight( const float skirtMinHeight ) { m_skirtSize = skirtMinHeight; }
         float getCustomSkirtMinHeight( void ) const { return m_skirtSize; }
+
+        // IGN CUSTOMIZE BEGIN
+        /// \brief See IORM_SOLID_COLOR and IORM_SOLID_THERMAL_COLOR_TEXTURED
+        /// Replaces renderable->setCustomRenderable(...) because
+        /// a Terrain may have many renderables but the color is the same
+        /// for all of them
+        /// \param[in] _idx must in range [1; 2]
+        /// \param[in] _idx _solidColor color to apply
+        void SetSolidColor(size_t _idx, const Vector4 _solidColor);
+
+        /// \brief See IORM_SOLID_COLOR and IORM_SOLID_THERMAL_COLOR_TEXTURED
+        /// Retrieves the value set with SetSolidColor. Throws if unset.
+        /// \param[in] _idx must in range [1; 2]
+        /// \return Color value
+        Vector4 SolidColor(size_t _idx) const;
+
+        /// \brief See IORM_SOLID_COLOR and IORM_SOLID_THERMAL_COLOR_TEXTURED
+        /// Checks whether a color has been set
+        /// \param[in] _idx must in range [1; 2]
+        /// \return True if color has been unset
+        bool HasSolidColor(size_t _idx) const;
+
+        /// \brief See IORM_SOLID_COLOR and IORM_SOLID_THERMAL_COLOR_TEXTURED
+        /// Marks all SetSolidColor as unset so that SolidColor throws
+        /// if used again without setting.
+        void UnsetSolidColors();
+        // IGN CUSTOMIZE END
 
         /** Must be called every frame so we can check the camera's position
             (passed in the constructor) and update our visible batches (and LODs)

--- a/ogre2/src/terrain/Terra/src/Terra.cpp
+++ b/ogre2/src/terrain/Terra/src/Terra.cpp
@@ -94,6 +94,13 @@ namespace Ogre
         m_camera( camera ),
         mHlmsTerraIndex( std::numeric_limits<uint32>::max() )
     {
+      // IGN CUSTOMIZE BEGIN
+      for(int i = 0; i < 2; ++i)
+      {
+        mSolidColor[i] = Vector4::ZERO;
+        mSolidColorSet[i] = false;
+      }
+      // IGN CUSTOMIZE END
     }
     //-----------------------------------------------------------------------------------
     Terra::~Terra()
@@ -522,6 +529,43 @@ namespace Ogre
 
         m_collectedCells[0].clear();
     }
+    //-----------------------------------------------------------------------------------
+    // IGN CUSTOMIZE BEGIN
+    void Terra::SetSolidColor(size_t _idx, const Vector4 solidColor)
+    {
+      assert(_idx > 0u && _idx < 3u);
+      _idx = _idx - 1u;
+
+      mSolidColor[_idx] = solidColor;
+      mSolidColorSet[_idx] = true;
+    }
+    //-----------------------------------------------------------------------------------
+    Vector4 Terra::SolidColor(size_t _idx) const
+    {
+      assert(_idx > 0u && _idx < 3u);
+      _idx = _idx - 1u;
+
+      if (!mSolidColorSet[_idx])
+      {
+        OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND,
+                    "Parameter at the given index was not found.",
+                    "Terra::getSolidColors");
+      }
+      return mSolidColor[_idx];
+    }
+    //-----------------------------------------------------------------------------------
+    bool Terra::HasSolidColor(size_t _idx) const
+    {
+      assert(_idx > 0u && _idx < 3u);
+      return mSolidColorSet[_idx - 1u];
+    }
+    //-----------------------------------------------------------------------------------
+    void Terra::UnsetSolidColors()
+    {
+      mSolidColorSet[0] = false;
+      mSolidColorSet[1] = false;
+    }
+    // IGN CUSTOMIZE END
     //-----------------------------------------------------------------------------------
     void Terra::update( const Vector3 &lightDir, float lightEpsilon )
     {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #504
Fixes #444

## Summary

The 3rd and final PR to ticket #504 !

After this PR:

 - Terra now works with all Cameras (Thermal, SelectionBuffer, Segmentation, Laser) as documented in ticket #444 (backporting this to Fortress w/out breaking ABI could be a ton of work unfortunately)
 - Fixes various misc bugs of wrong values used in these cameras by regular objects when their properties weren't set (documented in #521, technically it fixes that one, but the fix can be backported so the ticket can will open until these versions are fixed or EoL)
 - Deformation works correctly under these cameras (e.g. skeletal animation and morph target)
   - Only exception is Thermal camera when using `heatSignature` texture. This was not ported to Hlms pieces and we remain swapping a regular low level material
 - Swaps the low level material for all cameras, not just a few of them (as documented in #544; however it doesn't fix the underlying issue that we don't respect the original material's vertex shader deformation). This can be fixed in older versions as well (w/out breaking ABI).
 - Increases test coverage by throwing an error (and crashing) if an object tries to render without a color set while in `IORM_SOLID_COLOR` and `IORM_SOLID_THERMAL_COLOR_TEXTURED` modes. Previously Gazebo would render colour to non-colour render targets and the unit tests wouldn't always catch it.

### Notes:
 - Codeconv reports lower coverage partly because this patch now handles low level materials in all cameras; but there are no tests covering these new paths.
     - No tests covering these paths are tracked by #543 and does not just affect Garden, but also Fortress
     - Fortress does not currently handle this case, which would result in incorrect sensor data. This is a bug in Fortress and is being tracked by #544
     - This PR handles the case, but it just reverts to a standard default shader which is suboptimal. Proper solution would be to use the original vertex shader and various solutions to this problem are proposed in #544
 - Codeconv reports lower coverage partly because there are new codepaths to handle the terrain with each sensor (e.g. Laser, Segmented camera, etc) but no unit test is testing these paths.
     - Ticket #546 was created to track this issue

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
