### PR TITLE
Make sure shader param exists before setting its value

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -646,6 +646,13 @@ void Ogre2Material::UpdateShaderParams(ConstShaderParamsPtr _params,
       continue;
     }
 
+    if (!_ogreParams->_findNamedConstantDefinition(name_param.first))
+    {
+      ignwarn << "Unable to find GPU program parameter: "
+              << name_param.first << std::endl;
+      continue;
+    }
+
     if (ShaderParam::PARAM_FLOAT == name_param.second.Type())
     {
       float value;

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -671,6 +671,10 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
     // correct type and value.
     auto params = visual->Material()->VertexShaderParams();
     (*params)["worldviewproj_matrix"] = 1;
+
+    // check setting invalid param - this should print a warning msg and
+    // not cause the program to crash.
+    (*params)["worldviewproj_matrix_invalid"] = 1;
   }
 
   // render a few frames


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix
## Summary

Fixes crash when setting a shader parameter that does not exist. Now it prints out a warning msg to let users know what param will not be set.


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


