### PR TITLE
Fix missing terrain shadows casted on objects

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -35,6 +35,7 @@
 
 #include "Ogre2IgnHlmsCustomizations.hh"
 #include "Ogre2ParticleNoiseListener.hh"
+#include "Terra/Hlms/PbsListener/OgreHlmsPbsTerraShadows.h"
 
 #ifdef _MSC_VER
   #pragma warning(push, 0)
@@ -1248,11 +1249,27 @@ void Ogre2GpuRays::Render()
   Ogre2IgnHlmsCustomizations &hlmsCustomizations =
       engine->HlmsCustomizations();
 
+#if IGNITION_RENDERING_MAJOR_VERSION < 7
+    // TODO(anyone): Remove this block of code when porting to ign-rendering7
+    //
+    // Set Ogre2IgnHlmsCustomizations, as we don't need terrain shadows
+    auto ogreRoot = engine->OgreRoot();
+    Ogre::Hlms *hlmsPbs = ogreRoot->getHlmsManager()->getHlms(Ogre::HLMS_PBS);
+    hlmsPbs->setListener(&hlmsCustomizations);
+#endif
+
   hlmsCustomizations.minDistanceClip =
       static_cast<float>(this->NearClipPlane());
   this->UpdateRenderTarget1stPass();
   this->UpdateRenderTarget2ndPass();
   hlmsCustomizations.minDistanceClip = -1;
+
+#if IGNITION_RENDERING_MAJOR_VERSION < 7
+  // TODO(anyone): Remove this block of code when porting to ign-rendering7
+  //
+  // Restore the terrain shadows listener
+  hlmsPbs->setListener(engine->HlmsPbsTerraShadows());
+#endif
 
   this->scene->FlushGpuCommandsAndStartNewFrame(6u, false);
 }

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -788,7 +788,15 @@ void Ogre2RenderEngine::RegisterHlms()
 
     // disable writting debug output to disk
     hlmsPbs->setDebugOutputPath(false, false);
-    hlmsPbs->setListener(&this->dataPtr->hlmsCustomizations);
+
+#if IGNITION_RENDERING_MAJOR_VERSION >= 7
+    IGN_ASSERT(
+      hlmsPbs->getListener() != &this->dataPtr->hlmsCustomizations &&
+        hlmsPbs->getListener() != this->dataPtr->hlmsPbsTerraShadows.get(),
+      "Bad merge! In ign-rendering7 there's a new listener that will "
+      "coordinate all other listeners. Watch out all 3 Hlms (Unlit, Pbs, "
+      "Terra)");
+#endif
   }
 
   {


### PR DESCRIPTION
# 🦟 Bug fix

No ticket assigned; but it was mentioned in https://github.com/ignitionrobotics/ign-rendering/pull/536#issuecomment-1015813281

## Summary

Issue was incorrect listener setup due to bad merge.

ign-rendering7 has a more robust system to handle all listeners. For
Fortress this fix will do.

Garden will already have a better fix after PR #545 is merged.

The code that should not be carried over to Garden was surrounded by `#ifdef` macros and an assert was placed. Hopefully that will help reducing merge conflict mistakes.

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
