### PR TITLE
Do not set shader constants for textures on non-OpenGL graphics API

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2RenderEngine.hh
@@ -24,6 +24,7 @@
 
 #include <ignition/common/SingletonT.hh>
 
+#include "ignition/rendering/GraphicsAPI.hh"
 #include "ignition/rendering/RenderEnginePlugin.hh"
 #include "ignition/rendering/base/BaseRenderEngine.hh"
 #include "ignition/rendering/base/BaseRenderTypes.hh"
@@ -117,6 +118,12 @@ namespace ignition
       public: std::string CreateRenderWindow(const std::string &_handle,
                   const unsigned int _width, const unsigned int _height,
                   const double _ratio, const unsigned int _antiAliasing);
+
+      /// \brief Get the render engine's graphics API
+      /// Note: Do not merge this forward. This has been changed to
+      /// virtual function in ign-rendering7
+      /// \return The graphics API enum class
+      public: rendering::GraphicsAPI GraphicsAPI() const;
 
       /// \brief Create a scene
       /// \param[in] _id Unique scene Id

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -40,6 +40,7 @@
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Image.hh>
 
+#include "ignition/rendering/GraphicsAPI.hh"
 #include "ignition/rendering/ShaderParams.hh"
 #include "ignition/rendering/ShaderType.hh"
 #include "ignition/rendering/ogre2/Ogre2Material.hh"

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -646,7 +646,11 @@ void Ogre2Material::UpdateShaderParams(ConstShaderParamsPtr _params,
       continue;
     }
 
-    if (!_ogreParams->_findNamedConstantDefinition(name_param.first))
+    if (!_ogreParams->_findNamedConstantDefinition(name_param.first) &&
+        !(Ogre2RenderEngine::Instance()->GraphicsAPI() !=
+            GraphicsAPI::OPENGL &&
+            (ShaderParam::PARAM_TEXTURE == name_param.second.Type() ||
+             ShaderParam::PARAM_TEXTURE_CUBE == name_param.second.Type())))
     {
       ignwarn << "Unable to find GPU program parameter: "
               << name_param.first << std::endl;

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -993,6 +993,12 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 }
 
 //////////////////////////////////////////////////
+GraphicsAPI Ogre2RenderEngine::GraphicsAPI() const
+{
+  return this->dataPtr->graphicsAPI;
+}
+
+//////////////////////////////////////////////////
 void Ogre2RenderEngine::InitAttempt()
 {
   this->initialized = false;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This should fix the `waves` demo on macOS using ogre2 + metal. See https://github.com/ignitionrobotics/ign-rendering/pull/558#issuecomment-1056889775

I also had to backport the `GraphicsAPI` accessor function from https://github.com/ignitionrobotics/ign-rendering/pull/554

Waves demo now working again on macOS:

<img width="912" alt="waves_metal" src="https://user-images.githubusercontent.com/4000684/156430683-cbc5023a-be9f-4a3d-b692-d012eb3823b3.png">


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

