### PR TITLE
Use pose multiplication instead of addition

### DIFF
--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -351,7 +351,7 @@ namespace ignition
         {
           math::Pose3d targetCamPose = math::Pose3d(this->followOffset,
               this->WorldRotation());
-          targetCamPose += this->followNode->WorldPose();
+          targetCamPose = this->followNode->WorldPose() * targetCamPose;
 
           math::Vector3d pos = this->WorldPosition() +
               (targetCamPose.Pos() - this->WorldPosition()) * this->followPGain;
@@ -371,7 +371,7 @@ namespace ignition
         }
         else
         {
-          targetPose += this->trackNode->WorldPose();
+          targetPose = this->trackNode->WorldPose() * targetPose;
         }
 
         math::Pose3d p =

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -406,7 +406,7 @@ namespace ignition
 
         // get rotation of joint visual in model frame
         ignition::math::Quaterniond quatFromModel =
-            (this->LocalPose() + parentInitPose).Rot();
+            (parentInitPose * this->LocalPose()).Rot();
 
         // rotate arrow visual so that the axis vector applies to the model
         // frame.

--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -428,7 +428,7 @@ namespace ignition
         return pose;
       }
 
-      return pose + parent->WorldPose();
+      return parent->WorldPose() * pose;
     }
 
     //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignitionrobotics/ign-math/issues/60

## Summary

The ign-math Pose addition operator is going to be deprecated, so use the multiplication operator instead. It works in the opposite order, matching the behavior of coordinate transform multiplication. The deprecation is planned for ignition-math7, which will not affect Fortress, but I've targeted this branch to reduce the chance of conflicts when merging forward.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
