### PR TITLE
Respect vertex shader from low level materials in sensor passes (#544)

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -309,11 +309,27 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
 
       if (!subItem->getMaterial().isNull())
       {
-        // TODO(anyone): We need to keep the material's vertex shader
-        // to keep vertex deformation consistent. See
-        // https://github.com/ignitionrobotics/ign-rendering/issues/544
         this->materialMap.push_back({ subItem, subItem->getMaterial() });
-        subItem->setDatablock(defaultPbs);
+
+        // We need to keep the material's vertex shader
+        // to keep vertex deformation consistent; so we use
+        // a cloned material with a different pixel shader
+        // https://github.com/ignitionrobotics/ign-rendering/issues/544
+        auto material = Ogre::MaterialManager::getSingleton().getByName(
+          subItem->getMaterial()->getName() + "_solid",
+          Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        if (material->getNumSupportedTechniques() > 0u)
+        {
+          subItem->setMaterial(material);
+        }
+        else
+        {
+          // The supplied vertex shader could not pair with the
+          // pixel shader we provide. Try to salvage the situation
+          // using PBS shader. Custom deformation won't work but
+          // if we're lucky that won't matter
+          subItem->setDatablock(defaultPbs);
+        }
       }
       else
       {

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -855,7 +855,8 @@ Ogre::MaterialPtr Ogre2Material::Material()
       this->dataPtr->ogreSolidColorShader->setSourceFile("plain_color_fs.hlsl");
       break;
     case GraphicsAPI::METAL:
-      this->dataPtr->ogreSolidColorShader->setSourceFile("plain_color_fs.metal");
+      this->dataPtr->ogreSolidColorShader->setSourceFile(
+        "plain_color_fs.metal");
       break;
     default:
       IGN_ASSERT(false, "Impossible path!");

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -97,11 +97,27 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
 
       if (!subItem->getMaterial().isNull())
       {
-        // TODO(anyone): We need to keep the material's vertex shader
-        // to keep vertex deformation consistent. See
-        // https://github.com/ignitionrobotics/ign-rendering/issues/544
         this->materialMap.push_back({ subItem, subItem->getMaterial() });
-        subItem->setDatablock(defaultPbs);
+
+        // We need to keep the material's vertex shader
+        // to keep vertex deformation consistent; so we use
+        // a cloned material with a different pixel shader
+        // https://github.com/ignitionrobotics/ign-rendering/issues/544
+        auto material = Ogre::MaterialManager::getSingleton().getByName(
+          subItem->getMaterial()->getName() + "_solid",
+          Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+        if (material->getNumSupportedTechniques() > 0u)
+        {
+          subItem->setMaterial(material);
+        }
+        else
+        {
+          // The supplied vertex shader could not pair with the
+          // pixel shader we provide. Try to salvage the situation
+          // using PBS shader. Custom deformation won't work but
+          // if we're lucky that won't matter
+          subItem->setDatablock(defaultPbs);
+        }
       }
       else
       {

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -301,11 +301,27 @@ void Ogre2SegmentationMaterialSwitcher::cameraPreRenderScene(
 
         if (!subItem->getMaterial().isNull())
         {
-          // TODO(anyone): We need to keep the material's vertex shader
-          // to keep vertex deformation consistent. See
-          // https://github.com/ignitionrobotics/ign-rendering/issues/544
           this->materialMap.push_back({ subItem, subItem->getMaterial() });
-          subItem->setDatablock(defaultPbs);
+
+          // We need to keep the material's vertex shader
+          // to keep vertex deformation consistent; so we use
+          // a cloned material with a different pixel shader
+          // https://github.com/ignitionrobotics/ign-rendering/issues/544
+          auto material = Ogre::MaterialManager::getSingleton().getByName(
+            subItem->getMaterial()->getName() + "_solid",
+            Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+          if (material->getNumSupportedTechniques() > 0u)
+          {
+            subItem->setMaterial(material);
+          }
+          else
+          {
+            // The supplied vertex shader could not pair with the
+            // pixel shader we provide. Try to salvage the situation
+            // using PBS shader. Custom deformation won't work but
+            // if we're lucky that won't matter
+            subItem->setDatablock(defaultPbs);
+          }
         }
         else
         {

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -341,11 +341,25 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
 
           if (!subItem->getMaterial().isNull())
           {
-            // TODO(anyone): We need to keep the material's vertex shader
-            // to keep vertex deformation consistent. See
+            // We need to keep the material's vertex shader
+            // to keep vertex deformation consistent; so we use
+            // a cloned material with a different pixel shader
             // https://github.com/ignitionrobotics/ign-rendering/issues/544
-            this->materialMap.push_back({ subItem, subItem->getMaterial() });
-            subItem->setDatablock(defaultPbs);
+            auto material = Ogre::MaterialManager::getSingleton().getByName(
+              subItem->getMaterial()->getName() + "_solid",
+              Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+            if (material->getNumSupportedTechniques() > 0u)
+            {
+              subItem->setMaterial(material);
+            }
+            else
+            {
+              // The supplied vertex shader could not pair with the
+              // pixel shader we provide. Try to salvage the situation
+              // using PBS shader. Custom deformation won't work but
+              // if we're lucky that won't matter
+              subItem->setDatablock(defaultPbs);
+            }
           }
           else
           {
@@ -473,11 +487,25 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
 
           if (!subItem->getMaterial().isNull())
           {
-            // TODO(anyone): We need to keep the material's vertex shader
-            // to keep vertex deformation consistent. See
+            // We need to keep the material's vertex shader
+            // to keep vertex deformation consistent; so we use
+            // a cloned material with a different pixel shader
             // https://github.com/ignitionrobotics/ign-rendering/issues/544
-            this->materialMap.push_back({ subItem, subItem->getMaterial() });
-            subItem->setDatablock(defaultPbs);
+            auto material = Ogre::MaterialManager::getSingleton().getByName(
+              subItem->getMaterial()->getName() + "_solid",
+              Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+            if (material->getNumSupportedTechniques() > 0u)
+            {
+              subItem->setMaterial(material);
+            }
+            else
+            {
+              // The supplied vertex shader could not pair with the
+              // pixel shader we provide. Try to salvage the situation
+              // using PBS shader. Custom deformation won't work but
+              // if we're lucky that won't matter
+              subItem->setDatablock(defaultPbs);
+            }
           }
           else
           {

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -341,6 +341,8 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
 
           if (!subItem->getMaterial().isNull())
           {
+            this->materialMap.push_back({ subItem, subItem->getMaterial() });
+
             // We need to keep the material's vertex shader
             // to keep vertex deformation consistent; so we use
             // a cloned material with a different pixel shader
@@ -487,6 +489,8 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
 
           if (!subItem->getMaterial().isNull())
           {
+            this->materialMap.push_back({ subItem, subItem->getMaterial() });
+
             // We need to keep the material's vertex shader
             // to keep vertex deformation consistent; so we use
             // a cloned material with a different pixel shader


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #544 

## Summary

It implements the first option (clone the material with same VS but different PS).

However I could NOT test this PR because I had no test nor sample to test it.

That is the reason this PR is marked as draft. I would appreciate a way to play with this (i.e. a low level material entity being drawn in all sensors).

The lack of tests is tracked by #543

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
