### PR TITLE
Suppress error message when headless rendering is enabled

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -389,9 +389,13 @@ void Ogre2RenderEngine::CreateContext()
 
   if (!this->dummyDisplay)
   {
-    // Not able to create a Xwindow, try to run in headless mode
-    this->SetHeadless(true);
-    ignerr << "Unable to open display: " << XDisplayName(0) << std::endl;
+    if (!this->Headless())
+    {
+      // Not able to create a Xwindow, try to run in headless mode
+      this->SetHeadless(true);
+      ignwarn << "Unable to open display [" << XDisplayName(0)
+        << "]. Attempting headless rendering." << std::endl;
+    }
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

When using headless rendering, the following message will be printed but headless EGL rendering will still run.

```
[Err] [Ogre2RenderEngine.cc:394] Unable to open display: 
```
 
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.