### PR TITLE
Expose GraphicsAPI

### DIFF
--- a/include/ignition/rendering/RenderEngine.hh
+++ b/include/ignition/rendering/RenderEngine.hh
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 #include "ignition/rendering/config.hh"
+#include "ignition/rendering/GraphicsAPI.hh"
 #include "ignition/rendering/RenderTypes.hh"
 #include "ignition/rendering/Export.hh"
 
@@ -162,6 +163,10 @@ namespace ignition
       /// \return The created scene
       public: virtual ScenePtr CreateScene(unsigned int _id,
                   const std::string &_name) = 0;
+
+      /// \brief Returns the GraphicsAPI currently in use
+      /// \return GraphicsAPI currently in use
+      public: virtual GraphicsAPI CurrentGraphicsAPI() const = 0;
 
       /// \brief Set headless mode
       /// Only available in OGRE 2.2, which makes use of EGL

--- a/include/ignition/rendering/RenderEngine.hh
+++ b/include/ignition/rendering/RenderEngine.hh
@@ -166,7 +166,7 @@ namespace ignition
 
       /// \brief Returns the GraphicsAPI currently in use
       /// \return GraphicsAPI currently in use
-      public: virtual GraphicsAPI CurrentGraphicsAPI() const = 0;
+      public: virtual rendering::GraphicsAPI GraphicsAPI() const = 0;
 
       /// \brief Set headless mode
       /// Only available in OGRE 2.2, which makes use of EGL

--- a/include/ignition/rendering/base/BaseRenderEngine.hh
+++ b/include/ignition/rendering/base/BaseRenderEngine.hh
@@ -89,6 +89,12 @@ namespace ignition
       public: virtual void AddResourcePath(const std::string &_path) override;
 
       // Documentation Inherited
+      public: virtual GraphicsAPI CurrentGraphicsAPI() const override
+      {
+        return GraphicsAPI::UNKNOWN;
+      }
+
+      // Documentation Inherited
       public: virtual void SetHeadless(bool _headless) override;
 
       // Documentation Inherited

--- a/include/ignition/rendering/base/BaseRenderEngine.hh
+++ b/include/ignition/rendering/base/BaseRenderEngine.hh
@@ -89,7 +89,7 @@ namespace ignition
       public: virtual void AddResourcePath(const std::string &_path) override;
 
       // Documentation Inherited
-      public: virtual GraphicsAPI CurrentGraphicsAPI() const override
+      public: virtual rendering::GraphicsAPI GraphicsAPI() const override
       {
         return GraphicsAPI::UNKNOWN;
       }

--- a/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
@@ -101,7 +101,7 @@ namespace ignition
       public: void AddResourcePath(const std::string &_uri) override;
 
       // Documentation Inherited
-      public: virtual GraphicsAPI CurrentGraphicsAPI() const override;
+      public: virtual rendering::GraphicsAPI GraphicsAPI() const override;
 
       public: virtual Ogre::Root *OgreRoot() const;
 

--- a/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreRenderEngine.hh
@@ -100,6 +100,9 @@ namespace ignition
 
       public: void AddResourcePath(const std::string &_uri) override;
 
+      // Documentation Inherited
+      public: virtual GraphicsAPI CurrentGraphicsAPI() const override;
+
       public: virtual Ogre::Root *OgreRoot() const;
 
       public: std::string CreateRenderWindow(const std::string &_handle,

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -246,6 +246,12 @@ void OgreRenderEngine::AddResourcePath(const std::string &_uri)
 }
 
 //////////////////////////////////////////////////
+GraphicsAPI OgreRenderEngine::CurrentGraphicsAPI() const
+{
+  return GraphicsAPI::OPENGL;
+}
+
+//////////////////////////////////////////////////
 Ogre::Root *OgreRenderEngine::OgreRoot() const
 {
   return this->ogreRoot;

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -246,7 +246,7 @@ void OgreRenderEngine::AddResourcePath(const std::string &_uri)
 }
 
 //////////////////////////////////////////////////
-GraphicsAPI OgreRenderEngine::CurrentGraphicsAPI() const
+GraphicsAPI OgreRenderEngine::GraphicsAPI() const
 {
   return GraphicsAPI::OPENGL;
 }

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -217,10 +217,6 @@ namespace ignition
       public: Ogre::CompositorWorkspaceListener
           *TerraWorkspaceListener() const;
 
-      /// \brief Get the render engine's graphics API
-      /// \return The graphics API enum class
-      public: rendering::GraphicsAPI GraphicsAPI() const;
-
       /// \brief Pointer to the ogre's overlay system
       private: Ogre::v1::OverlaySystem *ogreOverlaySystem = nullptr;
 

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -121,7 +121,7 @@ namespace ignition
                   const double _ratio, const unsigned int _antiAliasing);
 
       // Documentation Inherited
-      public: virtual GraphicsAPI CurrentGraphicsAPI() const override;
+      public: virtual rendering::GraphicsAPI GraphicsAPI() const override;
 
       /// \brief Create a scene
       /// \param[in] _id Unique scene Id

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -120,6 +120,9 @@ namespace ignition
                   const unsigned int _width, const unsigned int _height,
                   const double _ratio, const unsigned int _antiAliasing);
 
