### PR TITLE
Restore format conversion in Ogre2RenderTarget::Copy

### DIFF
--- a/ogre2/src/Ogre2Conversions.cc
+++ b/ogre2/src/Ogre2Conversions.cc
@@ -55,7 +55,7 @@ const Ogre::PixelFormatGpu Ogre2Conversions::ogrePixelFormats[PF_COUNT] =
       // PF_L16
       Ogre::PFG_R16_UNORM,
       // PF_R8G8B8A8
-      Ogre::PFG_RGBA8_UNORM_SRGB,
+      Ogre::PFG_RGBA8_UNORM,
     };
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Conversions.cc
+++ b/ogre2/src/Ogre2Conversions.cc
@@ -53,7 +53,9 @@ const Ogre::PixelFormatGpu Ogre2Conversions::ogrePixelFormats[PF_COUNT] =
       // PF_FLOAT32_RGB
       Ogre::PFG_RGB32_FLOAT,
       // PF_L16
-      Ogre::PFG_R16_UNORM
+      Ogre::PFG_R16_UNORM,
+      // PF_R8G8B8A8
+      Ogre::PFG_RGBA8_UNORM_SRGB,
     };
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -360,13 +360,16 @@ void Ogre2RenderTarget::Copy(Image &_image) const
   Ogre::PixelFormatGpu dstOgrePf = Ogre2Conversions::Convert(_image.Format());
   Ogre::TextureGpu *texture = this->RenderTarget();
 
-  if (dstOgrePf != texture->getPixelFormat() &&
-      Ogre::PixelFormatGpuUtils::getEquivalentSRGB(dstOgrePf) ==
-        texture->getPixelFormat())
+  if (Ogre::PixelFormatGpuUtils::isSRgb(dstOgrePf) !=
+      Ogre::PixelFormatGpuUtils::isSRgb(texture->getPixelFormat()))
   {
     // Formats are identical except for sRGB-ness.
-    // Force a raw copy to go into the fast path (this is likely an Ogre bug)
-    dstOgrePf = Ogre::PixelFormatGpuUtils::getEquivalentSRGB(dstOgrePf);
+    // Force a raw copy by making them match (no conversion!).
+    // We can't change the TextureGpu format now, so we change dstOgrePf
+    if (Ogre::PixelFormatGpuUtils::isSRgb(texture->getPixelFormat()))
+      dstOgrePf = Ogre::PixelFormatGpuUtils::getEquivalentSRGB(dstOgrePf);
+    else
+      dstOgrePf = Ogre::PixelFormatGpuUtils::getEquivalentLinear(dstOgrePf);
   }
 
   Ogre::TextureBox dstBox(

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -373,14 +373,14 @@ void Ogre2RenderTarget::Copy(Image &_image) const
   }
 
   Ogre::TextureBox dstBox(
-    texture->getInternalWidth(), texture->getInternalHeight(),
+    texture->getWidth(), texture->getHeight(),
     texture->getDepth(), texture->getNumSlices(),
     static_cast<uint32_t>(
       Ogre::PixelFormatGpuUtils::getBytesPerPixel(dstOgrePf)),
     static_cast<uint32_t>(Ogre::PixelFormatGpuUtils::getSizeBytes(
-      texture->getInternalWidth(), 1u, 1u, 1u, dstOgrePf, 1u)),
+      texture->getWidth(), 1u, 1u, 1u, dstOgrePf, 1u)),
     static_cast<uint32_t>(Ogre::PixelFormatGpuUtils::getSizeBytes(
-      texture->getInternalWidth(), texture->getInternalHeight(), 1u, 1u,
+      texture->getWidth(), texture->getHeight(), 1u, 1u,
       dstOgrePf, 1u)));
   dstBox.data = _image.Data();
 


### PR DESCRIPTION
# 🦟 Bug fix

No ticket has been associated with this issue

## Summary

When ignition moved to Ogre 2.2+; `Ogre2RenderTarget::Copy` lost the ability to convert between src & dst formats. This PR restores it.

It also should be faster because we avoid an unnecessary extra copy.

Additionally, `Ogre2Conversions::ogrePixelFormats` had a missing entry which could trigger bugs if the not-so-popular `PF_R8G8B8A8` format is used

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
