### PR TITLE
[Metal] Fix sky background in RGBD camera to match #515

### DIFF
--- a/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
@@ -167,7 +167,7 @@ fragment float4 main_metal
     // due to the scatter effect. We should still render particles in the color
     // image
     // todo(iche033) handle case when background is a cubemap
-    if (hasBackground == 0 && particle.x < 1e-6)
+    if (p.hasBackground == 0 && particle.x < 1e-6)
     {
       color = float4(p.backgroundColor, 1.0);
     }
@@ -185,7 +185,7 @@ fragment float4 main_metal
 
     // clamp to background color only if it is not a particle pixel
     // todo(iche033) handle case when background is a cubemap
-    if (hasBackground == 0 && particle.x < 1e-6)
+    if (p.hasBackground == 0 && particle.x < 1e-6)
     {
       color = float4(p.backgroundColor, 1.0);
     }


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to #515

## Summary

This fix updates the `depth_camera_fs.metal` shader to scope the new parameter `hasBackground` correctly.

## Test it

```bash
ign gazebo depth_camera_sensor.sdf
```

![fix-515-test](https://user-images.githubusercontent.com/24916364/151134967-74b97514-c491-422d-8c8d-387ed7c747b4.png)

The example provided in #515 is not yet working on Metal due to another issue.  

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.