+      // Documentation Inherited
+      public: virtual GraphicsAPI CurrentGraphicsAPI() const override;
+
       /// \brief Create a scene
       /// \param[in] _id Unique scene Id
       /// \param[in] _name Name of scene

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -776,7 +776,7 @@ void Ogre2Material::UpdateShaderParams(ConstShaderParamsPtr _params,
                << name_param.first << std::endl;
         continue;
       }
-      if (Ogre2RenderEngine::Instance()->CurrentGraphicsAPI() ==
+      if (Ogre2RenderEngine::Instance()->GraphicsAPI() ==
           GraphicsAPI::OPENGL)
       {
         // set the texture map index
@@ -1119,7 +1119,7 @@ void Ogre2Material::SetVertexShader(const std::string &_path)
         "_ign_" + baseName,
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
         this->dataPtr->shaderLanguageCode(
-            Ogre2RenderEngine::Instance()->CurrentGraphicsAPI()),
+            Ogre2RenderEngine::Instance()->GraphicsAPI()),
         Ogre::GpuProgramType::GPT_VERTEX_PROGRAM);
 
   vertexShader->setSourceFile(_path);
@@ -1172,11 +1172,11 @@ void Ogre2Material::SetFragmentShader(const std::string &_path)
         "_ign_" + baseName,
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
         this->dataPtr->shaderLanguageCode(
-            Ogre2RenderEngine::Instance()->CurrentGraphicsAPI()),
+            Ogre2RenderEngine::Instance()->GraphicsAPI()),
         Ogre::GpuProgramType::GPT_FRAGMENT_PROGRAM);
 
   // set shader language specific parameters
-  if (Ogre2RenderEngine::Instance()->CurrentGraphicsAPI() == GraphicsAPI::METAL)
+  if (Ogre2RenderEngine::Instance()->GraphicsAPI() == GraphicsAPI::METAL)
   {
     // must set reflection pair hint for Metal fragment shaders
     // otherwise the parameters (uniforms) will not be set correctly

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -776,7 +776,8 @@ void Ogre2Material::UpdateShaderParams(ConstShaderParamsPtr _params,
                << name_param.first << std::endl;
         continue;
       }
-      if (Ogre2RenderEngine::Instance()->GraphicsAPI() == GraphicsAPI::OPENGL)
+      if (Ogre2RenderEngine::Instance()->CurrentGraphicsAPI() ==
+          GraphicsAPI::OPENGL)
       {
         // set the texture map index
         _ogreParams->setNamedConstant(name_param.first, &texIndex, 1, 1);
@@ -1118,7 +1119,7 @@ void Ogre2Material::SetVertexShader(const std::string &_path)
         "_ign_" + baseName,
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
         this->dataPtr->shaderLanguageCode(
-            Ogre2RenderEngine::Instance()->GraphicsAPI()),
+            Ogre2RenderEngine::Instance()->CurrentGraphicsAPI()),
         Ogre::GpuProgramType::GPT_VERTEX_PROGRAM);
 
   vertexShader->setSourceFile(_path);
@@ -1171,11 +1172,11 @@ void Ogre2Material::SetFragmentShader(const std::string &_path)
         "_ign_" + baseName,
         Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
         this->dataPtr->shaderLanguageCode(
-            Ogre2RenderEngine::Instance()->GraphicsAPI()),
+            Ogre2RenderEngine::Instance()->CurrentGraphicsAPI()),
         Ogre::GpuProgramType::GPT_FRAGMENT_PROGRAM);
 
   // set shader language specific parameters
-  if (Ogre2RenderEngine::Instance()->GraphicsAPI() == GraphicsAPI::METAL)
+  if (Ogre2RenderEngine::Instance()->CurrentGraphicsAPI() == GraphicsAPI::METAL)
   {
     // must set reflection pair hint for Metal fragment shaders
     // otherwise the parameters (uniforms) will not be set correctly

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1006,6 +1006,12 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 }
 
 //////////////////////////////////////////////////
+GraphicsAPI Ogre2RenderEngine::CurrentGraphicsAPI() const
+{
+  return this->dataPtr->graphicsAPI;
+}
+
+//////////////////////////////////////////////////
 void Ogre2RenderEngine::InitAttempt()
 {
   this->initialized = false;

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1069,12 +1069,6 @@ Ogre::CompositorWorkspaceListener *Ogre2RenderEngine::TerraWorkspaceListener()
   return this->dataPtr->terraWorkspaceListener.get();
 }
 
-/////////////////////////////////////////////////
-GraphicsAPI Ogre2RenderEngine::GraphicsAPI() const
-{
-  return this->dataPtr->graphicsAPI;
-}
-
 // Register this plugin
 IGNITION_ADD_PLUGIN(ignition::rendering::Ogre2RenderEnginePlugin,
                     ignition::rendering::RenderEnginePlugin)

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1006,7 +1006,7 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 }
 
 //////////////////////////////////////////////////
-GraphicsAPI Ogre2RenderEngine::CurrentGraphicsAPI() const
+GraphicsAPI Ogre2RenderEngine::GraphicsAPI() const
 {
   return this->dataPtr->graphicsAPI;
 }


### PR DESCRIPTION
# 🦟 Bug fix

There's no ticket assigned to this issue.

## Summary

The current GraphicsAPI is only available at Ogre2RenderEngine level, which is problematic when we want to be aware of it for multiple means.

ign-gui needs this information so it can decide on how to interface the API with Qt.

In some cases initialization may need additional steps if different APIs are used; so this info is needed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
