### PR TITLE
Don't crash if directly set low level materials are used in sensors

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -315,10 +315,14 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
         // to keep vertex deformation consistent; so we use
         // a cloned material with a different pixel shader
         // https://github.com/ignitionrobotics/ign-rendering/issues/544
+        //
+        // material may be a nullptr if we called setMaterial directly
+        // (i.e. it's not using Ogre2Material interface).
+        // In those cases we fallback to PBS in the current IORM mode.
         auto material = Ogre::MaterialManager::getSingleton().getByName(
           subItem->getMaterial()->getName() + "_solid",
           Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        if (material->getNumSupportedTechniques() > 0u)
+        if (material && material->getNumSupportedTechniques() > 0u)
         {
           subItem->setMaterial(material);
         }

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -322,9 +322,18 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
         auto material = Ogre::MaterialManager::getSingleton().getByName(
           subItem->getMaterial()->getName() + "_solid",
           Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        if (material && material->getNumSupportedTechniques() > 0u)
+        if (material)
         {
-          subItem->setMaterial(material);
+          if (material->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
+          {
+            // Manually defined materials like PointCloudPoint_solid need this
+            material->load();
+          }
+
+          if (material->getNumSupportedTechniques() > 0u)
+          {
+            subItem->setMaterial(material);
+          }
         }
         else
         {

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -103,10 +103,14 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
         // to keep vertex deformation consistent; so we use
         // a cloned material with a different pixel shader
         // https://github.com/ignitionrobotics/ign-rendering/issues/544
+        //
+        // material may be a nullptr if we called setMaterial directly
+        // (i.e. it's not using Ogre2Material interface).
+        // In those cases we fallback to PBS in the current IORM mode.
         auto material = Ogre::MaterialManager::getSingleton().getByName(
           subItem->getMaterial()->getName() + "_solid",
           Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        if (material->getNumSupportedTechniques() > 0u)
+        if (material && material->getNumSupportedTechniques() > 0u)
         {
           subItem->setMaterial(material);
         }

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -110,9 +110,18 @@ void Ogre2MaterialSwitcher::cameraPreRenderScene(
         auto material = Ogre::MaterialManager::getSingleton().getByName(
           subItem->getMaterial()->getName() + "_solid",
           Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-        if (material && material->getNumSupportedTechniques() > 0u)
+        if (material)
         {
-          subItem->setMaterial(material);
+          if (material->getLoadingState() == Ogre::Resource::LOADSTATE_UNLOADED)
+          {
+            // Manually defined materials like PointCloudPoint_solid need this
+            material->load();
+          }
+
+          if (material->getNumSupportedTechniques() > 0u)
+          {
+            subItem->setMaterial(material);
+          }
         }
         else
         {

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -314,9 +314,19 @@ void Ogre2SegmentationMaterialSwitcher::cameraPreRenderScene(
           auto material = Ogre::MaterialManager::getSingleton().getByName(
             subItem->getMaterial()->getName() + "_solid",
             Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-          if (material && material->getNumSupportedTechniques() > 0u)
+          if (material)
           {
-            subItem->setMaterial(material);
+            if (material->getLoadingState() ==
+                Ogre::Resource::LOADSTATE_UNLOADED)
+            {
+              // Manually defined materials like PointCloudPoint_solid need this
+              material->load();
+            }
+
+            if (material->getNumSupportedTechniques() > 0u)
+            {
+              subItem->setMaterial(material);
+            }
           }
           else
           {

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -307,10 +307,14 @@ void Ogre2SegmentationMaterialSwitcher::cameraPreRenderScene(
           // to keep vertex deformation consistent; so we use
           // a cloned material with a different pixel shader
           // https://github.com/ignitionrobotics/ign-rendering/issues/544
+          //
+          // material may be a nullptr if we called setMaterial directly
+          // (i.e. it's not using Ogre2Material interface).
+          // In those cases we fallback to PBS in the current IORM mode.
           auto material = Ogre::MaterialManager::getSingleton().getByName(
             subItem->getMaterial()->getName() + "_solid",
             Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-          if (material->getNumSupportedTechniques() > 0u)
+          if (material && material->getNumSupportedTechniques() > 0u)
           {
             subItem->setMaterial(material);
           }

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -347,10 +347,14 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
             // to keep vertex deformation consistent; so we use
             // a cloned material with a different pixel shader
             // https://github.com/ignitionrobotics/ign-rendering/issues/544
+            //
+            // material may be a nullptr if we called setMaterial directly
+            // (i.e. it's not using Ogre2Material interface).
+            // In those cases we fallback to PBS in the current IORM mode.
             auto material = Ogre::MaterialManager::getSingleton().getByName(
               subItem->getMaterial()->getName() + "_solid",
               Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-            if (material->getNumSupportedTechniques() > 0u)
+            if (material && material->getNumSupportedTechniques() > 0u)
             {
               subItem->setMaterial(material);
             }
@@ -495,10 +499,14 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
             // to keep vertex deformation consistent; so we use
             // a cloned material with a different pixel shader
             // https://github.com/ignitionrobotics/ign-rendering/issues/544
+            //
+            // material may be a nullptr if we called setMaterial directly
+            // (i.e. it's not using Ogre2Material interface).
+            // In those cases we fallback to PBS in the current IORM mode.
             auto material = Ogre::MaterialManager::getSingleton().getByName(
               subItem->getMaterial()->getName() + "_solid",
               Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-            if (material->getNumSupportedTechniques() > 0u)
+            if (material && material->getNumSupportedTechniques() > 0u)
             {
               subItem->setMaterial(material);
             }

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -353,9 +353,20 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
             auto material = Ogre::MaterialManager::getSingleton().getByName(
               subItem->getMaterial()->getName() + "_solid",
               Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-            if (material && material->getNumSupportedTechniques() > 0u)
+            if (material)
             {
-              subItem->setMaterial(material);
+              if (material->getLoadingState() ==
+                  Ogre::Resource::LOADSTATE_UNLOADED)
+              {
+                // Manually defined materials like PointCloudPoint_solid
+                // need this
+                material->load();
+              }
+
+              if (material->getNumSupportedTechniques() > 0u)
+              {
+                subItem->setMaterial(material);
+              }
             }
             else
             {
@@ -505,9 +516,20 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
             auto material = Ogre::MaterialManager::getSingleton().getByName(
               subItem->getMaterial()->getName() + "_solid",
               Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-            if (material && material->getNumSupportedTechniques() > 0u)
+            if (material)
             {
-              subItem->setMaterial(material);
+              if (material->getLoadingState() ==
+                  Ogre::Resource::LOADSTATE_UNLOADED)
+              {
+                // Manually defined materials like PointCloudPoint_solid
+                // need this
+                material->load();
+              }
+
+              if (material->getNumSupportedTechniques() > 0u)
+              {
+                subItem->setMaterial(material);
+              }
             }
             else
             {

--- a/ogre2/src/media/materials/programs/GLSL/point_vs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/point_vs.glsl
@@ -26,6 +26,7 @@ out vec3 ptColor;
 out gl_PerVertex
 {
   vec4 gl_Position;
+  float gl_PointSize;
 };
 
 void main()

--- a/ogre2/src/media/materials/scripts/picker.material
+++ b/ogre2/src/media/materials/scripts/picker.material
@@ -12,16 +12,6 @@ vertex_program plaincolor_vs_GLSL glsl
   }
 }
 
-fragment_program plaincolor_fs_GLSL glsl
-{
-  source plain_color_fs.glsl
-
-  default_params
-  {
-    param_named inColor float4 1 1 1 1
-  }
-}
-
 // Metal shaders
 vertex_program plaincolor_vs_Metal metal
 {
@@ -36,23 +26,11 @@ vertex_program plaincolor_vs_Metal metal
   }
 }
 
-fragment_program plaincolor_fs_Metal metal
-{
-  source plain_color_fs.metal
-  shader_reflection_pair_hint plaincolor_vs_Metal
-}
-
 // Unified shaders
 vertex_program plaincolor_vs unified
 {
   delegate plaincolor_vs_GLSL
   delegate plaincolor_vs_Metal
-}
-
-fragment_program plaincolor_fs unified
-{
-  delegate plaincolor_fs_GLSL
-  delegate plaincolor_fs_Metal
 }
 
 material ign-rendering/plain_color

--- a/ogre2/src/media/materials/scripts/picker.program
+++ b/ogre2/src/media/materials/scripts/picker.program
@@ -1,0 +1,24 @@
+// GLSL shaders
+fragment_program plaincolor_fs_GLSL glsl
+{
+  source plain_color_fs.glsl
+
+  default_params
+  {
+    param_named inColor float4 1 1 1 1
+  }
+}
+
+// Metal shaders
+fragment_program plaincolor_fs_Metal metal
+{
+  source plain_color_fs.metal
+  shader_reflection_pair_hint plaincolor_vs_Metal
+}
+
+// Unified shaders
+fragment_program plaincolor_fs unified
+{
+  delegate plaincolor_fs_GLSL
+  delegate plaincolor_fs_Metal
+}

--- a/ogre2/src/media/materials/scripts/point_cloud_point.material
+++ b/ogre2/src/media/materials/scripts/point_cloud_point.material
@@ -79,3 +79,21 @@ material PointCloudPoint
     }
   }
 }
+
+// For sensors
+material PointCloudPoint_solid
+{
+  technique
+  {
+    pass
+    {
+      point_size_attenuation on
+      point_sprites on
+      vertex_program_ref   PointCloudVS {}
+      fragment_program_ref plaincolor_fs
+      {
+        param_named_auto inColor custom 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

No ticket was issued for this problem
This PR supersedes #586

## Summary

The problem has been described in #586

This PR replaces it as it is applied to more sensors and comments explain why there can be nullptrs.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
