### PR TITLE
Remove unnecessary error message when headless rendering is enabled

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -383,6 +383,11 @@ void Ogre2RenderEngine::CreateLogger()
 void Ogre2RenderEngine::CreateContext()
 {
 #if not (__APPLE__ || _WIN32)
+  if (this->Headless())
+  {
+    // Nothing to do
+    return;
+  }
   // create X11 display
   this->dummyDisplay = XOpenDisplay(0);
   Display *x11Display = static_cast<Display*>(this->dummyDisplay);
@@ -391,7 +396,8 @@ void Ogre2RenderEngine::CreateContext()
   {
     // Not able to create a Xwindow, try to run in headless mode
     this->SetHeadless(true);
-    ignerr << "Unable to open display: " << XDisplayName(0) << std::endl;
+    ignwarn << "Unable to open display: " << XDisplayName(0)
+            << ". Trying to run in headless mode." << std::endl;
     return;
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/1270

## Summary
Currently, when running headless mode, an error `[Err] [Ogre2RenderEngine.cc:394] Unable to open display: ` is emitted in `ign-gazebo` even though rendering continues to work as expected. I think this is a false alarm and can be removed.

Also, currently, when a display is not found in non-headless mode, there is an error emitted saying "Unable to open display". I changed this to a warning since rendering continues to work if headless mode succeeds.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
