### PR TITLE
[Metal] update custom_shaders_uniforms example

### DIFF
--- a/examples/custom_shaders_uniforms/Main.cc
+++ b/examples/custom_shaders_uniforms/Main.cc
@@ -49,13 +49,18 @@ const std::string fragmentShaderGLSLFile = "fragment_shader.glsl";
 const std::string vertexShaderGLSL330File = "vertex_shader_330.glsl";
 const std::string fragmentShaderGLSL330File = "fragment_shader_330.glsl";
 
+const std::string vertexShaderMetalFile = "vertex_shader.metal";
+const std::string fragmentShaderMetalFile = "fragment_shader.metal";
+
 //! [init shaders variables]
 
 const std::string RESOURCE_PATH =
     ignition::common::joinPaths(std::string(PROJECT_BINARY_PATH), "media");
 
 //////////////////////////////////////////////////
-void buildScene(ScenePtr _scene, const std::string &_engineName)
+void buildScene(ScenePtr _scene,
+    const std::string &_engineName,
+    const std::map<std::string, std::string>& _params)
 {
   // initialize _scene
   _scene->SetAmbientLight(0.3, 0.3, 0.3);
@@ -72,8 +77,17 @@ void buildScene(ScenePtr _scene, const std::string &_engineName)
   std::string fragmentShaderFile;
   if (_engineName == "ogre2")
   {
-    vertexShaderFile = vertexShaderGLSL330File;
-    fragmentShaderFile = fragmentShaderGLSL330File;
+    auto it = _params.find("metal");
+    if (it != _params.end() && it->second == "1")
+    {
+      vertexShaderFile = vertexShaderMetalFile;
+      fragmentShaderFile = fragmentShaderMetalFile;
+    }
+    else
+    {
+      vertexShaderFile = vertexShaderGLSL330File;
+      fragmentShaderFile = fragmentShaderGLSL330File;
+    }
   }
   else
   {
@@ -132,7 +146,7 @@ CameraPtr createCamera(const std::string &_engineName,
     return CameraPtr();
   }
   ScenePtr scene = engine->CreateScene("scene");
-  buildScene(scene, _engineName);
+  buildScene(scene, _engineName, _params);
 
   // return camera sensor
   SensorPtr sensor = scene->SensorByName("camera");
@@ -173,9 +187,7 @@ int main(int _argc, char** _argv)
       if (engineName.compare("ogre2") == 0
           && graphicsApi == GraphicsAPI::METAL)
       {
-        // \todo(anyone) uncomment once metal shaders are available
-        // params["metal"] = "1";
-        ignerr << "Metal shaders are not implemented yet. Using GLSL" << std::endl;
+        params["metal"] = "1";
       }
 
       CameraPtr camera = createCamera(engineName, params);

--- a/examples/custom_shaders_uniforms/media/fragment_shader.metal
+++ b/examples/custom_shaders_uniforms/media/fragment_shader.metal
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+#define M_PI 3.1415926535897932384626433832795
+
+struct PS_INPUT
+{
+  float4 interpolatedPosition;
+};
+
+struct Params
+{
+  int u_seed;
+  float2 u_resolution;
+  float3 u_color;
+  float4x4 u_adjustments;
+};
+
+float random(float2 uv, float seed) {
+  return fract(sin(fmod(dot(uv, float2(12.9898, 78.233))
+          + 1113.1 * seed, M_PI)) * 43758.5453);
+}
+
+fragment float4 main_metal
+(
+  PS_INPUT inPs [[stage_in]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
+)
+{
+  // Metal matrices are row major: a[row][col]
+  float a0 = p.u_adjustments[0][0];
+  float a1 = p.u_adjustments[0][1];
+  float a2 = p.u_adjustments[0][2];
+  float a3 = p.u_adjustments[0][3];
+
+  float3 a = float3(a0, a1, a2);
+  float2 b = float2(distance(float3(inPs.interpolatedPosition.xyw), a)) * a3;
+  float2 normalizedFragCoord = b / p.u_resolution;
+
+  float color = random(normalizedFragCoord, float(p.u_seed));
+  return float4(color * p.u_color, 1.0);
+}

--- a/examples/custom_shaders_uniforms/media/vertex_shader.metal
+++ b/examples/custom_shaders_uniforms/media/vertex_shader.metal
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct VS_INPUT
+{
+  float4 position [[attribute(VES_POSITION)]];
+};
+
+struct PS_INPUT
+{
+  float4 gl_Position  [[position]];
+  float4 interpolatedPosition;
+};
+
+struct Params
+{
+  float4x4 worldviewproj_matrix;
+};
+
+vertex PS_INPUT main_metal
+(
+  VS_INPUT input [[stage_in]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
+)
+{
+  PS_INPUT outVs;
+
+  outVs.gl_Position = p.worldviewproj_matrix * input.position;
+  outVs.interpolatedPosition = outVs.gl_Position;
+  
+  return outVs;
+}

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -24,6 +24,7 @@
 
 #include <ignition/common/SingletonT.hh>
 
+#include "ignition/rendering/GraphicsAPI.hh"
 #include "ignition/rendering/RenderEnginePlugin.hh"
 #include "ignition/rendering/base/BaseRenderEngine.hh"
 #include "ignition/rendering/base/BaseRenderTypes.hh"
@@ -212,6 +213,10 @@ namespace ignition
       /// \return Pointer to the CompositorWorkspaceListener
       public: Ogre::CompositorWorkspaceListener
           *TerraWorkspaceListener() const;
+
+      /// \brief Get the render engine's graphics API
+      /// \return The graphics API enum class
+      public: GraphicsAPI GraphicsAPI() const;
 
       /// \brief Pointer to the ogre's overlay system
       private: Ogre::v1::OverlaySystem *ogreOverlaySystem = nullptr;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -216,7 +216,7 @@ namespace ignition
 
       /// \brief Get the render engine's graphics API
       /// \return The graphics API enum class
-      public: GraphicsAPI GraphicsAPI() const;
+      public: rendering::GraphicsAPI GraphicsAPI() const;
 
       /// \brief Pointer to the ogre's overlay system
       private: Ogre::v1::OverlaySystem *ogreOverlaySystem = nullptr;

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1166,14 +1166,14 @@ void Ogre2Material::SetFragmentShader(const std::string &_path)
         this->dataPtr->shaderLanguageCode(),
         Ogre::GpuProgramType::GPT_FRAGMENT_PROGRAM);
 
-  // set shader language specific parameters 
+  // set shader language specific parameters
   if (this->dataPtr->graphicsAPI == GraphicsAPI::METAL)
   {
     // must set reflection pair hint for Metal fragment shaders
     // otherwise the parameters (uniforms) will not be set correctly
     std::string paramName("shader_reflection_pair_hint");
     std::string paramValue =
-        "_ign_" + common::basename(this->dataPtr->vertexShaderPath); 
+        "_ign_" + common::basename(this->dataPtr->vertexShaderPath);
     fragmentShader->setParameter(paramName, paramValue);
   }
 

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -52,9 +52,6 @@
 /// \brief Private data for the Ogre2Material class
 class ignition::rendering::Ogre2MaterialPrivate
 {
-  /// \brief The graphics API to use
-  public: GraphicsAPI graphicsAPI{GraphicsAPI::OPENGL};
-
   /// \brief Ogre stores the name using hashes. This variable will
   /// store the material hash name
   public: std::string hashName;
@@ -71,10 +68,12 @@ class ignition::rendering::Ogre2MaterialPrivate
   /// \brief Parameters to be bound to the fragment shader
   public: ShaderParamsPtr fragmentShaderParams;
 
-  /// \brief Returns the shader language code
-  public: std::string shaderLanguageCode() const
+  /// \brief Returns the shader language code.
+  /// \param[in] _graphicsAPI The graphic API.
+  /// \return The shader language code string.
+  public: static std::string shaderLanguageCode(GraphicsAPI _graphicsAPI)
   {
-    switch (this->graphicsAPI)
+    switch (_graphicsAPI)
     {
       case GraphicsAPI::OPENGL:
         return "glsl";
@@ -770,7 +769,7 @@ void Ogre2Material::UpdateShaderParams(ConstShaderParamsPtr _params,
                << name_param.first << std::endl;
         continue;
       }
-      if (this->dataPtr->graphicsAPI == GraphicsAPI::OPENGL)
+      if (Ogre2RenderEngine::Instance()->GraphicsAPI() == GraphicsAPI::OPENGL)
       {
         // set the texture map index
         _ogreParams->setNamedConstant(name_param.first, &texIndex, 1, 1);
@@ -1111,7 +1110,8 @@ void Ogre2Material::SetVertexShader(const std::string &_path)
     Ogre::HighLevelGpuProgramManager::getSingletonPtr()->createProgram(
         "_ign_" + baseName,
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
-        this->dataPtr->shaderLanguageCode(),
+        this->dataPtr->shaderLanguageCode(
+            Ogre2RenderEngine::Instance()->GraphicsAPI()),
         Ogre::GpuProgramType::GPT_VERTEX_PROGRAM);
 
   vertexShader->setSourceFile(_path);
@@ -1163,11 +1163,12 @@ void Ogre2Material::SetFragmentShader(const std::string &_path)
     Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(
         "_ign_" + baseName,
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
-        this->dataPtr->shaderLanguageCode(),
+        this->dataPtr->shaderLanguageCode(
+            Ogre2RenderEngine::Instance()->GraphicsAPI()),
         Ogre::GpuProgramType::GPT_FRAGMENT_PROGRAM);
 
   // set shader language specific parameters
-  if (this->dataPtr->graphicsAPI == GraphicsAPI::METAL)
+  if (Ogre2RenderEngine::Instance()->GraphicsAPI() == GraphicsAPI::METAL)
   {
     // must set reflection pair hint for Metal fragment shaders
     // otherwise the parameters (uniforms) will not be set correctly

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1063,6 +1063,12 @@ Ogre::CompositorWorkspaceListener *Ogre2RenderEngine::TerraWorkspaceListener()
   return this->dataPtr->terraWorkspaceListener.get();
 }
 
+/////////////////////////////////////////////////
+GraphicsAPI Ogre2RenderEngine::GraphicsAPI() const
+{
+  return this->dataPtr->graphicsAPI;
+}
+
 // Register this plugin
 IGNITION_ADD_PLUGIN(ignition::rendering::Ogre2RenderEnginePlugin,
                     ignition::rendering::RenderEnginePlugin)


### PR DESCRIPTION
This PR adds metal shaders to the custom_shaders_uniforms example.

# 🎉 New feature

Enhances #520

## Summary

- Metal vertex and fragment shaders are added to the custom_shaders_uniforms example.
- `Ogre2Material` is modified to specify the render system being used when creating the GPU programs.
- Add an accessor for the graphics API to `Ogre2RenderEngine`

## Test it

Run the example using `ogre2` and specifying `metal` as the graphics API:

```bash
./custom_shaders_uniforms ogre2 metal
```

<img width="828" alt="custom-shaders-metal" src="https://user-images.githubusercontent.com/24916364/152578931-e3de66b3-2915-4393-8831-16c07dd6edb6.png">

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.