### PR TITLE
Fix for #578 on macOS / Metal

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -862,12 +862,6 @@ Ogre::MaterialPtr Ogre2Material::Material()
       IGN_ASSERT(false, "Impossible path!");
     }
 
-    auto mat = this->dataPtr->ogreSolidColorMat;
-    auto pass = mat->getTechnique(0u)->getPass(0);
-    pass->setFragmentProgram(this->dataPtr->ogreSolidColorShader->getName());
-    auto psParams = pass->getFragmentProgramParameters();
-    psParams->setNamedAutoConstant("inColor",
-                                   Ogre::GpuProgramParameters::ACT_CUSTOM, 1u);
   }
 
   return this->ogreMaterial;
@@ -1209,6 +1203,17 @@ void Ogre2Material::SetVertexShader(const std::string &_path)
   // Metal needs this. Other APIs will ignore it.
   this->dataPtr->ogreSolidColorShader->setParameter(
     "shader_reflection_pair_hint", vertexShader->getName());
+
+  // Set 'inColor' on the cloned pixel shader. For Metal this must occur
+  // after vertex shader has been created and the reflection pair set.
+  {
+    auto mat = this->dataPtr->ogreSolidColorMat;
+    auto pass = mat->getTechnique(0u)->getPass(0);
+    pass->setFragmentProgram(this->dataPtr->ogreSolidColorShader->getName());
+    auto psParams = pass->getFragmentProgramParameters();
+    psParams->setNamedAutoConstant("inColor",
+        Ogre::GpuProgramParameters::ACT_CUSTOM, 1u);
+  }
 
   Ogre::MaterialPtr mat[2] = { mainMat, this->dataPtr->ogreSolidColorMat };
 


### PR DESCRIPTION
# 🦟 Bug fix

Fix issue for macOS / Metal introduced in #578

## Summary

#578 introduced an error on macOS / Metal for a number of examples where the parameters for the pixel shader
could not be set because the reflection pair hint was not available. This PR moves the block of code causing the issue to after the vertex shader has been created and reflection pair hint has been set.

See comment here: 

- https://github.com/ignitionrobotics/ign-rendering/pull/578#issuecomment-1069391532

Test outcome here:

- https://github.com/ignitionrobotics/ign-rendering/pull/578#issuecomment-1069652246

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.