### PR TITLE
Fix shaders for other sensors that require material switching (ogre2)

### DIFF
--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -109,7 +109,6 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
       if (!subItem->getMaterial().isNull())
       {
         materialMap[this][subItem] = subItem->getMaterial();
-        subItem->setMaterial(this->plainMaterial);
         auto technique = subItem->getMaterial()->getTechnique(0);
 
         if (technique && !technique->isDepthWriteEnabled() &&

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -91,6 +91,9 @@ class IGNITION_RENDERING_OGRE2_VISIBLE Ogre2SegmentationMaterialSwitcher :
   private: std::unordered_map<Ogre::SubItem *,
     Ogre::HlmsDatablock *> datablockMap;
 
+  /// \brief A map of ogre sub item pointer to their original low level material
+  private: std::map<Ogre::SubItem *, Ogre::MaterialPtr> segmentationMaterialMap;
+
   /// \brief Ogre material consisting of a shader that changes the
   /// appearance of item to use a unique color for mouse picking
   private: Ogre::MaterialPtr plainMaterial;

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.hh
@@ -18,6 +18,7 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2SEGMENTATIONMATERIALSWITCHER_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2SEGMENTATIONMATERIALSWITCHER_HH_
 
+#include <map>
 #include <string>
 #include <random>
 #include <unordered_map>

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -138,6 +138,9 @@ class Ogre2ThermalCameraMaterialSwitcher : public Ogre::Camera::Listener
   private: std::unordered_map<Ogre::SubItem *, Ogre::HlmsDatablock *>
       datablockMap;
 
+  /// \brief A map of ogre sub item pointer to their original low level material
+  private: std::map<Ogre::SubItem *, Ogre::MaterialPtr> thermalMaterialMap;
+
   /// \brief linear temperature resolution. Defaults to 10mK
   private: double resolution = 0.01;
 
@@ -150,7 +153,6 @@ class Ogre2ThermalCameraMaterialSwitcher : public Ogre::Camera::Listener
 }
 }
 }
-
 
 /// \internal
 /// \brief Private data for the Ogre2ThermalCamera class
@@ -242,7 +244,6 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
   // swap item to use v1 shader material
   // Note: keep an eye out for performance impact on switching materials
   // on the fly. We are not doing this often so should be ok.
-  this->datablockMap.clear();
   auto itor = this->scene->OgreSceneManager()->getMovableObjectIterator(
       Ogre::ItemFactory::FACTORY_TYPE_NAME);
   while (itor.hasMoreElements())
@@ -319,9 +320,18 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
           // see media/materials/programs/thermal_camera_fs.glsl
           subItem->setCustomParameter(this->customParamIdx,
               Ogre::Vector4(color, 0, 0, 0.0));
-          Ogre::HlmsDatablock *datablock = subItem->getDatablock();
-          this->datablockMap[subItem] = datablock;
-
+          // case when item is using low level materials
+          // e.g. shaders
+          if (!subItem->getMaterial().isNull())
+          {
+            this->thermalMaterialMap[subItem] = subItem->getMaterial();
+          }
+          // regular Pbs Hlms datablock
+          else
+          {
+            Ogre::HlmsDatablock *datablock = subItem->getDatablock();
+            this->datablockMap[subItem] = datablock;
+          }
           subItem->setMaterial(this->heatSourceMaterial);
         }
       }
@@ -384,8 +394,18 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
         {
           Ogre::SubItem *subItem = item->getSubItem(i);
 
-          Ogre::HlmsDatablock *datablock = subItem->getDatablock();
-          this->datablockMap[subItem] = datablock;
+          // case when item is using low level materials
+          // e.g. shaders
+          if (!subItem->getMaterial().isNull())
+          {
+            this->thermalMaterialMap[subItem] = subItem->getMaterial();
+          }
+          // regular Pbs Hlms datablock
+          else
+          {
+            Ogre::HlmsDatablock *datablock = subItem->getDatablock();
+            this->datablockMap[subItem] = datablock;
+          }
 
           subItem->setMaterial(this->heatSignatureMaterials[item->getId()]);
         }
