### PR TITLE
Fix render pass example on ogre2

### DIFF
--- a/examples/render_pass/Main.cc
+++ b/examples/render_pass/Main.cc
@@ -160,18 +160,24 @@ CameraPtr createCamera(const std::string &_engineName,
   {
     // add gaussian noise pass
     RenderPassPtr pass = rpSystem->Create<GaussianNoisePass>();
-    GaussianNoisePassPtr noisePass =
-        std::dynamic_pointer_cast<GaussianNoisePass>(pass);
-    noisePass->SetMean(0.1);
-    noisePass->SetStdDev(0.08);
-    camera->AddRenderPass(noisePass);
+    if (pass)
+    {
+      GaussianNoisePassPtr noisePass =
+          std::dynamic_pointer_cast<GaussianNoisePass>(pass);
+      noisePass->SetMean(0.1);
+      noisePass->SetStdDev(0.08);
+      camera->AddRenderPass(noisePass);
+    }
 
     // add distortion pass
     pass = rpSystem->Create<DistortionPass>();
-    DistortionPassPtr distortionPass =
-        std::dynamic_pointer_cast<DistortionPass>(pass);
-    distortionPass->SetK1(0.5);
-    camera->AddRenderPass(distortionPass);
+    if (pass)
+    {
+      DistortionPassPtr distortionPass =
+          std::dynamic_pointer_cast<DistortionPass>(pass);
+      distortionPass->SetK1(0.5);
+      camera->AddRenderPass(distortionPass);
+    }
   }
   //! [get render pass system]
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Running the [render_pass](https://github.com/ignitionrobotics/ign-rendering/tree/ign-rendering6/examples/render_pass) example with `ogre2` currently results in a crash because it tries to load the distortion render pass which has not been ported to ogre2 implementation yet.

This PR adds a check to make sure the render pass is not null before adding it to the render pass system.

to test, build and run the `render_pass` example:

```
./render_pass ogre2
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

