### PR TITLE
Fix sky background compositor setup

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -708,11 +708,16 @@ void Ogre2DepthCamera::CreateDepthTexture()
         passScene->mIncludeOverlays = false;
         passScene->mFirstRQ = 0u;
         passScene->mLastRQ = 2u;
-        if (!validBackground)
+        if (validBackground)
+        {
+          passScene->setAllLoadActions(Ogre::LoadAction::DontCare);
+          passScene->mLoadActionDepth = Ogre::LoadAction::Clear;
+          passScene->mLoadActionStencil = Ogre::LoadAction::Clear;
+        }
+        else
         {
           passScene->setAllLoadActions(Ogre::LoadAction::Clear);
-          passScene->setAllClearColours(Ogre::ColourValue(
-              Ogre2Conversions::Convert(this->Scene()->BackgroundColor())));
+          passScene->setAllClearColours(this->ogreBackgroundColor);
         }
       }
 

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -717,7 +717,9 @@ void Ogre2DepthCamera::CreateDepthTexture()
         else
         {
           passScene->setAllLoadActions(Ogre::LoadAction::Clear);
-          passScene->setAllClearColours(this->ogreBackgroundColor);
+          passScene->setAllClearColours(
+              Ogre2Conversions::Convert(this->Scene()->BackgroundColor()));
+
         }
       }
 
@@ -732,10 +734,6 @@ void Ogre2DepthCamera::CreateDepthTexture()
             + this->Name();
         passQuad->mFrustumCorners =
             Ogre::CompositorPassQuadDef::CAMERA_DIRECTION;
-
-        passQuad->setAllLoadActions(Ogre::LoadAction::Clear);
-        passQuad->setAllClearColours(Ogre::ColourValue(
-            Ogre2Conversions::Convert(this->Scene()->BackgroundColor())));
       }
 
       // scene pass - transparent stuff

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -198,7 +198,13 @@ void Ogre2RenderTarget::BuildCompositor()
         passScene->mIncludeOverlays = false;
         passScene->mFirstRQ = 0u;
         passScene->mLastRQ = 2u;
-        if (!validBackground)
+        if (validBackground)
+        {
+          passScene->setAllLoadActions(Ogre::LoadAction::DontCare);
+          passScene->mLoadActionDepth = Ogre::LoadAction::Clear;
+          passScene->mLoadActionStencil = Ogre::LoadAction::Clear;
+        }
+        else
         {
           passScene->setAllLoadActions(Ogre::LoadAction::Clear);
           passScene->setAllClearColours(this->ogreBackgroundColor);
@@ -216,9 +222,6 @@ void Ogre2RenderTarget::BuildCompositor()
             + this->Name();
         passQuad->mFrustumCorners =
             Ogre::CompositorPassQuadDef::CAMERA_DIRECTION;
-
-        passQuad->setAllLoadActions(Ogre::LoadAction::Clear);
-        passQuad->setAllClearColours(this->ogreBackgroundColor);
       }
 
       // scene pass - transparent stuff


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes  https://github.com/ignitionrobotics/ign-rendering/issues/568

## Summary

When sky is enabled, we are clearing the existing scene with objects in render queue 0, 1. We didn't notice any issue because, as pointed out, we don't have any objects that occupy those render queue. This PR implements the fix suggested in Implemented suggested fix from https://github.com/ignitionrobotics/ign-rendering/issues/568.

The bug was introduced in https://github.com/ignitionrobotics/ign-rendering/pull/440, which was done to fix flickering issues. It is difficult to add a test for this PR since we don't have features in ign-rendering that are in those render queues. One way to test this is to launch ign gazebo Fortress Demo world and make sure that this does not cause any regression, i.e. the scene is not be flickering in the GUI 3D window.
```
# this may take a couple minutes to load
ign gazebo -v 4 -r "https://fuel.ignitionrobotics.org/1.0/OpenRobotics/worlds/Fortress demo"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