@@ -414,8 +434,16 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
             for (unsigned int i = 0; i < item->getNumSubItems(); ++i)
             {
               Ogre::SubItem *subItem = item->getSubItem(i);
-              Ogre::HlmsDatablock *datablock = subItem->getDatablock();
-              this->datablockMap[subItem] = datablock;
+              if (!subItem->getMaterial().isNull())
+              {
+                this->thermalMaterialMap[subItem] = subItem->getMaterial();
+              }
+              // regular Pbs Hlms datablock
+              else
+              {
+                Ogre::HlmsDatablock *datablock = subItem->getDatablock();
+                this->datablockMap[subItem] = datablock;
+              }
               subItem->setDatablock(unlit);
             }
           }
@@ -436,6 +464,16 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPostRenderScene(
     Ogre::SubItem *subItem = it.first;
     subItem->setDatablock(it.second);
   }
+
+  // restore item to use low level material
+  for (auto it : this->thermalMaterialMap)
+  {
+    Ogre::SubItem *subItem = it.first;
+    subItem->setMaterial(it.second);
+  }
+
+  this->datablockMap.clear();
+  this->thermalMaterialMap.clear();
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -702,7 +702,8 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
 
   // Create segmentation camera
   // segmentation material switching may also affect shader materials
-  auto segmentationCamera = scene->CreateSegmentationCamera("SegmentationCamera");
+  auto segmentationCamera =
+      scene->CreateSegmentationCamera("SegmentationCamera");
   ASSERT_NE(camera, nullptr);
   segmentationCamera->SetLocalPosition(0.0, 0.0, 0.0);
   segmentationCamera->SetLocalRotation(0.0, 0.0, 0.0);

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -26,7 +26,10 @@
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/RenderingIface.hh"
 #include "ignition/rendering/Scene.hh"
+#include "ignition/rendering/SegmentationCamera.hh"
 #include "ignition/rendering/ShaderParams.hh"
+#include "ignition/rendering/ThermalCamera.hh"
+
 
 using namespace ignition;
 using namespace rendering;
@@ -647,6 +650,10 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   visual->SetWorldRotation(0.0, 0.0, 0.0);
   visual->SetMaterial(shader);
   root->AddChild(visual);
+  // for thermal camera
+  visual->SetUserData("temperature", 310.0f);
+  // for segmentation camera
+  visual->SetUserData("label", 1);
 
   // visual will clone and create a unique material
   // so destroy this one
@@ -679,9 +686,34 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   gpuRays->SetAngleMin(hMinAngle);
   gpuRays->SetAngleMax(hMaxAngle);
   gpuRays->SetRayCount(hRayCount);
-
   gpuRays->SetVerticalRayCount(vRayCount);
   root->AddChild(gpuRays);
