### PR TITLE
[Metal] Fix per-point colors in point clouds to match #494

### DIFF
--- a/ogre2/src/media/materials/programs/GLSL/point_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/point_fs.glsl
@@ -17,7 +17,6 @@
 
 #version 330
 
-uniform vec4 color;
 in vec3 ptColor;
 
 out vec4 fragColor;

--- a/ogre2/src/media/materials/programs/Metal/point_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/point_fs.metal
@@ -14,17 +14,17 @@
  * limitations under the License.
  *
  */
- 
+
 #include <metal_stdlib>
 using namespace metal;
 
 struct PS_INPUT
 {
+  float3 ptColor;
 };
 
 struct Params
 {
-  float4 color;
 };
 
 fragment float4 main_metal
@@ -33,5 +33,5 @@ fragment float4 main_metal
   constant Params &p [[buffer(PARAMETER_SLOT)]]
 )
 {
-  return p.color;
+  return float4(inPs.ptColor.x, inPs.ptColor.y, inPs.ptColor.z, 1.0);
 }

--- a/ogre2/src/media/materials/programs/Metal/point_vs.metal
+++ b/ogre2/src/media/materials/programs/Metal/point_vs.metal
@@ -14,19 +14,21 @@
  * limitations under the License.
  *
  */
- 
+
 #include <metal_stdlib>
 using namespace metal;
 
 struct VS_INPUT
 {
   float4 position [[attribute(VES_POSITION)]];
+  float3 normal   [[attribute(VES_NORMAL)]];
 };
 
 struct PS_INPUT
 {
   float4 gl_Position  [[position]];
   float  gl_PointSize [[point_size]];
+  float3 ptColor;
 };
 
 struct Params
@@ -45,6 +47,8 @@ vertex PS_INPUT main_metal
 
   outVs.gl_Position    = ( p.worldViewProj * input.position ).xyzw;
   outVs.gl_PointSize   = p.size;
+  // We're abusing the normal variable to hold per-point colors
+  outVs.ptColor        = input.normal;
 
   return outVs;
 }

--- a/ogre2/src/media/materials/scripts/point_cloud_point.material
+++ b/ogre2/src/media/materials/scripts/point_cloud_point.material
@@ -32,7 +32,6 @@ fragment_program PointCloudFS_GLSL glsl
   source point_fs.glsl
   default_params
   {
-    param_named color float4 1.0 1.0 1.0 1.0
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to #494 

## Summary

This fix applies changes proposed by @iche033 to update Metal shaders that were missed from the merged PR.

It is a cherry-pick of 5df748eb48cff2fb60b544501da6afcdd5a8ec28

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.