### PR TITLE
Fix crash on material switcher when there are points

### DIFF
--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -106,7 +106,7 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
         auto material = Ogre::MaterialManager::getSingleton().getByName(
           subItem->getMaterial()->getName() + "_solid",
           Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        if (material->getNumSupportedTechniques() > 0u)
+        if (material && material->getNumSupportedTechniques() > 0u)
         {
           subItem->setMaterial(material);
         }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Since #578, simulations where we use point markers are crashing when the user clicks on the scene. I traced it back to a null pointer access. This fixes the issue for me, but I don't know if there are unintended consequences.

CC @darksylinc 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
