### PR TITLE
Increase particle emitter quota

### DIFF
--- a/ogre2/src/Ogre2ParticleEmitter.cc
+++ b/ogre2/src/Ogre2ParticleEmitter.cc
@@ -483,7 +483,7 @@ void Ogre2ParticleEmitter::CreateParticleSystem()
       Ogre::Any(this->Id()));
 
   this->dataPtr->ps->setCullIndividually(true);
-  this->dataPtr->ps->setParticleQuota(500);
+  this->dataPtr->ps->setParticleQuota(5000);
   this->dataPtr->ps->setSortingEnabled(true);
 
   this->dataPtr->ps->setVisibilityFlags(kParticleVisibilityFlags);


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Increase particle quota - this is the max number of particles present in the scene. The changes here increase the limit so that we can generate denser particle effects in larger environments.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
