### PR TITLE
Use custom simulation time variants for Ogre

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -40,6 +40,12 @@ release will remove the deprecated code.
 1. **depth_camera_fs.glsl** and **depth_camera_final_fs.glsl**
     + Far clipping changed from clipping by depth to clipping by range, i.e. distance to point, so that the data generated will never exceed the specified max range of the camera.
 
+1. `Scene::SetTime` is often unset. Ignition's `Ogre2` now defaults to 60hz otherwise rendering won't advance forward.
+	+ Mostly affects Particles.
+	+ Also may affect gaussian postprocessing and other filters dependant on time.
+	+ Previous behavior was using real time instead of simulation time, which is wrong.
+	+ See https://github.com/ignitionrobotics/ign-rendering/issues/556 for details.
+
 ## Ignition Rendering 4.0 to 4.1
 
 ## ABI break

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Scene.hh
@@ -75,6 +75,10 @@ namespace ignition
       public: virtual VisualPtr RootVisual() const override;
 
       // Documentation inherited.
+      public: virtual void SetTime(
+        const std::chrono::steady_clock::duration &_time) override;
+
+      // Documentation inherited.
       public: virtual math::Color AmbientLight() const override;
 
       // Documentation inherited.

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -99,6 +99,10 @@ class ignition::rendering::Ogre2ScenePrivate
   ///
   /// See https://github.com/ignitionrobotics/ign-rendering/issues/556
   /// See https://github.com/ignitionrobotics/ign-rendering/pull/584
+  ///
+  /// TODO(anyone): Remove any code using hackIgnoringSimTime for
+  /// ign-rendering7 as we can safely default to simulation time
+  /// without worrying about breaking existing apps.
   public: bool hackIgnoringSimTime = true;
 #endif
 

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -159,7 +159,7 @@ void Ogre2Scene::SetTime(const std::chrono::steady_clock::duration &_time)
   {
     this->dataPtr->hackIgnoringSimTime = false;
   }
-  else
+  else  // NOLINT
 #endif
   {
     this->time = _time;

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -100,8 +100,6 @@ class ignition::rendering::Ogre2ScenePrivate
 using namespace ignition;
 using namespace rendering;
 
-static const Ogre::Real kSimulationTime = Ogre::Real(1.0 / 60.0);
-
 //////////////////////////////////////////////////
 Ogre2Scene::Ogre2Scene(unsigned int _id, const std::string &_name) :
   BaseScene(_id, _name), dataPtr(std::make_unique<Ogre2ScenePrivate>())
@@ -274,7 +272,11 @@ void Ogre2Scene::StartRendering(Ogre::Camera *_camera)
 
     Ogre::FrameEvent evt;
     evt.timeSinceLastEvent = 0;  // Not used by Ogre so we don't care
-    evt.timeSinceLastFrame = kSimulationTime;
+    evt.timeSinceLastFrame = static_cast<Ogre::Real>(
+      static_cast<double>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(this->Time())
+          .count()) /
+      1000000000.0);
     engine->OgreRoot()->_fireFrameStarted(evt);
 
     this->ogreSceneManager->updateSceneGraph();
@@ -340,7 +342,11 @@ void Ogre2Scene::EndFrame()
 
   Ogre::FrameEvent evt;
   evt.timeSinceLastEvent = 0;  // Not used by Ogre so we don't care
-  evt.timeSinceLastFrame = kSimulationTime;
+  evt.timeSinceLastFrame = static_cast<Ogre::Real>(
+    static_cast<double>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(this->Time())
+        .count()) /
+    1000000000.0);
   ogreRoot->_fireFrameRenderingQueued(evt);
 
   auto itor = ogreRoot->getSceneManagerIterator();

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -100,6 +100,8 @@ class ignition::rendering::Ogre2ScenePrivate
 using namespace ignition;
 using namespace rendering;
 
+static const Ogre::Real kSimulationTime = Ogre::Real(1.0 / 60.0);
+
 //////////////////////////////////////////////////
 Ogre2Scene::Ogre2Scene(unsigned int _id, const std::string &_name) :
   BaseScene(_id, _name), dataPtr(std::make_unique<Ogre2ScenePrivate>())
