### PR TITLE
Fix objects using shaders when there is a lidar in the scene (ogre2)

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -337,10 +337,10 @@ void Ogre2LaserRetroMaterialSwitcher::cameraPostRenderScene(
     subItem->setDatablock(it.second);
   }
 
-  auto lIt = laserRetroMaterialMap.find(this);
-  if (lIt !=  laserRetroMaterialMap.end())
+  auto laserRetroIt = laserRetroMaterialMap.find(this);
+  if (laserRetroIt !=  laserRetroMaterialMap.end())
   {
-    for (auto it : lIt->second)
+    for (auto it : laserRetroIt->second)
     {
       Ogre::SubItem *subItem = it.first;
       subItem->setMaterial(it.second);

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -114,9 +114,13 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
 
         if (technique && !technique->isDepthWriteEnabled() &&
             !technique->isDepthCheckEnabled())
+        {
           subItem->setMaterial(this->plainOverlayMaterial);
+        }
         else
+        {
           subItem->setMaterial(this->plainMaterial);
+        }
       }
       // regular Pbs Hlms datablock
       else

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -37,8 +37,8 @@ using namespace rendering;
 
 
 /// \brief A map of ogre sub item pointer to their original low level material
-/// \todo(anyone) Added here for ABI compatibity This can be removed once
-/// ign-rendering7 switches to Hlms customization for "switching" materials
+/// \todo(anyone) Added here for ABI compatibity. Move to private class
+/// in ign-rendering7
 std::map<Ogre2MaterialSwitcher *,
          std::map<Ogre::SubItem *, Ogre::MaterialPtr>> materialMap;
 
@@ -110,6 +110,13 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
       {
         materialMap[this][subItem] = subItem->getMaterial();
         subItem->setMaterial(this->plainMaterial);
+        auto technique = subItem->getMaterial()->getTechnique(0);
+
+        if (technique && !technique->isDepthWriteEnabled() &&
+            !technique->isDepthCheckEnabled())
+          subItem->setMaterial(this->plainOverlayMaterial);
+        else
+          subItem->setMaterial(this->plainMaterial);
       }
       // regular Pbs Hlms datablock
       else

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -22,6 +22,7 @@
 #include "test_config.h"  // NOLINT(build/include)
 
 #include "ignition/rendering/Camera.hh"
+#include "ignition/rendering/GpuRays.hh"
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/RenderingIface.hh"
 #include "ignition/rendering/Scene.hh"
@@ -663,6 +664,25 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   camera->SetHFOV(IGN_PI / 2);
   root->AddChild(camera);
 
+  // Create a gpu ray
+  // laser retro material switching may also affect shader materials
+  const double hMinAngle = -IGN_PI/2.0;
+  const double hMaxAngle = IGN_PI/2.0;
+  const double minRange = 0.1;
+  const double maxRange = 10.0;
+  const int hRayCount = 320;
+  const int vRayCount = 1;
+  GpuRaysPtr gpuRays = scene->CreateGpuRays("gpu_rays");
+  gpuRays->SetWorldPosition(0, 0, 0);
+  gpuRays->SetNearClipPlane(minRange);
+  gpuRays->SetFarClipPlane(maxRange);
+  gpuRays->SetAngleMin(hMinAngle);
+  gpuRays->SetAngleMax(hMaxAngle);
+  gpuRays->SetRayCount(hRayCount);
+
+  gpuRays->SetVerticalRayCount(vRayCount);
+  root->AddChild(gpuRays);
+
   if (_renderEngine == "ogre2")
   {
     // worldviewproj_matrix is a constant defined by ogre.
@@ -681,6 +701,7 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   for (auto i = 0; i < 30; ++i)
   {
     camera->Update();
+    gpuRays->Update();
   }
 
   // capture a frame


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

The gpu ray sensor sets up generates retro values by switching materials. The probably is that it incorrectly restores shader materials causing objects using custom shaders to render incorrectly after first update.

Applied a similar fix as as https://github.com/ignitionrobotics/ign-rendering/pull/533. Updated integration test should which fail without this fix.

On way to reproduce the issue is to run this [shader_param_gpu_lidar.sdf](https://gist.github.com/iche033/e74b66edcf4a95554b6a015c72cba2b7) world with ign-gazebo:

```
ign gazebo -v 4 -r shader_param_gpu_lidar.sdf
```

Without this fix, the red sphere and waves (which use custom shaders) will appear black in the `Image Display` plugin.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

