### PR TITLE
[ogre2] Fix heightmap height and update docs

### DIFF
--- a/examples/heightmap/Main.cc
+++ b/examples/heightmap/Main.cc
@@ -195,7 +195,7 @@ void createDemHeightmaps(const ScenePtr _scene, VisualPtr _root)
     HeightmapDescriptor desc2;
     desc2.SetName("example_moon");
     desc2.SetData(data2);
-    desc2.SetSize({20, 20, 5});
+    desc2.SetSize({20, 20, 6.85});
     desc2.SetSampling(2u);
     desc2.SetUseTerrainPaging(false);
 

--- a/include/ignition/rendering/HeightmapDescriptor.hh
+++ b/include/ignition/rendering/HeightmapDescriptor.hh
@@ -186,11 +186,11 @@ inline namespace IGNITION_RENDERING_VERSION_NAMESPACE {
     /// \param[in] _data New data.
     public: void SetData(const std::shared_ptr<common::HeightmapData> &_data);
 
-    /// \brief Get the heightmap's scaling factor.
+    /// \brief Get the heightmap's final size in world units.
     /// \return The heightmap's size.
     public: ignition::math::Vector3d Size() const;
 
-    /// \brief Set the heightmap's scaling factor. Defaults to 1x1x1.
+    /// \brief Set the heightmap's final size in world units. Defaults to 1x1x1.
     /// \return The heightmap's size factor.
     public: void SetSize(const ignition::math::Vector3d &_size);
 

--- a/ogre2/src/Ogre2Heightmap.cc
+++ b/ogre2/src/Ogre2Heightmap.cc
@@ -158,8 +158,8 @@ void Ogre2Heightmap::Init()
   // Obtain min and max elevation and bring everything to range [0; 1]
   // Terra should support non-normalized ranges but there are a couple
   // bugs preventing that, so it's just easier to normalize the data
-  float minElevation = 0.0;
-  float maxElevation = 0.0;
+  double minElevation = this->descriptor.Data()->MinElevation();
+  double maxElevation = this->descriptor.Data()->MaxElevation();
 
   for (unsigned int y = 0; y < newWidth; ++y)
   {
@@ -167,8 +167,12 @@ void Ogre2Heightmap::Init()
     {
       const size_t index = y * srcWidth + x;
       const float heightVal = lookup[index];
-      minElevation = std::min(minElevation, heightVal);
-      maxElevation = std::max(maxElevation, heightVal);
+      if (heightVal < minElevation || heightVal > maxElevation)
+      {
+        ignerr << "Internal error: height [" << heightVal
+               << "] is out of bounds [" << minElevation << " / "
+               << maxElevation << "]" << std::endl;
+      }
       this->dataPtr->heights.push_back(heightVal);
     }
   }

--- a/ogre2/src/Ogre2Heightmap.cc
+++ b/ogre2/src/Ogre2Heightmap.cc
@@ -205,13 +205,12 @@ void Ogre2Heightmap::Init()
                          1u, Ogre::TextureTypes::Type2D,
                          Ogre::PFG_R32_FLOAT, false);
 
-  const math::Vector3d newSize = this->descriptor.Size() *
-                                 math::Vector3d(1.0, 1.0, heightDiff);
+  const math::Vector3d size = this->descriptor.Size();
 
   math::Vector3d center(
       this->descriptor.Position().X(),
       this->descriptor.Position().Y(),
-      this->descriptor.Position().Z() + newSize.Z() * 0.5 + minElevation);
+      this->descriptor.Position().Z() + size.Z() * 0.5 + minElevation);
 
   Ogre::Root *ogreRoot = Ogre2RenderEngine::Instance()->OgreRoot();
   Ogre::SceneManager *ogreSceneManager = ogreScene->OgreSceneManager();
@@ -230,7 +229,7 @@ void Ogre2Heightmap::Init()
   this->dataPtr->terra->load(
         image,
         Ogre2Conversions::Convert(center),
-        Ogre2Conversions::Convert(newSize),
+        Ogre2Conversions::Convert(size),
         this->descriptor.Name());
   this->dataPtr->autoSkirtValue =
       this->dataPtr->terra->getCustomSkirtMinHeight();
@@ -271,8 +270,8 @@ void Ogre2Heightmap::Init()
     using namespace Ogre;
     const HeightmapTexture *texture0 = this->descriptor.TextureByIndex(0);
     if (texture0->Normal().empty() &&
-        abs(newSize.X() - texture0->Size()) < 1e-6 &&
-        abs(newSize.Y() - texture0->Size()) < 1e-6 )
+        abs(size.X() - texture0->Size()) < 1e-6 &&
+        abs(size.Y() - texture0->Size()) < 1e-6 )
     {
       bCanUseFirstAsBase = true;
     }
@@ -302,9 +301,9 @@ void Ogre2Heightmap::Init()
                             texture0->Normal(), &samplerblock);
 
       const float sizeX =
-              static_cast<float>(newSize.X() / texture0->Size());
+              static_cast<float>(size.X() / texture0->Size());
       const float sizeY =
-              static_cast<float>(newSize.Y() / texture0->Size());
+              static_cast<float>(size.Y() / texture0->Size());
       if (!texture0->Diffuse().empty() || !texture0->Normal().empty())
         datablock->setDetailMapOffsetScale(0, Vector4(0, 0, sizeX, sizeY));
     }
@@ -323,9 +322,9 @@ void Ogre2Heightmap::Init()
                             texture->Normal(), &samplerblock);
 
       const float sizeX =
-              static_cast<float>(newSize.X() / texture->Size());
+              static_cast<float>(size.X() / texture->Size());
       const float sizeY =
-              static_cast<float>(newSize.Y() / texture->Size());
+              static_cast<float>(size.Y() / texture->Size());
       if (!texture->Diffuse().empty() || !texture->Normal().empty())
       {
           datablock->setDetailMapOffsetScale(


### PR DESCRIPTION
# 🦟 Bug fix

* Closes #508 
* Builds on top of #560 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The Ogre 2 implementation was incorrectly multiplying the final size by the height difference for Z, which resulted on extremely tall heightmaps. According to the [SDF spec](http://sdformat.org/spec?ver=1.9&elem=geometry#heightmap_size), the size is meant to represent the final size of the heightmap; it's not a scaling factor. Gazebo [passes](https://github.com/ignitionrobotics/ign-gazebo/blob/f5bb284884de9c5d4d7fa5614e53b528654b6611/src/rendering/SceneManager.cc#L705) the SDF's size straight to the `HeightmapDescriptor`'s size.

With this change, the DEMs introduced in #560 have the same size across Ogre 1 and 2. I also verified that the image-based heightmaps aren't affected.

Ogre | Ogre 2
-- | --
![heightmap_ogre](https://user-images.githubusercontent.com/5751272/157369070-90329357-fc4b-4966-abbb-e3e3b55d60e8.png) | ![heightmap_ogre2](https://user-images.githubusercontent.com/5751272/157369087-de05474a-a752-4a27-887d-de2b12a35792.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