@@ -269,7 +271,11 @@ void Ogre2Scene::StartRendering(Ogre::Camera *_camera)
   if (this->LegacyAutoGpuFlush())
   {
     auto engine = Ogre2RenderEngine::Instance();
-    engine->OgreRoot()->_fireFrameStarted();
+
+    Ogre::FrameEvent evt;
+    evt.timeSinceLastEvent = 0;  // Not used by Ogre so we don't care
+    evt.timeSinceLastFrame = kSimulationTime;
+    engine->OgreRoot()->_fireFrameStarted(evt);
 
     this->ogreSceneManager->updateSceneGraph();
   }
@@ -332,7 +338,10 @@ void Ogre2Scene::EndFrame()
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
 
-  ogreRoot->_fireFrameRenderingQueued();
+  Ogre::FrameEvent evt;
+  evt.timeSinceLastEvent = 0;  // Not used by Ogre so we don't care
+  evt.timeSinceLastFrame = kSimulationTime;
+  ogreRoot->_fireFrameRenderingQueued(evt);
 
   auto itor = ogreRoot->getSceneManagerIterator();
   while (itor.hasMoreElements())
@@ -341,7 +350,7 @@ void Ogre2Scene::EndFrame()
     sceneManager->clearFrameData();
   }
 
-  ogreRoot->_fireFrameEnded();
+  ogreRoot->_fireFrameEnded(evt);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -104,6 +104,10 @@ using namespace rendering;
 Ogre2Scene::Ogre2Scene(unsigned int _id, const std::string &_name) :
   BaseScene(_id, _name), dataPtr(std::make_unique<Ogre2ScenePrivate>())
 {
+  // Default to 60hz otherwise nothing can advance if user
+  // forgot to call SetTime
+  this->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 }
 
 //////////////////////////////////////////////////

