### PR TITLE
Replace deprecated common::SubMesh::MaterialIndex() with GetMaterialIndex()

### DIFF
--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -409,7 +409,10 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
         *indices++ = subMesh.Index(j);
 
       common::MaterialPtr material;
-      material = _desc.mesh->MaterialByIndex(subMesh.MaterialIndex());
+      if (const auto subMeshIdx = subMesh.GetMaterialIndex())
+      {
+        material = _desc.mesh->MaterialByIndex(subMeshIdx.value());
+      }
 
       MaterialPtr mat = this->scene->CreateMaterial();
       if (material)

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -469,7 +469,10 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
       iBuf->unlock();
 
       common::MaterialPtr material;
-      material = _desc.mesh->MaterialByIndex(subMesh.MaterialIndex());
+      if (const auto subMeshIdx = subMesh.GetMaterialIndex())
+      {
+        material = _desc.mesh->MaterialByIndex(subMeshIdx.value());
+      }
 
       MaterialPtr mat = this->scene->CreateMaterial();
       if (material)

--- a/optix/src/OptixMeshFactory.cc
+++ b/optix/src/OptixMeshFactory.cc
@@ -125,7 +125,10 @@ OptixSubMeshStorePtr OptixSubMeshStoreFactory::Create(
       sm->optixGeomInstance->setGeometry(optixGeometry);
 
       common::MaterialPtr material;
-      material = _desc.mesh->MaterialByIndex(subMesh->MaterialIndex());
+      if (const auto subMeshIdx = SubMesh.GetMaterialIndex())
+      {
+        material = _desc.mesh->MaterialByIndex(subMeshIdx.value());
+      }
       MaterialPtr mat = this->scene->CreateMaterial();
       if (material)
       {


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <42042756+adlarkin@users.noreply.github.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
This PR replaces deprecated calls to `ignition::common::SubMesh::MaterialIndex()` with the new `GetMaterialIndex()` method that was introduced in https://github.com/ignitionrobotics/ign-common/pull/319.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.