+
+  // Create thermal camera
+  // heat map material switching may also affect shader materials
+  auto thermalCamera = scene->CreateThermalCamera("ThermalCamera");
+  ASSERT_NE(thermalCamera, nullptr);
+  thermalCamera->SetAmbientTemperature(296.0f);
+  thermalCamera->SetAspectRatio(1.333);
+  thermalCamera->SetImageWidth(320);
+  thermalCamera->SetImageHeight(240);
+  thermalCamera->SetHFOV(IGN_PI / 2);
+  root->AddChild(thermalCamera);
+
+  // Create segmentation camera
+  // segmentation material switching may also affect shader materials
+  auto segmentationCamera = scene->CreateSegmentationCamera("SegmentationCamera");
+  ASSERT_NE(camera, nullptr);
+  segmentationCamera->SetLocalPosition(0.0, 0.0, 0.0);
+  segmentationCamera->SetLocalRotation(0.0, 0.0, 0.0);
+  segmentationCamera->SetBackgroundLabel(23);
+  segmentationCamera->SetSegmentationType(SegmentationType::ST_SEMANTIC);
+  segmentationCamera->EnableColoredMap(false);
+  segmentationCamera->SetAspectRatio(1.333);
+  segmentationCamera->SetImageWidth(320);
+  segmentationCamera->SetImageHeight(240);
+  segmentationCamera->SetHFOV(IGN_PI / 2);
+  root->AddChild(segmentationCamera);
 
   if (_renderEngine == "ogre2")
   {
@@ -702,6 +734,8 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   {
     camera->Update();
     gpuRays->Update();
+    thermalCamera->Update();
+    segmentationCamera->Update();
   }
 
   // capture a frame

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -697,7 +697,7 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   thermalCamera->SetAspectRatio(1.333);
   thermalCamera->SetImageWidth(320);
   thermalCamera->SetImageHeight(240);
-  thermalCamera->SetHFOV(IGN_PI / 2);
+  thermalCamera->SetHFOV(IGN_PI_2);
   root->AddChild(thermalCamera);
 
   // Create segmentation camera
@@ -713,7 +713,7 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   segmentationCamera->SetAspectRatio(1.333);
   segmentationCamera->SetImageWidth(320);
   segmentationCamera->SetImageHeight(240);
-  segmentationCamera->SetHFOV(IGN_PI / 2);
+  segmentationCamera->SetHFOV(IGN_PI_2);
   root->AddChild(segmentationCamera);
 
   if (_renderEngine == "ogre2")

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -700,24 +700,26 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
   thermalCamera->SetHFOV(IGN_PI_2);
   root->AddChild(thermalCamera);
 
-  // Create segmentation camera
-  // segmentation material switching may also affect shader materials
-  auto segmentationCamera =
-      scene->CreateSegmentationCamera("SegmentationCamera");
-  ASSERT_NE(camera, nullptr);
-  segmentationCamera->SetLocalPosition(0.0, 0.0, 0.0);
-  segmentationCamera->SetLocalRotation(0.0, 0.0, 0.0);
-  segmentationCamera->SetBackgroundLabel(23);
-  segmentationCamera->SetSegmentationType(SegmentationType::ST_SEMANTIC);
-  segmentationCamera->EnableColoredMap(false);
-  segmentationCamera->SetAspectRatio(1.333);
-  segmentationCamera->SetImageWidth(320);
-  segmentationCamera->SetImageHeight(240);
-  segmentationCamera->SetHFOV(IGN_PI_2);
-  root->AddChild(segmentationCamera);
-
+  // Currently, only ogre2 supports segmentation cameras
+  SegmentationCameraPtr segmentationCamera;
   if (_renderEngine == "ogre2")
   {
+    // Create segmentation camera
+    // segmentation material switching may also affect shader materials
+    segmentationCamera =
+        scene->CreateSegmentationCamera("SegmentationCamera");
+    ASSERT_NE(camera, nullptr);
+    segmentationCamera->SetLocalPosition(0.0, 0.0, 0.0);
+    segmentationCamera->SetLocalRotation(0.0, 0.0, 0.0);
+    segmentationCamera->SetBackgroundLabel(23);
+    segmentationCamera->SetSegmentationType(SegmentationType::ST_SEMANTIC);
+    segmentationCamera->EnableColoredMap(false);
+    segmentationCamera->SetAspectRatio(1.333);
+    segmentationCamera->SetImageWidth(320);
+    segmentationCamera->SetImageHeight(240);
+    segmentationCamera->SetHFOV(IGN_PI_2);
+    root->AddChild(segmentationCamera);
+
     // worldviewproj_matrix is a constant defined by ogre.
     // Here we add a line to add this constant to the params.
     // The specified value is ignored as it will be auto bound to the
@@ -736,7 +738,8 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
     camera->Update();
     gpuRays->Update();
     thermalCamera->Update();
-    segmentationCamera->Update();
+    if (segmentationCamera)
+      segmentationCamera->Update();
   }
 
   // capture a frame


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Follow-up to #https://github.com/ignitionrobotics/ign-rendering/pull/575 and [these comments](https://github.com/ignitionrobotics/ign-rendering/commit/dd8b465384315eb8ed198446c8aeeb37ded60125#comments)

This PR fixes objects with shader material when there is a thermal camera or a segmentation camera in the scene. These sensor all perform material switching during a render update, and the shader materials should now be correctly restored. Also updated test.

Here is a [shader_param_sensors.sdf]( https://gist.github.com/iche033/01ef166ed150d0b0046daa8176de5640) for testing with ign-gazebo. The cameras should produce correct output and the waves and deformable sphere should be render correctly in the GUI and camera and depth sensors. 

Note that the thermal and segmentation cameras do not show the animation of waves and is being addressed in #578 (which has a separate fix for this issue targeting ign-rendering7).
```
ign gazebo -v 4 -r shader_param_sensors.sdf
```

![shader_param_sensors](https://user-images.githubusercontent.com/4000684/157139502-20660dd3-ba64-4492-b4d6-9d590deab505.png)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