--- a/src/Scene_TEST.cc
+++ b/src/Scene_TEST.cc
@@ -675,6 +675,15 @@ void SceneTest::Time(const std::string &_renderEngine)
   std::chrono::steady_clock::duration duration =
     std::chrono::steady_clock::duration::zero();
 
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // -1 is a hack and is the only value supposed to
+  // be ignored by ign-rendering6.
+  //
+  // We must call it and EXPECT_EQ(duration, scene->Time());
+  // should still be pass in ign-rendering6.
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
+
   EXPECT_EQ(duration, scene->Time());
 
   duration = std::chrono::seconds(23);

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -141,7 +141,13 @@ std::chrono::steady_clock::duration BaseScene::Time() const
 //////////////////////////////////////////////////
 void BaseScene::SetTime(const std::chrono::steady_clock::duration &_time)
 {
-  this->time = _time;
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // TODO(anyone): Remove me in ign-rendering7
+  if (std::chrono::duration_cast<std::chrono::nanoseconds>(_time).count() != -1)
+#endif
+  {
+    this->time = _time;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -78,9 +78,11 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   VisualPtr root = scene->RootVisual();
 
@@ -109,6 +111,7 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   EXPECT_EQ(initPos, camera->WorldPosition());
   EXPECT_NE(initRot, camera->WorldRotation());
@@ -129,6 +132,7 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // verify camera orientation when tracking target with offset
   // in world frame
@@ -147,6 +151,7 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   // verify camera orientation when tracking target with offset
   // in local frame
   // camera should be looking down and to the right
@@ -163,6 +168,7 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // reset camera pose
   camera->SetWorldPosition(initPos);
@@ -178,6 +184,7 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // verify camera rotaion has pitch component
   // but not as large as before without p gain
@@ -250,6 +257,7 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
   for (auto i = 0; i < 30; ++i)
   {
     camera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   }
 
   EXPECT_EQ(800u, camera->ImageWidth());
@@ -301,6 +309,7 @@ void CameraTest::VisualAt(const std::string &_renderEngine)
   for (auto i = 0; i < 30; ++i)
   {
     camera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   }
 
   // test that VisualAt still works after resize
@@ -362,6 +371,7 @@ void CameraTest::Follow(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // verify camera is at same location as visual because
   // no offset is given
@@ -376,6 +386,7 @@ void CameraTest::Follow(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // verify camera pose when following target with offset
   // in world frame
@@ -392,6 +403,7 @@ void CameraTest::Follow(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // verify camera pose when following target with offset
   // in local frame
@@ -408,6 +420,7 @@ void CameraTest::Follow(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // reset camera pose
   camera->SetWorldPosition(initPos);
@@ -423,6 +436,7 @@ void CameraTest::Follow(const std::string &_renderEngine)
 
   // render a frame
   camera->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   // verify camera position has changed but
   // but not as close to the target as before without p gain
@@ -743,6 +757,7 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
     thermalCamera->Update();
     if (segmentationCamera)
       segmentationCamera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   }
 
   // capture a frame

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -78,6 +78,9 @@ void CameraTest::Track(const std::string &_renderEngine)
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 
   VisualPtr root = scene->RootVisual();
 

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -99,9 +99,11 @@ void DepthCameraTest::DepthCameraBoxes(
 
   // red background
   scene->SetBackgroundColor(1.0, 0.0, 0.0);
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   // Create an scene with a box in it
   scene->SetAmbientLight(1.0, 1.0, 1.0);
@@ -175,6 +177,7 @@ void DepthCameraTest::DepthCameraBoxes(
     g_depthCounter = 0u;
     g_pointCloudCounter = 0u;
     depthCamera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     EXPECT_EQ(1u, g_depthCounter);
     EXPECT_EQ(1u, g_pointCloudCounter);
 
@@ -305,6 +308,7 @@ void DepthCameraTest::DepthCameraBoxes(
     g_depthCounter = 0u;
     g_pointCloudCounter = 0u;
     depthCamera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     EXPECT_EQ(1u, g_depthCounter);
     EXPECT_EQ(1u, g_pointCloudCounter);
 
@@ -361,6 +365,7 @@ void DepthCameraTest::DepthCameraBoxes(
     g_depthCounter = 0u;
     g_pointCloudCounter = 0u;
     depthCamera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     EXPECT_EQ(1u, g_depthCounter);
     EXPECT_EQ(1u, g_pointCloudCounter);
 
@@ -419,6 +424,7 @@ void DepthCameraTest::DepthCameraBoxes(
     g_depthCounter = 0u;
     g_pointCloudCounter = 0u;
     depthCamera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     EXPECT_EQ(1u, g_depthCounter);
     EXPECT_EQ(1u, g_pointCloudCounter);
 
@@ -513,9 +519,11 @@ void DepthCameraTest::DepthCameraParticles(
 
   // red background
   scene->SetBackgroundColor(1.0, 0.0, 0.0);
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   // Create an scene with a box in it
   scene->SetAmbientLight(1.0, 1.0, 1.0);
@@ -589,6 +597,7 @@ void DepthCameraTest::DepthCameraParticles(
     g_depthCounter = 0u;
     g_pointCloudCounter = 0u;
     depthCamera->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     EXPECT_EQ(1u, g_depthCounter);
     EXPECT_EQ(1u, g_pointCloudCounter);
 
@@ -642,6 +651,7 @@ void DepthCameraTest::DepthCameraParticles(
     for (unsigned int i = 0; i < 100; ++i)
     {
       depthCamera->Update();
+      scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     }
     EXPECT_EQ(100u, g_depthCounter);
     EXPECT_EQ(100u, g_pointCloudCounter);
@@ -711,6 +721,7 @@ void DepthCameraTest::DepthCameraParticles(
     for (unsigned int i = 0; i < 100; ++i)
     {
       depthCamera->Update();
+      scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
     }
     EXPECT_EQ(100u, g_depthCounter);
     EXPECT_EQ(100u, g_pointCloudCounter);

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -99,6 +99,9 @@ void DepthCameraTest::DepthCameraBoxes(
 
   // red background
   scene->SetBackgroundColor(1.0, 0.0, 0.0);
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 
   // Create an scene with a box in it
   scene->SetAmbientLight(1.0, 1.0, 1.0);
@@ -510,6 +513,9 @@ void DepthCameraTest::DepthCameraParticles(
 
   // red background
   scene->SetBackgroundColor(1.0, 0.0, 0.0);
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 
   // Create an scene with a box in it
   scene->SetAmbientLight(1.0, 1.0, 1.0);

--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -92,9 +92,10 @@ void GpuRaysTest::Configure(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   VisualPtr root = scene->RootVisual();
 
@@ -205,9 +206,10 @@ void GpuRaysTest::RaysUnitBox(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   VisualPtr root = scene->RootVisual();
 
@@ -290,6 +292,7 @@ void GpuRaysTest::RaysUnitBox(const std::string &_renderEngine)
           std::placeholders::_4, std::placeholders::_5));
 
   gpuRays->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   int mid = static_cast<int>(hRayCount/2) * channels;
   int last = (hRayCount - 1) * channels;
@@ -317,6 +320,7 @@ void GpuRaysTest::RaysUnitBox(const std::string &_renderEngine)
   float *scan2 = new float[hRayCount * vRayCount * 3];
 
   gpuRays2->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   // Test Copy method instead of using the callback for the second rays caster
   gpuRays2->Copy(scan2);
 
@@ -334,7 +338,9 @@ void GpuRaysTest::RaysUnitBox(const std::string &_renderEngine)
   visualBox2->SetWorldRotation(box02Pose.Rot());
 
   gpuRays->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   gpuRays2->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
   gpuRays2->Copy(scan2);
 
   for (int i = 0; i < gpuRays->RayCount(); ++i)
@@ -397,9 +403,10 @@ void GpuRaysTest::LaserVertical(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   VisualPtr root = scene->RootVisual();
 
@@ -439,6 +446,7 @@ void GpuRaysTest::LaserVertical(const std::string &_renderEngine)
           std::placeholders::_4, std::placeholders::_5));
 
   gpuRays->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   unsigned int mid = hRayCount * channels / 2;
   double unitBoxSize = 1.0;
@@ -480,6 +488,7 @@ void GpuRaysTest::LaserVertical(const std::string &_renderEngine)
 
   // wait for a few more laser scans
   gpuRays->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   for (int j = 0; j < gpuRays->VerticalRayCount(); ++j)
   {
@@ -538,9 +547,10 @@ void GpuRaysTest::RaysParticles(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   VisualPtr root = scene->RootVisual();
 
@@ -639,6 +649,7 @@ void GpuRaysTest::RaysParticles(const std::string &_renderEngine)
   for (unsigned int i = 0u; i < 100u; ++i)
   {
     gpuRays->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
     // sensor should see ether a particle or box01
     double particleRange = static_cast<double>(scan[mid]);
@@ -677,6 +688,7 @@ void GpuRaysTest::RaysParticles(const std::string &_renderEngine)
   for (unsigned int i = 0u; i < 100u; ++i)
   {
     gpuRays->Update();
+    scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
     // sensor should see ether a particle or box01
     double particleRange = static_cast<double>(scan[mid]);
@@ -758,9 +770,10 @@ void GpuRaysTest::SingleRay(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
-  // 60hz
-  scene->SetTime(
-    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+#if IGNITION_RENDERING_MAJOR_VERSION <= 6
+  // HACK: Tell ign-rendering6 to listen to SetTime calls
+  scene->SetTime(std::chrono::nanoseconds(-1));
+#endif
 
   VisualPtr root = scene->RootVisual();
 
@@ -800,6 +813,7 @@ void GpuRaysTest::SingleRay(const std::string &_renderEngine)
           std::placeholders::_4, std::placeholders::_5));
 
   gpuRays->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
 
   int mid = 0;
   double unitBoxSize = 1.0;

--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -92,6 +92,10 @@ void GpuRaysTest::Configure(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+
   VisualPtr root = scene->RootVisual();
 
   GpuRaysPtr gpuRays = scene->CreateGpuRays();
@@ -200,6 +204,10 @@ void GpuRaysTest::RaysUnitBox(const std::string &_renderEngine)
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
+
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 
   VisualPtr root = scene->RootVisual();
 
@@ -389,6 +397,10 @@ void GpuRaysTest::LaserVertical(const std::string &_renderEngine)
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
 
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
+
   VisualPtr root = scene->RootVisual();
 
   // Create first ray caster
@@ -525,6 +537,10 @@ void GpuRaysTest::RaysParticles(const std::string &_renderEngine)
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
+
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 
   VisualPtr root = scene->RootVisual();
 
@@ -741,6 +757,10 @@ void GpuRaysTest::SingleRay(const std::string &_renderEngine)
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_TRUE(scene != nullptr);
+
+  // 60hz
+  scene->SetTime(
+    std::chrono::nanoseconds(static_cast<uint64_t>(1000000000.0 / 60.0)));
 
   VisualPtr root = scene->RootVisual();
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #556

## Summary

This fixes Particle FXs not respecting simulation time.

After researching Ogre behavior, turns out we already had the functionality to use custom simulation (deterministic) time. We just had to use it. Turned out to be much easier than I expected (I actually started writing more code until I realized it... :( )

**Note:** This is a draft because I was unsure _where to pull gazebo's simulation time from_. Therefore it is currently hardcoded with:

```cpp
static const Ogre::Real kSimulationTime = Ogre::Real(1.0 / 60.0);
```

and obviously needs to be changed to use gazebo's.

But other than that, once that's implemented (I'm asking for pointers here....!) it should just work.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
