### PR TITLE
Default cameraPassCountPerGpuFlush to 6

### DIFF
--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -91,7 +91,7 @@ class ignition::rendering::Ogre2ScenePrivate
   public: uint32_t currNumCameraPasses = 0u;
 
   /// \brief Flag to indicate if we should flush GPU very often (per camera)
-  public: uint8_t cameraPassCountPerGpuFlush = 0u;
+  public: uint8_t cameraPassCountPerGpuFlush = 6u;
 
   /// \brief Name of shadow compositor node
   public: const std::string kShadowNodeName = "PbsMaterialsShadowNode";


### PR DESCRIPTION
# 🦟 Bug fix

No ticket is associated.

But there is a relevant discussion in https://github.com/ignitionrobotics/ign-rendering/issues/323#issuecomment-865413892

## Summary

I thought `cameraPassCountPerGpuFlush` was already at default 6.

[ign-gazebo/src/gui/plugins/scene3d/Scene3D.cc](https://github.com/ignitionrobotics/ign-gazebo/blob/39a0ce3712580e855838cf7557013a262d42e1a1/src/gui/plugins/scene3d/Scene3D.cc#L2126) should already be setting this value on the GUI side.

Same goes for [ign-gazebo/src/systems/sensors/Sensors.cc](https://github.com/ignitionrobotics/ign-gazebo/blob/39a0ce3712580e855838cf7557013a262d42e1a1/src/systems/sensors/Sensors.cc#L239)

I don't want to think of the implications of setting this value to 6 on already released versions. It's probably harmless. But anyway, the API was introduced in Edifice, Fortress still defaults to legacy; it makes sense for Garden to start defaulting to non-legacy mode.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
