### PR TITLE
Separate cache files for each heightmap LOD

### DIFF
--- a/ogre/src/OgreHeightmap.cc
+++ b/ogre/src/OgreHeightmap.cc
@@ -530,13 +530,21 @@ void OgreHeightmap::Init()
         "General");
   }
 
+  std::string terrainNameSuffix = "";
+  if (this->LOD() == 0)
+  {
+    terrainNameSuffix = "_LOD0";
+  }
+
   // If the paging is enabled we modify the number of subterrains
   std::string prefix;
   if (this->descriptor.UseTerrainPaging())
   {
     this->dataPtr->splitTerrain = true;
     nTerrains = this->dataPtr->numTerrainSubdivisions;
-    prefix = common::joinPaths(terrainDirPath, "ignition_terrain_cache");
+    std::string terrainName = "gazebo_terrain_cache" +
+        terrainNameSuffix;
+    prefix = terrainDirPath / terrainName.c_str();
   }
   else
   {
@@ -555,7 +563,8 @@ void OgreHeightmap::Init()
       ignmsg << "Large heightmap used with LOD. It will be subdivided into " <<
           this->dataPtr->numTerrainSubdivisions << " terrains." << std::endl;
     }
-    prefix = common::joinPaths(terrainDirPath, "ignition_terrain");
+    std::string terrainName = "gazebo_terrain" + terrainNameSuffix;
+    prefix = terrainDirPath / terrainName.c_str();
   }
 
   double sqrtN = sqrt(nTerrains);

--- a/ogre/src/OgreHeightmap.cc
+++ b/ogre/src/OgreHeightmap.cc
@@ -531,7 +531,7 @@ void OgreHeightmap::Init()
   }
 
   std::string terrainNameSuffix = "";
-  if (this->LOD() == 0)
+  if (static_cast<unsigned int>(this->dataPtr->maxPixelError) == 0)
   {
     terrainNameSuffix = "_LOD0";
   }
@@ -544,7 +544,7 @@ void OgreHeightmap::Init()
     nTerrains = this->dataPtr->numTerrainSubdivisions;
     std::string terrainName = "gazebo_terrain_cache" +
         terrainNameSuffix;
-    prefix = terrainDirPath / terrainName.c_str();
+    prefix = common::joinPaths(terrainDirPath, terrainName.c_str());
   }
   else
   {
@@ -564,7 +564,7 @@ void OgreHeightmap::Init()
           this->dataPtr->numTerrainSubdivisions << " terrains." << std::endl;
     }
     std::string terrainName = "gazebo_terrain" + terrainNameSuffix;
-    prefix = terrainDirPath / terrainName.c_str();
+    prefix = common::joinPaths(terrainDirPath, terrainName.c_str());
   }
 
   double sqrtN = sqrt(nTerrains);


### PR DESCRIPTION
# 🦟 Bug fix

From gazebo-classic
* https://github.com/osrf/gazebo Separate cache files for each heightmap LOD/pull/3200

## Summary
To prevent gazebo from loading the wrong cache files, each heightmap LOD will have its own set of cache files.

The LOD is appended to the cache files' names (_5_ in the example):
```
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00000000.dat
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00010000.dat
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00000001.dat
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00010001.dat
```
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.