### PR TITLE
Destroy root node and clean up sensor resources on exit

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -386,6 +386,9 @@ void Ogre2GpuRays::Init()
 //////////////////////////////////////////////////
 void Ogre2GpuRays::Destroy()
 {
+  if (!this->dataPtr->ogreCamera)
+    return;
+
   if (this->dataPtr->gpuRaysBuffer)
   {
     delete [] this->dataPtr->gpuRaysBuffer;
@@ -464,6 +467,32 @@ void Ogre2GpuRays::Destroy()
     ogreCompMgr->removeNodeDefinition(
         this->dataPtr->ogreCompositorNodeDef2nd);
     this->dataPtr->ogreCompositorWorkspaceDef2nd.clear();
+  }
+
+  if (this->scene)
+  {
+    Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+    if (ogreSceneManager == nullptr)
+    {
+      ignerr << "Scene manager cannot be obtained" << std::endl;
+    }
+    else
+    {
+      for (unsigned int i = 0u; i < 6u; ++i)
+      {
+        if (this->dataPtr->cubeCam[i])
+        {
+          this->dataPtr->cubeCam[i]->removeListener(
+              this->dataPtr->particleNoiseListener[i].get());
+          ogreSceneManager->destroyCamera(this->dataPtr->cubeCam[i]);
+          this->dataPtr->cubeCam[i] = nullptr;
+        }
+        this->dataPtr->particleNoiseListener[i].reset();
+        this->dataPtr->laserRetroMaterialSwitcher[i].reset();
+      }
+      ogreSceneManager->destroyCamera(this->dataPtr->ogreCamera);
+      this->dataPtr->ogreCamera = nullptr;
+    }
   }
 }
 

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -177,7 +177,7 @@ class ignition::rendering::Ogre2ThermalCameraPrivate
   public: Ogre::CompositorWorkspace *ogreCompositorWorkspace;
 
   /// \brief Thermal textures.
-  public: Ogre::TextureGpu *ogreThermalTexture;
+  public: Ogre::TextureGpu *ogreThermalTexture{nullptr};
 
   /// \brief Dummy render texture for the thermal data
   public: RenderTexturePtr thermalTexture = nullptr;
@@ -536,6 +536,7 @@ void Ogre2ThermalCamera::Destroy()
   {
     Ogre::MaterialManager::getSingleton().remove(
         this->dataPtr->thermalMaterial->getName());
+    this->dataPtr->thermalMaterial.setNull();
   }
 
   if (!this->dataPtr->ogreCompositorWorkspaceDef.empty())
@@ -560,6 +561,8 @@ void Ogre2ThermalCamera::Destroy()
       this->ogreCamera = nullptr;
     }
   }
+
+  this->dataPtr->thermalMaterialSwitcher.reset();
 }
 
 //////////////////////////////////////////////////

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1420,7 +1420,13 @@ bool BaseScene::LegacyAutoGpuFlush() const
 //////////////////////////////////////////////////
 void BaseScene::Clear()
 {
-  this->nodes->DestroyAll();
+  this->DestroyNodes();
+  auto root = this->RootVisual();
+  if (root)
+  {
+    root->RemoveChildren();
+    this->DestroyNode(root);
+  }
   this->DestroyMaterials();
   this->nextObjectId = ignition::math::MAX_UI16;
 }

--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -798,6 +798,15 @@ void CameraTest::ShaderSelection(const std::string &_renderEngine)
 
   // Clean up
   engine->DestroyScene(scene);
+
+  ASSERT_EQ(1u, camera.use_count());
+  ASSERT_EQ(1u, gpuRays.use_count());
+  ASSERT_EQ(1u, thermalCamera.use_count());
+  if (segmentationCamera)
+  {
+    ASSERT_EQ(1u, segmentationCamera.use_count());
+  }
+
   rendering::unloadEngine(engine->Name());
 }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-rendering/issues/615

## Summary

When the scene was destroyed, only non-root nodes were destroyed. This PR makes sure to destroy the root node as well.  As soon as that is done, I noticed that destructors of sensors are now called but tests are segfaulting. Fixed by cleaning up more resources in sensors' `Destroy` function.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

